### PR TITLE
chore: add no-unused-vars rule to eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     eqeqeq: "error",
     "prefer-const": "error",
     "@typescript-eslint/dot-notation": "error",
+    "@typescript-eslint/no-unused-vars": "error",
     curly: "error",
   },
 };


### PR DESCRIPTION
**Summary**
This adds a new rule to prevent unused imports in our code. Previously, this was a warning.

**Testing**
- Ran `yarn lint`
