### PR TITLE
Enforce Dot Notation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,6 @@ module.exports = {
   rules: {
     eqeqeq: "error",
     "prefer-const": "error",
-    "dot-notation": "error"
+    "dot-notation": "error",
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,5 +13,6 @@ module.exports = {
   rules: {
     eqeqeq: "error",
     "prefer-const": "error",
+    "dot-notation": "error"
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,11 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 6,
     sourceType: "module",
-    project: ["./tsconfig.json", "./client/tsconfig.json", "./server/tsconfig.json"]
+    project: [
+      "./tsconfig.json",
+      "./client/tsconfig.json",
+      "./server/tsconfig.json",
+    ],
   },
   env: {
     node: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 6,
     sourceType: "module",
+    project: ["./tsconfig.json", "./client/tsconfig.json", "./server/tsconfig.json"]
   },
   env: {
     node: true,
@@ -13,6 +14,6 @@ module.exports = {
   rules: {
     eqeqeq: "error",
     "prefer-const": "error",
-    "dot-notation": "error",
+    "@typescript-eslint/dot-notation": "error",
   },
 };

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -300,35 +300,35 @@ export class ProfileConfig {
       };
     }
 
-    profileClone["endpoint"] = await createInputTextBox(
+    profileClone.endpoint = await createInputTextBox(
       ProfilePromptType.Endpoint,
-      profileClone["endpoint"]
+      profileClone.endpoint
     );
-    if (!profileClone["endpoint"]) return;
+    if (!profileClone.endpoint) return;
 
-    profileClone["context"] = await createInputTextBox(
+    profileClone.context = await createInputTextBox(
       ProfilePromptType.ComputeContext,
-      profileClone["context"] || DEFAULT_COMPUTE_CONTEXT
+      profileClone.context || DEFAULT_COMPUTE_CONTEXT
     );
     if (
-      profileClone["context"] === "" ||
-      profileClone["context"] === DEFAULT_COMPUTE_CONTEXT
+      profileClone.context === "" ||
+      profileClone.context === DEFAULT_COMPUTE_CONTEXT
     ) {
-      delete profileClone["context"];
+      delete profileClone.context;
     }
 
-    profileClone["clientId"] = await createInputTextBox(
+    profileClone.clientId = await createInputTextBox(
       ProfilePromptType.ClientId,
-      profileClone["clientId"]
+      profileClone.clientId
     );
-    if (profileClone["clientId"] === "") {
-      delete profileClone["clientId"];
+    if (profileClone.clientId === "") {
+      delete profileClone.clientId;
     }
 
-    if (profileClone["clientId"]) {
-      profileClone["clientSecret"] = await createInputTextBox(
+    if (profileClone.clientId) {
+      profileClone.clientSecret = await createInputTextBox(
         ProfilePromptType.ClientSecret,
-        profileClone["clientSecret"]
+        profileClone.clientSecret
       );
     }
 

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -300,7 +300,7 @@ export class ProfileConfig {
       };
     }
 
-    profileClone["endpoint"] = await createInputTextBox(
+    profileClone.endpoint = await createInputTextBox(
       ProfilePromptType.Endpoint,
       profileClone.endpoint
     );

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -300,7 +300,7 @@ export class ProfileConfig {
       };
     }
 
-    profileClone.endpoint = await createInputTextBox(
+    profileClone["endpoint"] = await createInputTextBox(
       ProfilePromptType.Endpoint,
       profileClone.endpoint
     );

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,6 +7,6 @@
     "rootDir": ".",
     "sourceMap": true
   },
-  "include": ["src","test"],
+  "include": ["src", "test"],
   "exclude": ["node_modules", ".vscode-test"]
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,6 +7,6 @@
     "rootDir": ".",
     "sourceMap": true
   },
-  "include": ["test"],
+  "include": ["src","test"],
   "exclude": ["node_modules", ".vscode-test"]
 }

--- a/server/src/sas/CodeZoneManager.ts
+++ b/server/src/sas/CodeZoneManager.ts
@@ -2,7 +2,7 @@
 // Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion,
-@typescript-eslint/no-unused-vars,@typescript-eslint/no-explicit-any */
+@typescript-eslint/no-unused-vars,@typescript-eslint/no-explicit-any, @typescript-eslint/dot-notation */
 import { arrayToMap } from "./utils";
 import { LexerEx } from "./LexerEx";
 import { Lexer, Token } from "./Lexer";
@@ -504,8 +504,8 @@ export class CodeZoneManager {
         text: token.text,
       };
       if (token.start.line !== token.end.line) {
-        nToken.endLine = token.end.line;
-        nToken.endCol = token.end.column;
+        nToken["endLine"] = token.end.line;
+        nToken["endCol"] = token.end.column;
       }
       return nToken;
     }
@@ -1221,7 +1221,7 @@ export class CodeZoneManager {
         CodeZoneManager.ZONE_TYPE.RESTRICTED,
         CodeZoneManager.ZONE_TYPE.STYLE_ATTR
       );
-      ret.op1 = {
+      ret["op1"] = {
         op: token,
         op1: op1,
         op2: this._stmtOptions(
@@ -1232,7 +1232,7 @@ export class CodeZoneManager {
         ),
       };
     } else {
-      ret.op1 = styleElemNames;
+      ret["op1"] = styleElemNames;
     }
     return ret;
   }
@@ -1850,14 +1850,14 @@ export class CodeZoneManager {
           opts.push(viewOrPrg);
           this._copyContext(tmpContext, context);
           token1 = this._getNextEx(context); // view name or program name
-          viewOrPrg.op2 = token1;
+          viewOrPrg["op2"]= token1;
           if (Lexer.isWord[token1.type]) {
             this._emit(token1, CodeZoneManager.ZONE_TYPE.VIEW_OR_PGM_NAME);
             tmpContext = this._cloneContext(context);
             token2 = this._getNextEx(tmpContext);
             if (token2.text === "(") {
               this._emit(token1, CodeZoneManager.ZONE_TYPE.OBJECT);
-              viewOrPrg.op2 = {
+              viewOrPrg["op2"] = {
                 op: token1,
                 op1: this._argList(
                   context,

--- a/server/src/sas/CodeZoneManager.ts
+++ b/server/src/sas/CodeZoneManager.ts
@@ -504,8 +504,8 @@ export class CodeZoneManager {
         text: token.text,
       };
       if (token.start.line !== token.end.line) {
-        nToken["endLine"] = token.end.line;
-        nToken["endCol"] = token.end.column;
+        nToken.endLine = token.end.line;
+        nToken.endCol = token.end.column;
       }
       return nToken;
     }
@@ -1221,7 +1221,7 @@ export class CodeZoneManager {
         CodeZoneManager.ZONE_TYPE.RESTRICTED,
         CodeZoneManager.ZONE_TYPE.STYLE_ATTR
       );
-      ret["op1"] = {
+      ret.op1 = {
         op: token,
         op1: op1,
         op2: this._stmtOptions(
@@ -1232,7 +1232,7 @@ export class CodeZoneManager {
         ),
       };
     } else {
-      ret["op1"] = styleElemNames;
+      ret.op1 = styleElemNames;
     }
     return ret;
   }
@@ -1850,14 +1850,14 @@ export class CodeZoneManager {
           opts.push(viewOrPrg);
           this._copyContext(tmpContext, context);
           token1 = this._getNextEx(context); // view name or program name
-          viewOrPrg["op2"] = token1;
+          viewOrPrg.op2 = token1;
           if (Lexer.isWord[token1.type]) {
             this._emit(token1, CodeZoneManager.ZONE_TYPE.VIEW_OR_PGM_NAME);
             tmpContext = this._cloneContext(context);
             token2 = this._getNextEx(tmpContext);
             if (token2.text === "(") {
               this._emit(token1, CodeZoneManager.ZONE_TYPE.OBJECT);
-              viewOrPrg["op2"] = {
+              viewOrPrg.op2 = {
                 op: token1,
                 op1: this._argList(
                   context,

--- a/server/src/sas/CodeZoneManager.ts
+++ b/server/src/sas/CodeZoneManager.ts
@@ -1850,7 +1850,7 @@ export class CodeZoneManager {
           opts.push(viewOrPrg);
           this._copyContext(tmpContext, context);
           token1 = this._getNextEx(context); // view name or program name
-          viewOrPrg["op2"]= token1;
+          viewOrPrg["op2"] = token1;
           if (Lexer.isWord[token1.type]) {
             this._emit(token1, CodeZoneManager.ZONE_TYPE.VIEW_OR_PGM_NAME);
             tmpContext = this._cloneContext(context);

--- a/server/src/sas/SyntaxDataProvider.ts
+++ b/server/src/sas/SyntaxDataProvider.ts
@@ -2,7 +2,8 @@
 // Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types,
-@typescript-eslint/no-unused-vars,@typescript-eslint/no-explicit-any */
+@typescript-eslint/no-unused-vars,@typescript-eslint/no-explicit-any,@typescript-eslint/dot-notation */
+
 
 import { arrayToMap } from "./utils";
 import { ResLoader } from "../node/ResLoader";
@@ -407,7 +408,7 @@ function _iterateKeywords(
 ) {
   const count = keywords.length;
   for (let i = 0; i < count; i++) {
-    if (!keywords[i].Name) continue;
+    if (!keywords[i]["Name"]) continue;
     const names = keywords[i].Name.split("|");
     for (let j = 0; j < names.length; j++) {
       cb(i, names[j], keywords[i]);
@@ -545,13 +546,13 @@ function _loadProceduresFromPubs(cb?: () => void) {
     url,
     function (data?: string[]) {
       if (data && data.length) {
-        if (db.kwPool.proc === undefined) {
+        if (db.kwPool["proc"] === undefined) {
           db.kwPool.proc = {};
         }
         data.forEach(function (item) {
-          db.kwPool.proc[item] = {};
+          db.kwPool["proc"][item] = {};
         });
-        db.kwPool.proc[ID_KEYWORDS] = data;
+        db.kwPool["proc"][ID_KEYWORDS] = data;
         if (cb) cb();
       }
     },
@@ -1237,8 +1238,8 @@ function _setProcedureOptions(procName: string, data: any[]) {
     let keywords: string[] = [];
     if (!(data instanceof Array)) data = [data];
     for (let i = 0; i < data.length; i++) {
-      if (!data[i].ProcedureOptionName) continue;
-      const names = data[i].ProcedureOptionName.split("|");
+      if (!data[i]["ProcedureOptionName"]) continue;
+      const names = data[i]["ProcedureOptionName"].split("|");
       if (names[names.length - 1] === "") names.pop();
       for (let j = 0; j < names.length; j++) {
         _setProcedureOption(procName, names[j], data[i]);
@@ -1624,7 +1625,7 @@ function _setProcedureStatementOptions(
     let keywords: string[] = [];
     if (!(data instanceof Array)) data = [data];
     for (let i = 0; i < data.length; i++) {
-      let names = data[i].StatementOptionName;
+      let names = data[i]["StatementOptionName"];
       if (!names) continue;
       names = names.split("|");
       if (names[names.length - 1] === "") names.pop();
@@ -1701,7 +1702,7 @@ function _setProcedureStatements(procName: string, data: any[]) {
     let keywords: string[] = [];
     if (!(data instanceof Array)) data = [data];
     for (let i = 0; i < data.length; i++) {
-      let names = data[i].StatementName;
+      let names = data[i]["StatementName"];
       if (!names) continue;
       names = names.split("|");
       if (names[names.length - 1] === "") names.pop();
@@ -2462,7 +2463,7 @@ export class SyntaxDataProvider {
   }
   getFunctions(cb?: (data: string[]) => void) {
     return _tryToLoadFunctionsFromPubs("base", cb, function () {
-      const data = db.functions.base[ID_KEYWORDS];
+      const data = db.functions["base"][ID_KEYWORDS];
       return data;
     });
   }
@@ -2471,7 +2472,7 @@ export class SyntaxDataProvider {
   }
   getMacroFunctions(cb?: (data: string[]) => void) {
     return _tryToLoadFunctionsFromPubs("macro", cb, function () {
-      const data = db.functions.macro[ID_KEYWORDS];
+      const data = db.functions["macro"][ID_KEYWORDS];
       return data;
     });
   }
@@ -2656,7 +2657,7 @@ export class SyntaxDataProvider {
   }
   isSasFunction(name: string) {
     return _tryToLoadFunctionsFromPubs("base", null, function () {
-      return db.functions.base[ID_KEYWORDS].indexOf(name) !== -1;
+      return db.functions["base"][ID_KEYWORDS].indexOf(name) !== -1;
     });
   }
   isDataSetType(type: string) {

--- a/server/src/sas/SyntaxDataProvider.ts
+++ b/server/src/sas/SyntaxDataProvider.ts
@@ -4,7 +4,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types,
 @typescript-eslint/no-unused-vars,@typescript-eslint/no-explicit-any,@typescript-eslint/dot-notation */
 
-
 import { arrayToMap } from "./utils";
 import { ResLoader } from "../node/ResLoader";
 

--- a/server/src/sas/SyntaxDataProvider.ts
+++ b/server/src/sas/SyntaxDataProvider.ts
@@ -407,8 +407,8 @@ function _iterateKeywords(
 ) {
   const count = keywords.length;
   for (let i = 0; i < count; i++) {
-    if (!keywords[i]["Name"]) continue;
-    const names = keywords[i]["Name"].split("|");
+    if (!keywords[i].Name) continue;
+    const names = keywords[i].Name.split("|");
     for (let j = 0; j < names.length; j++) {
       cb(i, names[j], keywords[i]);
     }
@@ -545,13 +545,13 @@ function _loadProceduresFromPubs(cb?: () => void) {
     url,
     function (data?: string[]) {
       if (data && data.length) {
-        if (db.kwPool["proc"] === undefined) {
-          db.kwPool["proc"] = {};
+        if (db.kwPool.proc === undefined) {
+          db.kwPool.proc = {};
         }
         data.forEach(function (item) {
-          db.kwPool["proc"][item] = {};
+          db.kwPool.proc[item] = {};
         });
-        db.kwPool["proc"][ID_KEYWORDS] = data;
+        db.kwPool.proc[ID_KEYWORDS] = data;
         if (cb) cb();
       }
     },
@@ -1237,8 +1237,8 @@ function _setProcedureOptions(procName: string, data: any[]) {
     let keywords: string[] = [];
     if (!(data instanceof Array)) data = [data];
     for (let i = 0; i < data.length; i++) {
-      if (!data[i]["ProcedureOptionName"]) continue;
-      const names = data[i]["ProcedureOptionName"].split("|");
+      if (!data[i].ProcedureOptionName) continue;
+      const names = data[i].ProcedureOptionName.split("|");
       if (names[names.length - 1] === "") names.pop();
       for (let j = 0; j < names.length; j++) {
         _setProcedureOption(procName, names[j], data[i]);
@@ -1624,7 +1624,7 @@ function _setProcedureStatementOptions(
     let keywords: string[] = [];
     if (!(data instanceof Array)) data = [data];
     for (let i = 0; i < data.length; i++) {
-      let names = data[i]["StatementOptionName"];
+      let names = data[i].StatementOptionName;
       if (!names) continue;
       names = names.split("|");
       if (names[names.length - 1] === "") names.pop();
@@ -1701,7 +1701,7 @@ function _setProcedureStatements(procName: string, data: any[]) {
     let keywords: string[] = [];
     if (!(data instanceof Array)) data = [data];
     for (let i = 0; i < data.length; i++) {
-      let names = data[i]["StatementName"];
+      let names = data[i].StatementName;
       if (!names) continue;
       names = names.split("|");
       if (names[names.length - 1] === "") names.pop();
@@ -2462,7 +2462,7 @@ export class SyntaxDataProvider {
   }
   getFunctions(cb?: (data: string[]) => void) {
     return _tryToLoadFunctionsFromPubs("base", cb, function () {
-      const data = db.functions["base"][ID_KEYWORDS];
+      const data = db.functions.base[ID_KEYWORDS];
       return data;
     });
   }
@@ -2471,7 +2471,7 @@ export class SyntaxDataProvider {
   }
   getMacroFunctions(cb?: (data: string[]) => void) {
     return _tryToLoadFunctionsFromPubs("macro", cb, function () {
-      const data = db.functions["macro"][ID_KEYWORDS];
+      const data = db.functions.macro[ID_KEYWORDS];
       return data;
     });
   }
@@ -2656,7 +2656,7 @@ export class SyntaxDataProvider {
   }
   isSasFunction(name: string) {
     return _tryToLoadFunctionsFromPubs("base", null, function () {
-      return db.functions["base"][ID_KEYWORDS].indexOf(name) !== -1;
+      return db.functions.base[ID_KEYWORDS].indexOf(name) !== -1;
     });
   }
   isDataSetType(type: string) {


### PR DESCRIPTION
What should our stance on enforcing dot notation be? I found some spots where javascript key notation is used for getting and setting values. I'd like to propose that we take a stance of using idiomatic typescript whenever possible, including using the dot syntax. 

It gets a bit trickier for any types. I'd propose that we leave the enforcement of the rule at error and manually suppress these on a case by case basis. I would think that for this issue, having a lot of manual suppressions would indicate some kind of design smell in the types that we'd want to address.