### PR TITLE
fix: Only show Results window if result is generated #46.

### DIFF
--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -124,7 +124,6 @@ async function run(code: string, onLog?: (logs: LogLine[]) => void) {
         res.title = result.name;
       }
 
-      res.title = result.name;
       break;
     }
   }

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -116,7 +116,14 @@ async function run(code: string, onLog?: (logs: LogLine[]) => void) {
   for (const result of results.reverse()) {
     const link = result.links[0];
     if (link.type === "text/html") {
-      res.html5 = (await job.requestLink<string>(link)).data;
+      const html5 = (await job.requestLink<string>(link)).data;
+
+      //Make sure that the html has a valid body
+      if (html5.search('<*id="IDX*.+">') !== -1) {
+        res.html5 = html5;
+        res.title = result.name;
+      }
+
       res.title = result.name;
       break;
     }


### PR DESCRIPTION
The results window was being displayed for all code executions, regardless of whether or not an actual ODS result was created. This is because the code
is wrapped in ods html5; ... ods html5 close;
This generates an html file, even if it does not
have anything in it.

Signed-off-by: Joseph Henry <joseph.henry@sas.com>

**Summary**
I am now checking for a valid body in the HTML before it is displayed.

**Testing**
I ran simple tests like 

`proc options; run;`

and 

```
data _null_;
x=10;
run;
```

That do not produce any ODS output and confirmed that the Result window does not appear.

Other tests like 

`proc print data=sashelp.cars;run;`

does produce a Result.
