### PR TITLE
fix: copy vscode setting object (#43)

### DIFF
--- a/client/src/session/rest/index.ts
+++ b/client/src/session/rest/index.ts
@@ -209,7 +209,7 @@ async function close() {
 }
 
 export function getSession(c: Config): Session {
-  config = c;
+  config = { ...c };
   config.endpoint = config.endpoint.replace(/\/$/, "");
   apiConfig.basePath = config.endpoint + "/compute";
 


### PR DESCRIPTION
It appears that altering value in the object got from vscode settings will result in error in this case, has to copy. 