### PR TITLE
feat: support authorization redirect

### DIFF
--- a/client/src/components/AuthProvider.ts
+++ b/client/src/components/AuthProvider.ts
@@ -1,0 +1,85 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+// Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
+
+import {
+  AuthenticationProvider,
+  AuthenticationProviderAuthenticationSessionsChangeEvent,
+  AuthenticationSession,
+  Disposable,
+  Event,
+  EventEmitter,
+  SecretStorage,
+} from "vscode";
+import { profileConfig } from "../commands/profile";
+import { getTokens, refreshToken } from "../connection/rest/auth";
+import { getCurrentUser } from "../connection/rest/identities";
+
+const SECRET_KEY = "SASAuth";
+
+interface SASAuthSession extends AuthenticationSession {
+  refreshToken?: string;
+}
+
+export class SASAuthProvider implements AuthenticationProvider, Disposable {
+  static id = "SAS";
+
+  private _onDidChangeSessions =
+    new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
+  get onDidChangeSessions(): Event<AuthenticationProviderAuthenticationSessionsChangeEvent> {
+    return this._onDidChangeSessions.event;
+  }
+
+  constructor(private readonly secretStorage: SecretStorage) {}
+
+  dispose(): void {
+    this._onDidChangeSessions.dispose();
+  }
+
+  async getSessions(): Promise<readonly AuthenticationSession[]> {
+    const stored = await this.secretStorage.get(SECRET_KEY);
+    if (!stored) {
+      return [];
+    }
+    const session: SASAuthSession = JSON.parse(stored);
+    const activeProfile = profileConfig.getActiveProfileDetail();
+    const tokens = await refreshToken(activeProfile.profile, {
+      access_token: session.accessToken,
+      refresh_token: session.refreshToken,
+    });
+    if (!tokens) {
+      // refresh token failed, the stored session is not valid anymore
+      await this.removeSession();
+      return [];
+    }
+    const accessToken = tokens.access_token;
+    if (accessToken === session.accessToken) {
+      return [session];
+    }
+    const newSession = { ...session, accessToken: tokens.access_token };
+    await this.secretStorage.store(SECRET_KEY, JSON.stringify(newSession));
+    return [newSession];
+  }
+
+  async createSession(): Promise<AuthenticationSession> {
+    const activeProfile = profileConfig.getActiveProfileDetail();
+    const { access_token: accessToken, refresh_token: refreshToken } =
+      await getTokens(activeProfile.profile);
+    const user = await getCurrentUser({
+      endpoint: activeProfile.profile.endpoint,
+      accessToken,
+    });
+    const session: SASAuthSession = {
+      id: "SAS",
+      account: { id: user.id, label: user.name },
+      accessToken,
+      refreshToken,
+      scopes: [],
+    };
+    await this.secretStorage.store(SECRET_KEY, JSON.stringify(session));
+    return session;
+  }
+
+  async removeSession(): Promise<void> {
+    await this.secretStorage.delete(SECRET_KEY);
+  }
+}

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -1,8 +1,7 @@
-// Copyright © 2022, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+// Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 // Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
 
-import { window, workspace, ConfigurationTarget } from "vscode";
-import { closeSession } from "../commands/closeSession";
+import { commands, window, workspace, ConfigurationTarget } from "vscode";
 
 export const EXTENSION_CONFIG_KEY = "SAS";
 export const EXTENSION_DEFINE_PROFILES_CONFIG_KEY = "connectionProfiles";
@@ -155,7 +154,7 @@ export class ProfileConfig {
       profiles: profileList,
     };
     if (activeProfileParam in profileList) {
-      closeSession();
+      commands.executeCommand("SAS.close", true);
     } else {
       profiles.activeProfile = "";
     }

--- a/client/src/connection/rest/auth.ts
+++ b/client/src/connection/rest/auth.ts
@@ -2,7 +2,7 @@
 // Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
 
 import axios from "axios";
-import { env, Uri, window } from "vscode";
+import { CancellationTokenSource, env, Uri, window } from "vscode";
 import { URLSearchParams } from "url";
 import { createHash } from "crypto";
 import { Config } from ".";
@@ -13,60 +13,95 @@ interface Tokens {
   access_token: string;
   refresh_token: string;
 }
-let tokens: Tokens | undefined;
 
