### PR TITLE
fix: double quote glob patterns when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -502,7 +502,7 @@
   "qna": "https://marketplace.visualstudio.com/items?itemName=SAS.sas-lsp&ssr=false#qna",
   "scripts": {
     "vscode:prepublish": "npm run lint && npm run compile && npm run compile-browser",
-    "lint": "node node_modules/eslint/bin/eslint.js './client/src/**/*.ts' './server/src/**/*.ts'",
+    "lint": "node node_modules/eslint/bin/eslint.js \"./client/src/**/*.ts\" \"./server/src/**/*.ts\"",
     "compile": "node ./tools/build.mjs",
     "watch": "node ./tools/build.mjs dev",
     "compile-browser": "webpack --mode production",


### PR DESCRIPTION
**Summary**
Quoting glob patterns on windows with single quotes generates errors when running 
`npm run lint`. 
Using double quotes and properly escaping the double quotes will resolve the issue.

**Testing**
1. Fixed lint script
2. Manually introduced a code lint issue
3. Run `npm run lint` from the terminal.  Verify that the error is properly reported in the terminal
4. Fix the manually introduced code lint issues
5. Run `npm run lint` again from the terminal. Verify that the script runs to completion with rc 0.
