### PR TITLE
fix: improve the new file/folder name validator (#156)

### DIFF
--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -156,7 +156,8 @@ export class ContentModel {
         {
           headers: {
             "Content-Type": "text/plain",
-            "Content-Disposition": `filename="${fileName}"`,
+            "Content-Disposition": `filename*=UTF-8''${encodeURI(fileName)}`,
+            Accept: "application/vnd.sas.file+json",
           },
         }
       );

--- a/client/src/components/ContentNavigator/const.ts
+++ b/client/src/components/ContentNavigator/const.ts
@@ -47,7 +47,8 @@ export const Messages = {
   FileOpenError: "The file type is unsupported.",
   FileValidationError: "Invalid file name.",
   FolderDeletionError: "Unable to delete folder.",
-  FolderValidationError: "Invalid folder name.",
+  FolderValidationError:
+    "The folder name cannot contain more than 100 characters.",
   NewFileCreationError: 'Unable to create file "%(name)s".',
   NewFilePrompt: "Enter a file name.",
   NewFileTitle: "New File",

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -20,11 +20,13 @@ import { ContentItem } from "./types";
 import { getUri, isContainer as getIsContainer } from "./utils";
 
 const fileValidator = (value: string): string | null =>
-  /^([a-zA-Z0-9\s._-]+)\.\w+$/.test(value)
+  /^([^,/<>?;:\\{}|`=+*&^%#@!~\uff01-\uff5e\u3000-\u303f\u0080-\u00ff]+)\.\w+$/.test(
+    value
+  )
     ? null
     : Messages.FileValidationError;
 const folderValidator = (value: string): string | null =>
-  /^([a-zA-Z0-9\s_-]+)$/.test(value) ? null : Messages.FolderValidationError;
+  value.length <= 100 ? null : Messages.FolderValidationError;
 
 class ContentNavigator {
   private contentDataProvider: ContentDataProvider;

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -20,8 +20,8 @@ import { ContentItem } from "./types";
 import { getUri, isContainer as getIsContainer } from "./utils";
 
 const fileValidator = (value: string): string | null =>
-  /^([^,/<>?;:\\{}|`=+*&^%#@!~\uff01-\uff5e\u3000-\u303f\u0080-\u00ff]+)\.\w+$/.test(
-    // the file name does NOT allow some special characters like punctuations (especially full width), CJK and Latin-1 characters.
+  /^([^/<>;\\{}?#]+)\.\w+$/.test(
+    // file service does not allow /, <, >, ;, \, {, } while vscode does not allow ? and #
     value
   )
     ? null

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -21,6 +21,7 @@ import { getUri, isContainer as getIsContainer } from "./utils";
 
 const fileValidator = (value: string): string | null =>
   /^([^,/<>?;:\\{}|`=+*&^%#@!~\uff01-\uff5e\u3000-\u303f\u0080-\u00ff]+)\.\w+$/.test(
+    // the file name does NOT allow some special characters like punctuations (especially full width), CJK and Latin-1 characters.
     value
   )
     ? null


### PR DESCRIPTION
**Summary**
Fix #156 
I noticed that the folder service does not check the special characters so I changed the folder name validator to only check the max length. If the name is more than 100 characters, there would be a new error message.
And change the validator for the new file name to allow Chinese characters (as well as other languages)

**Testing**
Test case in #156 
