### PR TITLE
Change Run and Run Selected behavior (including default keybindings) to be consistent with other SAS IDEs

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -19,10 +19,17 @@ let running = false;
 function getCode(outputHtml: boolean, selected = false): string {
   const editor = window.activeTextEditor;
   const doc = editor?.document;
-  let code: string;
+  let code = "";
   if (selected) {
-    // run selected code if there is a selection, otherwise run all code
-    code = doc?.getText(editor?.selection);
+    // run selected code if there is one or more non-empty selections, otherwise run all code
+
+    // since you can have multiple selections, append the text for each selection in order of selection
+    // note: selection ranges can be empty (ex. just a carat)
+    for (const selection of editor.selections) {
+      const selectedText: string = doc.getText(selection);
+      code += selectedText;
+    }
+    // if no non-whitespace characters are selected, treat as no selection and run all code
     if (code.trim().length === 0) {
       code = doc?.getText();
     }
@@ -30,11 +37,7 @@ function getCode(outputHtml: boolean, selected = false): string {
     code = doc?.getText();
   }
 
-  return code
-    ? outputHtml
-      ? "ods html5;\n" + code + "\n;quit;ods html5 close;"
-      : code
-    : "";
+  return outputHtml ? "ods html5;\n" + code + "\n;quit;ods html5 close;" : code;
 }
 
 async function runCode(selected?: boolean) {

--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -19,7 +19,16 @@ let running = false;
 function getCode(outputHtml: boolean, selected = false): string {
   const editor = window.activeTextEditor;
   const doc = editor?.document;
-  const code = selected ? doc?.getText(editor?.selection) : doc?.getText();
+  let code: string;
+  if (selected) {
+    // run selected code if there is a selection, otherwise run all code
+    code = doc?.getText(editor?.selection);
+    if (code.trim().length === 0) {
+      code = doc?.getText();
+    }
+  } else {
+    code = doc?.getText();
+  }
 
   return code
     ? outputHtml

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -38,11 +38,13 @@ async function setup() {
     }
   }
 
-  if (computeSession) return;
+  if (computeSession) {
+    return;
+  }
 
   //Set the locale in the base options so it appears on all api calls
   const locale = JSON.parse(process.env.VSCODE_NLS_CONFIG ?? "{}").locale;
-  apiConfig.baseOptions["headers"] = { "Accept-Language": locale };
+  apiConfig.baseOptions.headers = { "Accept-Language": locale };
 
   if (config.serverId) {
     const server1 = new ComputeServer(config.serverId);
@@ -59,8 +61,9 @@ async function setup() {
         filter: `eq(name,'${contextName}')`,
       })
     ).data.items[0];
-    if (!context?.id)
+    if (!context?.id) {
       throw new Error("Compute Context not found: " + contextName);
+    }
 
     const sess = (
       await contextsApi.createSession(
@@ -83,7 +86,9 @@ async function printLog(job: ComputeJob, onLog?: (logs: LogLine[]) => void) {
 }
 
 async function run(code: string, onLog?: (logs: LogLine[]) => void) {
-  if (!computeSession?.sessionId) throw new Error();
+  if (!computeSession?.sessionId) {
+    throw new Error();
+  }
 
   //Get the job
   const job = await computeSession.execute({ code: [code] });

--- a/package.json
+++ b/package.json
@@ -216,23 +216,35 @@
         "category": "SAS"
       }
     ],
+    "keybindings": [
+      {
+        "when": "editorFocus && editorLangId == sas && !SAS.hideRunMenuItem",
+        "command": "SAS.run",
+        "key": "f8"
+      },
+      {
+        "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+        "command": "SAS.runSelected",
+        "key": "f3"
+      }
+    ],
     "menus": {
       "editor/title/run": [
         {
           "when": "editorFocus && editorLangId == sas && !SAS.hideRunMenuItem",
-          "command": "SAS.run"
+          "command": "SAS.runSelected"
         }
       ],
       "editor/context": [
         {
           "when": "editorFocus && editorLangId == sas && !SAS.hideRunMenuItem",
           "command": "SAS.run",
-          "group": "navigation"
+          "group": "navigation@2"
         },
         {
-          "when": "editorHasSelection && !editorHasMultipleSelections && editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
           "command": "SAS.runSelected",
-          "group": "navigation"
+          "group": "navigation@1"
         }
       ],
       "editor/title": [
@@ -248,7 +260,7 @@
           "command": "SAS.run"
         },
         {
-          "when": "editorHasSelection && !editorHasMultipleSelections && editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
           "command": "SAS.runSelected"
         }
       ]

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,11 +11,11 @@
   "configuration.SAS.connectionProfiles.profiles.clientId": "SAS Viya Client ID",
   "configuration.SAS.connectionProfiles.profiles.clientSecret": "SAS Viya Client Secret",
 
-  "commands.SAS.run": "Run SAS code",
+  "commands.SAS.run": "Run All SAS Code",
   "commands.SAS.close": "Close Current Session",
   "commands.SAS.switchProfile": "Switch Current Connection Profile",
   "commands.SAS.addProfile": "Add New Connection Profile",
   "commands.SAS.deleteProfile": "Delete Connection Profile",
   "commands.SAS.updateProfile": "Update Connection Profile",
-  "commands.SAS.runSelected": "Run Selected SAS Code"
+  "commands.SAS.runSelected": "Run Selected or All SAS Code"
 }


### PR DESCRIPTION
Matching the defaults of SAS Studio and EG, and very similar to DMS.

Planning to submit additional commits to change the run behavior to be more consistent with SAS Studio, EG, and DMS by default. For example, Run Selected should run all the code if there is no selection. Also, the "Run" button on the toolbar should perform the "Run selected" command...  if there is a selection, run just the selection, if there is no selection run all the code.