### PR TITLE
Standard Semantic Highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,30 +26,20 @@
     "virtualWorkspaces": true
   },
   "contributes": {
-    "semanticTokenScopes": [
-      {
-        "language": "sas",
-        "scopes": {
-          "date": [
-            "entity."
-          ]
-        }
-      }
-    ],
     "semanticTokenTypes": [
       {
         "id": "date",
-        "superType": "decorator",
+        "superType": "numeric",
         "description": "Date"
       },
       {
         "id": "time",
-        "superType": "decorator",
+        "superType": "numeric",
         "description": "Time"
       },
       {
         "id": "dt",
-        "superType": "decorator",
+        "superType": "numeric",
         "description": "DateTime"
       },
       {
@@ -59,7 +49,7 @@
       },
       {
         "id": "namelit",
-        "superType": "decorator",
+        "superType": "string",
         "description": "Name literal"
       },
       {
@@ -84,8 +74,8 @@
       },
       {
         "id": "macro-sec-keyword",
-        "superType": "function",
-        "description": "SAS Macro Secondary Keyword"
+        "superType": "macro",
+        "description": "SAS Macro Section Keyword"
       },
       {
         "id": "macro-ref",
@@ -105,7 +95,7 @@
       {
         "id": "sec-keyword",
         "superType": "function",
-        "description": "SAS Secondary keyword"
+        "description": "SAS Section keyword"
       },
       {
         "id": "proc-name",

--- a/package.json
+++ b/package.json
@@ -28,101 +28,100 @@
   "contributes": {
     "semanticTokenTypes": [
       {
-				"id": "date",
-				"superType": "string",
-				"description": "Date"
-			},
-			{
-				"id": "time",
-				"superType": "string",
-				"description": "Time"
-			},
-			{
-				"id": "dt",
-				"superType": "string",
-				"description": "DateTime"
-			},
-			{
-				"id": "format",
-				"superType": "string",
-				"description": "Format"
-			},
-			{
-				"id": "numeric",
-				"superType": "number",
-				"description": "Numeric"
-			},
-			{
-				"id": "bitmask",
-				"superType": "number",
-				"description": "Bitmask"
-			},
-			{
-				"id": "namebit",
-				"superType": "number",
-				"description": "Namebit"
-			},
-			{
-				"id": "hex",
-				"superType": "number",
-				"description": "Hex"
-			},
-			{
-				"id": "sep",
-				"superType": "operator",
-				"description": "Separator"
-			},
-			{
-				"id": "macro-sec-keyword",
-				"superType": "operator",
-				"description": "SAS Macro Secondary Keyword"
-			},
-			{
-				"id": "macro-ref",
-				"superType": "operator",
-				"description": "SAS Macro Reference"
-			},
-			{
-				"id": "macro-keyword",
-				"superType": "keyword",
-				"description": "SAS Macro Keyword"
-			},
-			{
-				"id": "macro-comment",
-				"superType": "comment",
-				"description": "Macro Comment"
-			},
-
-			{
-				"id": "sec-keyword",
-				"superType": "method",
-				"description": "SAS Secondary keyword"
-			},
-			{
-				"id": "proc-name",
-				"superType": "method",
-				"description": "Name of the proc"
-			},			
-			{
-				"id": "cards-data",
-				"superType": "parameter",
-				"description": "Card data"
-			},
-			{
-				"id": "error",
-				"superType": "event",
-				"description": "Error event"
-			},
-			{
-				"id": "warning",
-				"superType": "event",
-				"description": "Warning event"
-			},
-			{
-				"id": "note",
-				"superType": "event",
-				"description": "Note"
-			}
+        "id": "date",
+        "superType": "string",
+        "description": "Date"
+      },
+      {
+        "id": "time",
+        "superType": "string",
+        "description": "Time"
+      },
+      {
+        "id": "dt",
+        "superType": "string",
+        "description": "DateTime"
+      },
+      {
+        "id": "format",
+        "superType": "string",
+        "description": "Format"
+      },
+      {
+        "id": "numeric",
+        "superType": "number",
+        "description": "Numeric"
+      },
+      {
+        "id": "bitmask",
+        "superType": "number",
+        "description": "Bitmask"
+      },
+      {
+        "id": "namebit",
+        "superType": "number",
+        "description": "Namebit"
+      },
+      {
+        "id": "hex",
+        "superType": "number",
+        "description": "Hex"
+      },
+      {
+        "id": "sep",
+        "superType": "operator",
+        "description": "Separator"
+      },
+      {
+        "id": "macro-sec-keyword",
+        "superType": "operator",
+        "description": "SAS Macro Secondary Keyword"
+      },
+      {
+        "id": "macro-ref",
+        "superType": "operator",
+        "description": "SAS Macro Reference"
+      },
+      {
+        "id": "macro-keyword",
+        "superType": "keyword",
+        "description": "SAS Macro Keyword"
+      },
+      {
+        "id": "macro-comment",
+        "superType": "comment",
+        "description": "Macro Comment"
+      },
+      {
+        "id": "sec-keyword",
+        "superType": "method",
+        "description": "SAS Secondary keyword"
+      },
+      {
+        "id": "proc-name",
+        "superType": "method",
+        "description": "Name of the proc"
+      },
+      {
+        "id": "cards-data",
+        "superType": "parameter",
+        "description": "Card data"
+      },
+      {
+        "id": "error",
+        "superType": "event",
+        "description": "Error event"
+      },
+      {
+        "id": "warning",
+        "superType": "event",
+        "description": "Warning event"
+      },
+      {
+        "id": "note",
+        "superType": "event",
+        "description": "Note"
+      }
     ],
     "configuration": [
       {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,104 @@
     "virtualWorkspaces": true
   },
   "contributes": {
+    "semanticTokenTypes": [
+      {
+				"id": "date",
+				"superType": "string",
+				"description": "Date"
+			},
+			{
+				"id": "time",
+				"superType": "string",
+				"description": "Time"
+			},
+			{
+				"id": "dt",
+				"superType": "string",
+				"description": "DateTime"
+			},
+			{
+				"id": "format",
+				"superType": "string",
+				"description": "Format"
+			},
+			{
+				"id": "numeric",
+				"superType": "number",
+				"description": "Numeric"
+			},
+			{
+				"id": "bitmask",
+				"superType": "number",
+				"description": "Bitmask"
+			},
+			{
+				"id": "namebit",
+				"superType": "number",
+				"description": "Namebit"
+			},
+			{
+				"id": "hex",
+				"superType": "number",
+				"description": "Hex"
+			},
+			{
+				"id": "sep",
+				"superType": "operator",
+				"description": "Separator"
+			},
+			{
+				"id": "macro-sec-keyword",
+				"superType": "operator",
+				"description": "SAS Macro Secondary Keyword"
+			},
+			{
+				"id": "macro-ref",
+				"superType": "operator",
+				"description": "SAS Macro Reference"
+			},
+			{
+				"id": "macro-keyword",
+				"superType": "keyword",
+				"description": "SAS Macro Keyword"
+			},
+			{
+				"id": "macro-comment",
+				"superType": "comment",
+				"description": "Macro Comment"
+			},
+
+			{
+				"id": "sec-keyword",
+				"superType": "method",
+				"description": "SAS Secondary keyword"
+			},
+			{
+				"id": "proc-name",
+				"superType": "method",
+				"description": "Name of the proc"
+			},			
+			{
+				"id": "cards-data",
+				"superType": "parameter",
+				"description": "Card data"
+			},
+			{
+				"id": "error",
+				"superType": "event",
+				"description": "Error event"
+			},
+			{
+				"id": "warning",
+				"superType": "event",
+				"description": "Warning event"
+			},
+			{
+				"id": "note",
+				"superType": "event",
+				"description": "Note"
+			}
+    ],
     "configuration": [
       {
         "title": "%configuration.SAS.session.title.general%",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       },
       {
         "id": "bitmask",
-        "superType": "number",
+        "superType": "string",
         "description": "Bit mask"
       },
       {

--- a/package.json
+++ b/package.json
@@ -26,26 +26,41 @@
     "virtualWorkspaces": true
   },
   "contributes": {
+    "semanticTokenScopes": [
+      {
+        "language": "sas",
+        "scopes": {
+          "date": [
+            "entity."
+          ]
+        }
+      }
+    ],
     "semanticTokenTypes": [
       {
         "id": "date",
-        "superType": "string",
+        "superType": "decorator",
         "description": "Date"
       },
       {
         "id": "time",
-        "superType": "string",
+        "superType": "decorator",
         "description": "Time"
       },
       {
         "id": "dt",
-        "superType": "string",
+        "superType": "decorator",
         "description": "DateTime"
       },
       {
         "id": "format",
-        "superType": "string",
+        "superType": "decorator",
         "description": "Format"
+      },
+      {
+        "id": "namelit",
+        "superType": "decorator",
+        "description": "Name literal"
       },
       {
         "id": "numeric",
@@ -55,17 +70,12 @@
       {
         "id": "bitmask",
         "superType": "number",
-        "description": "Bitmask"
-      },
-      {
-        "id": "namebit",
-        "superType": "number",
-        "description": "Namebit"
+        "description": "Bit mask"
       },
       {
         "id": "hex",
         "superType": "number",
-        "description": "Hex"
+        "description": "Hexadecimal notation"
       },
       {
         "id": "sep",
@@ -74,12 +84,12 @@
       },
       {
         "id": "macro-sec-keyword",
-        "superType": "operator",
+        "superType": "function",
         "description": "SAS Macro Secondary Keyword"
       },
       {
         "id": "macro-ref",
-        "superType": "operator",
+        "superType": "variable",
         "description": "SAS Macro Reference"
       },
       {
@@ -90,37 +100,22 @@
       {
         "id": "macro-comment",
         "superType": "comment",
-        "description": "Macro Comment"
+        "description": "SAS Macro Comment"
       },
       {
         "id": "sec-keyword",
-        "superType": "method",
+        "superType": "function",
         "description": "SAS Secondary keyword"
       },
       {
         "id": "proc-name",
-        "superType": "method",
+        "superType": "function",
         "description": "Name of the proc"
       },
       {
         "id": "cards-data",
         "superType": "parameter",
         "description": "Card data"
-      },
-      {
-        "id": "error",
-        "superType": "event",
-        "description": "Error event"
-      },
-      {
-        "id": "warning",
-        "superType": "event",
-        "description": "Warning event"
-      },
-      {
-        "id": "note",
-        "superType": "event",
-        "description": "Note"
       }
     ],
     "configuration": [

--- a/server/src/sas/LanguageServiceProvider.ts
+++ b/server/src/sas/LanguageServiceProvider.ts
@@ -24,7 +24,7 @@ export const legend = {
     "time",
     "dt",
     "bitmask",
-    "namebit",
+    "namelit",
     "hex",
     "numeric",
     "format", //, 'text', 'blank'

--- a/themes/sas-dark-color-theme.json
+++ b/themes/sas-dark-color-theme.json
@@ -17,7 +17,7 @@
     "time": { "foreground": "#0caca4", "bold": true },
     "dt": { "foreground": "#0caca4", "bold": true },
     "bitmask": { "foreground": "#ff3dff", "bold": true },
-    "namebit": { "foreground": "#ff3dff", "bold": true },
+    "namelit": { "foreground": "#ff3dff", "bold": true },
     "hex": { "foreground": "#ff3dff", "bold": true },
     "numeric": { "foreground": "#0caca4", "bold": true },
     "format": { "foreground": "#0caca4" },

--- a/themes/sas-highcontrast-color-theme.json
+++ b/themes/sas-highcontrast-color-theme.json
@@ -17,7 +17,7 @@
     "time": { "foreground": "#28e6d1", "bold": true },
     "dt": { "foreground": "#28e6d1", "bold": true },
     "bitmask": { "foreground": "#ffb9c5", "bold": true },
-    "namebit": { "foreground": "#ffb9c5", "bold": true },
+    "namelit": { "foreground": "#ffb9c5", "bold": true },
     "hex": { "foreground": "#ff3dff", "bold": true },
     "numeric": { "foreground": "#28e6d1", "bold": true },
     "format": { "foreground": "#28e6d1" },

--- a/themes/sas-light-color-theme.json
+++ b/themes/sas-light-color-theme.json
@@ -17,7 +17,7 @@
     "time": { "foreground": "#08726d", "bold": true },
     "dt": { "foreground": "#08726d", "bold": true },
     "bitmask": { "foreground": "#800080", "bold": true },
-    "namebit": { "foreground": "#800080", "bold": true },
+    "namelit": { "foreground": "#800080", "bold": true },
     "hex": { "foreground": "#800080", "bold": true },
     "numeric": { "foreground": "#08726d", "bold": true },
     "format": { "foreground": "#08726d" },


### PR DESCRIPTION
## Description

Setting custom sematic tokens to base from standard tokens laid out in the [semantic highlighting guide for vscode](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide).

## Motivation and Context

An issue #13 was created to request support for syntax highlighting with the common themes instead of using the SAS Custom Themes.  Following the [semantic highlighting guide](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide), I was able to set a superType for all of the custom semantic token types.  This was an addition to the root package.json file.

## How Has This Been Tested?

The only way I was able to test was to delete the themes from the themes directory and start a debug session.  Then I copied the testFixture/SampleCode.sas file into a text file.  Then I was able to switch to multiple color themes to see if the syntax highlighting still was available.  This worked for themes  Material UI Theme & GitHub Theme.