-export async function getAccessToken(config: Config): Promise<string> {
+export async function refreshToken(
+  config: Config,
+  tokens: Tokens
+): Promise<Tokens | undefined> {
   const clientId = config.clientId || "vscode";
   const clientSecret = config.clientSecret ?? "";
 
-  if (tokens) {
-    const rootApi = RootApi(
-      new Configuration({ basePath: config.endpoint + "/compute" })
-    );
-    await rootApi.headersForRoot().catch((err) => {
-      if (err.response?.status === 401) {
-        // token expired, try refresh token
-        return axios
-          .post(
-            `${config.endpoint}/SASLogon/oauth/token`,
-            new URLSearchParams({
-              client_id: clientId,
-              client_secret: clientSecret,
-              grant_type: "refresh_token",
-              refresh_token: tokens?.refresh_token,
-            }).toString()
-          )
-          .then(
-            (res) => {
-              tokens = res.data;
-            },
-            () => {
-              // refresh token failed, has to login again
-              tokens = undefined;
-            }
-          );
-      }
-      throw err;
-    });
-  }
+  const rootApi = RootApi(
+    new Configuration({ basePath: config.endpoint + "/compute" })
+  );
+  await rootApi.headersForRoot().catch((err) => {
+    if (err.response?.status === 401) {
+      // token expired, try refresh token
+      return axios
+        .post(
+          `${config.endpoint}/SASLogon/oauth/token`,
+          new URLSearchParams({
+            client_id: clientId,
+            client_secret: clientSecret,
+            grant_type: "refresh_token",
+            refresh_token: tokens?.refresh_token,
+          }).toString()
+        )
+        .then(
+          (res) => {
+            tokens = res.data;
+          },
+          () => {
+            // refresh token failed, has to login again
+            tokens = undefined;
+          }
+        );
+    }
+    throw err;
+  });
 
-  if (tokens) {
-    return tokens.access_token;
-  }
+  return tokens;
+}
+
+export async function getTokens(
+  config: Config,
+  tokens?: Tokens
+): Promise<Tokens> {
+  const clientId = config.clientId || "vscode";
+  const clientSecret = config.clientSecret ?? "";
 
   const { codeVerifier, codeChallenge } = getPKCE();
 
+  const callbackUrl = await env.asExternalUri(
+    Uri.parse(`${env.uriScheme}://sas.sas-lsp`)
+  );
+
+  const params = new URLSearchParams([
+    ["client_id", clientId],
+    ["response_type", "code"],
+    ["code_challenge_method", "S256"],
+    ["code_challenge", codeChallenge],
+    ["state", encodeURIComponent(callbackUrl.toString(true))],
+  ]);
   await env.openExternal(
     Uri.parse(
-      `${config.endpoint}/SASLogon/oauth/authorize?client_id=${clientId}&response_type=code&code_challenge_method=S256&code_challenge=${codeChallenge}`
+      `${config.endpoint}/SASLogon/oauth/authorize?${params.toString()}`
     )
   );
 
-  const authCode = await window.showInputBox({
-    placeHolder: `Paste authorization code here`,
-    password: true,
-    ignoreFocusOut: true,
+  const cancellationToken = new CancellationTokenSource();
+  let authCode: string;
+  const handler = window.registerUriHandler({
+    handleUri: (uri) => {
+      const code = new URLSearchParams(uri.query).get("code");
+      if (code) {
+        authCode = code;
+        cancellationToken.cancel();
+      }
+    },
   });
+  const inputCode = await window.showInputBox(
+    {
+      placeHolder: `Paste authorization code here`,
+      password: true,
+      ignoreFocusOut: true,
+    },
+    cancellationToken.token
+  );
+  handler.dispose();
+  if (!authCode && inputCode) {
+    authCode = inputCode;
+  }
   if (!authCode) {
     throw new Error("No authorization code");
   }
@@ -83,11 +118,7 @@ export async function getAccessToken(config: Config): Promise<string> {
       }).toString()
     )
   ).data;
-  return tokens?.access_token ?? "";
-}
-
-export function clearTokens(): void {
-  tokens = undefined;
+  return tokens;
 }
 
 function getPKCE() {

--- a/client/src/connection/rest/identities.ts
+++ b/client/src/connection/rest/identities.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+export interface User {
+  id: string;
+  name: string;
+}
+
+// It's used by AuthProvider before a new authentication session returned
+// So has to pass access token mannually
+export async function getCurrentUser(options: {
+  endpoint: string;
+  accessToken: string;
+}) {
+  return (
+    await axios.get<User>(`${options.endpoint}/identities/users/@currentUser`, {
+      headers: {
+        Authorization: "Bearer " + options.accessToken,
+      },
+    })
+  ).data;
+}

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -3,6 +3,7 @@
 
 import * as path from "path";
 import {
+  authentication,
   commands,
   ConfigurationChangeEvent,
   ExtensionContext,
@@ -28,6 +29,7 @@ import {
   deleteProfile,
 } from "../commands/profile";
 import { run, runSelected } from "../commands/run";
+import { SASAuthProvider } from "../components/AuthProvider";
 
 let client: LanguageClient;
 // Create Profile status bar item
@@ -78,13 +80,18 @@ export function activate(context: ExtensionContext): void {
   context.subscriptions.push(
     commands.registerCommand("SAS.run", run),
     commands.registerCommand("SAS.runSelected", runSelected),
-    commands.registerCommand("SAS.close", () =>
-      closeSession("The SAS session has closed.")
+    commands.registerCommand("SAS.close", (silent) =>
+      closeSession(silent === true ? undefined : "The SAS session has closed.")
     ),
     commands.registerCommand("SAS.switchProfile", switchProfile),
     commands.registerCommand("SAS.addProfile", addProfile),
     commands.registerCommand("SAS.deleteProfile", deleteProfile),
     commands.registerCommand("SAS.updateProfile", updateProfile),
+    authentication.registerAuthenticationProvider(
+      SASAuthProvider.id,
+      "SAS",
+      new SASAuthProvider(context.secrets)
+    ),
     languages.registerDocumentSemanticTokensProvider(
       { language: "sas-log" },
       LogTokensProvider,


### PR DESCRIPTION
**Summary**

- Register SAS as an [AuthenticationProvider](https://code.visualstudio.com/api/references/vscode-api#AuthenticationProvider) to take standard VS Code authentication behavior, which means
  - SAS account will sit in VS Code's standard Accounts menu
  - Authentication can be shared in a standard way across different functionalities (run, content navi, etc.) and even different extensions in future
  - Authentication can persist across VS Code sessions (#94)
- Support direct re-direct from SASLogon so that user don't need to copy/paste authorization code
  - It also depends on server update
  - It uses the standard https://vscode.dev/redirect as the single redirect uri

**Testing**
- Make sure no regressions. User can still paste authorization code
- Close and re-open VS Code, the authentication persist
- It also works on https://vscode.dev with remote extension host
