### PR TITLE
fix: Support SAS Library viewer with a direct connection.

### DIFF
--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -127,7 +127,6 @@ class LibraryModel {
       })
     );
 
-
     return this.processItems(libraryItems, "library", undefined);
   }
 

--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -127,13 +127,6 @@ class LibraryModel {
       })
     );
 
-    libraryItems.push({
-      uid: "WORK",
-      id: "WORK",
-      name: "WORK",
-      readOnly: false,
-      type: "library",
-    });
 
     return this.processItems(libraryItems, "library", undefined);
   }

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -57,6 +57,12 @@ export enum ConnectionType {
  * Profile is an interface that represents a users profile.  Currently
  * supports two different authentication flows, token and password
  * flow with the clientId and clientSecret.
+ *
+ * Direct connect is also supported where a server is already started with
+ * a static serverId. Setting serverId in the profile indicates that a connection
+ * to that specific server with Id will be created. This overrides the context
+ * value. Normally this option should not be set by the user since it is most likely
+ * being set by an automated process.
  */
 export interface ViyaProfile {
   connectionType: ConnectionType.Rest;
@@ -64,6 +70,7 @@ export interface ViyaProfile {
   clientId?: string;
   clientSecret?: string;
   context?: string;
+  serverId?: string;
 }
 
 export interface SSHProfile {

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -163,7 +163,7 @@ function triggerProfileUpdate(): void {
       "setContext",
       "SAS.connection.direct",
       connectionType === ConnectionType.Rest &&
-        !!profileList[activeProfileName]?.serverId
+        "serverId" in profileList[activeProfileName]
     );
   } else {
     profileConfig.updateActiveProfileSetting("");

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -157,14 +157,14 @@ function triggerProfileUpdate(): void {
 
     //Set the connection type
     commands.executeCommand("setContext", "SAS.connectionType", connectionType);
-    if (connectionType === ConnectionType.Rest) {
-      //Check to see if we are directly connected (Ie. we have a serverId)
-      if ("serverId" in profileList[activeProfileName]) {
-        commands.executeCommand("setContext", "SAS.connection.direct", true);
-      }
-    } else {
-      commands.executeCommand("setContext", "SAS.connection.direct", false);
-    }
+
+    //See if the connection is direct (ie. serverId)
+    commands.executeCommand(
+      "setContext",
+      "SAS.connection.direct",
+      connectionType === ConnectionType.Rest &&
+        !!profileList[activeProfileName]?.serverId
+    );
   } else {
     profileConfig.updateActiveProfileSetting("");
   }

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -151,11 +151,20 @@ function triggerProfileUpdate(): void {
   const activeProfileName = profileConfig.getActiveProfile();
   if (activeProfileName in profileList || activeProfileName === "") {
     updateStatusBarProfile(activeProfileStatusBarIcon);
-    commands.executeCommand(
-      "setContext",
-      "SAS.connectionType",
-      profileList[activeProfileName].connectionType || ConnectionType.Rest
-    );
+
+    const connectionType =
+      profileList[activeProfileName].connectionType || ConnectionType.Rest;
+
+    //Set the connection type
+    commands.executeCommand("setContext", "SAS.connectionType", connectionType);
+    if (connectionType === ConnectionType.Rest) {
+      //Check to see if we are directly connected (Ie. we have a serverId)
+      if ("serverId" in profileList[activeProfileName]) {
+        commands.executeCommand("setContext", "SAS.connection.direct", true);
+      }
+    } else {
+      commands.executeCommand("setContext", "SAS.connection.direct", false);
+    }
   } else {
     profileConfig.updateActiveProfileSetting("");
   }

--- a/package.json
+++ b/package.json
@@ -525,12 +525,12 @@
         {
           "id": "sas-library-navigator",
           "name": "Libraries",
-          "when": "SAS.authorized && SAS.connectionType == rest"
+          "when": "(SAS.authorized && SAS.connectionType == rest) || SAS.connection.direct"
         },
         {
           "id": "sas-content-get-started",
           "name": "Sign In",
-          "when": "!SAS.authorized && SAS.connectionType == rest"
+          "when": "(!SAS.authorized && SAS.connectionType == rest) && !SAS.connection.direct"
         },
         {
           "id": "sas-content-invalid-connection",
@@ -542,7 +542,7 @@
     "viewsWelcome": [
       {
         "view": "sas-content-get-started",
-        "when": "!SAS.authorized && SAS.connectionType == rest",
+        "when": "(!SAS.authorized && SAS.connectionType == rest) && !SAS.connection.direct",
         "contents": "%views.SAS.welcome%",
         "enablement": "!SAS.authorizing"
       },


### PR DESCRIPTION
**Summary**
This is a change set made to be an addition onto adding Library support https://github.com/sassoftware/vscode-sas-extension/pull/143

If a direct connection is being made (IE, using the compute REST API but not going through Viya services, authentication is not done viya SASLogon, so the authentication requirement is not valid.

This change allows the Libraries view when a direct connection is established but also disables the content browser, since the Files and Folders service is not available.

**Testing**
I made sure that libraries show up with a direct connection.
