### PR TITLE
Make prettier the default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.tabSize": 2,
   "editor.insertSpaces": true,
   "editor.formatOnSave": true,


### PR DESCRIPTION
Since we already recommend prettier as the formatter of choice, and already source a config js for it, set it as the default formatter. #48 