### PR TITLE
fix: run all mocha tests

### DIFF
--- a/client/test/profile.test.ts
+++ b/client/test/profile.test.ts
@@ -25,7 +25,7 @@ async function initProfile(): Promise<void> {
   profileConfig = new ProfileConfig();
 }
 
-describe.only("Profiles", async function () {
+describe("Profiles", async function () {
   before(async () => {
     await workspace
       .getConfiguration(EXTENSION_CONFIG_KEY)


### PR DESCRIPTION
**Summary**
Removes "only" function that was errantly causing only the profile test suite to run

**Testing**
1. rm -rf client/out
2. npm run test
3. Verify that all test suites including profile run as expected and pass.
