### PR TITLE
feat: Reconnect to existing SAS Session if possible.

### DIFF
--- a/client/src/components/ExtensionContext.ts
+++ b/client/src/components/ExtensionContext.ts
@@ -19,6 +19,8 @@ export async function setContextValue(
 /*
  * Get an extension context value.
  */
-export async function getContextValue(key: string): Promise<string> {
+export async function getContextValue(
+  key: string
+): Promise<string | undefined> {
   return context.workspaceState.get(key);
 }

--- a/client/src/components/ExtensionContext.ts
+++ b/client/src/components/ExtensionContext.ts
@@ -1,0 +1,24 @@
+import { ExtensionContext } from "vscode";
+
+let context: ExtensionContext;
+
+export function setContext(c: ExtensionContext) {
+  context = c;
+}
+
+/*
+ * Set an extension context value.
+ */
+export async function setContextValue(
+  key: string,
+  value: string
+): Promise<void> {
+  context.workspaceState.update(key, value);
+}
+
+/*
+ * Get an extension context value.
+ */
+export async function getContextValue(key: string): Promise<string> {
+  return context.workspaceState.get(key);
+}

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -1,9 +1,13 @@
 // Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 // Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
 
-import { authentication, commands } from "vscode";
+import { authentication } from "vscode";
 import { RunResult, Session } from "..";
 import { SASAuthProvider } from "../../components/AuthProvider";
+import {
+  getContextValue,
+  setContextValue,
+} from "../../components/ExtensionContext";
 import { ContextsApi, LogLine } from "./api/compute";
 import { ComputeState, getApiConfig } from "./common";
 import { ComputeJob } from "./job";
@@ -57,10 +61,7 @@ async function setup(): Promise<void> {
     const server1 = new ComputeServer(config.serverId);
 
     //if we have a session already, get it
-    let sessionId: string = await commands.executeCommand<string>(
-      "SAS.contextValue.get",
-      "SAS.sessionId"
-    );
+    let sessionId: string = await getContextValue("SAS.sessionId");
     if (!config.reconnect) {
       sessionId = undefined;
     }
@@ -72,11 +73,7 @@ async function setup(): Promise<void> {
         console.log(
           `Attempt to reconnect to session ${sessionId} failed. Starting a new session`
         );
-        commands.executeCommand(
-          "SAS.contextValue.set",
-          "SAS.sessionId",
-          undefined
-        );
+        setContextValue("SAS.sessionId", undefined);
       }
     }
     computeSession = await server1.getSession();
@@ -105,11 +102,7 @@ async function setup(): Promise<void> {
   }
 
   //Save the current sessionId
-  commands.executeCommand(
-    "SAS.contextValue.set",
-    "SAS.sessionId",
-    computeSession.sessionId
-  );
+  setContextValue("SAS.sessionId", computeSession.sessionId);
 }
 
 /*

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -26,6 +26,56 @@ export interface Config {
 let config: Config;
 let computeSession: ComputeSession | undefined;
 
+async function reconnectComputeSession(): Promise<ComputeSession> {
+  let session: ComputeSession = undefined;
+
+  if (!config.reconnect) {
+    return undefined;
+  }
+
+  //Grab the sessionId
+  const sessionId: string = await getContextValue("SAS.sessionId");
+
+  if (sessionId === undefined) {
+    //No sessionId in the cache means nothing to reconnect to
+    return undefined;
+  }
+
+  //At this point a sessionId was retrieved, so try and re-connect
+
+  if (config.serverId) {
+    const computeServer = new ComputeServer(config.serverId);
+
+    try {
+      session = await computeServer.getSession(sessionId);
+    } catch (error) {
+      console.log(
+        `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
+      );
+    }
+  } else {
+    const apiConfig = getApiConfig();
+    const sessions = SessionsApi(apiConfig);
+
+    try {
+      const mySession = (await sessions.getSession({ sessionId: sessionId }))
+        .data;
+      session = ComputeSession.fromInterface(mySession);
+    } catch (error) {
+      console.log(
+        `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
+      );
+    }
+  }
+
+  if (session === undefined) {
+    //If we tried to reconnect and failed, set the cached sessionId to undefined
+    setContextValue("SAS.sessionId", undefined);
+  }
+
+  return session;
+}
+
 async function setup(): Promise<void> {
   const apiConfig = getApiConfig();
   if (!config.serverId) {
@@ -57,25 +107,16 @@ async function setup(): Promise<void> {
   const locale = JSON.parse(process.env.VSCODE_NLS_CONFIG ?? "{}").locale;
   apiConfig.baseOptions.headers = { "Accept-Language": locale };
 
+  //Check to see if we can reconnect to a session first
+  computeSession = await reconnectComputeSession();
+  if (computeSession) {
+    //reconnected to a running session, so just return
+    return;
+  }
+
+  //Start a new session
   if (config.serverId) {
     const server1 = new ComputeServer(config.serverId);
-
-    //if we have a session already, get it
-    let sessionId: string = await getContextValue("SAS.sessionId");
-    if (!config.reconnect) {
-      sessionId = undefined;
-    }
-    if (sessionId !== undefined) {
-      try {
-        computeSession = await server1.getSession(sessionId);
-        return;
-      } catch (error) {
-        console.log(
-          `Attempt to reconnect to session ${sessionId} failed. Starting a new session`
-        );
-        setContextValue("SAS.sessionId", undefined);
-      }
-    }
     computeSession = await server1.getSession();
 
     //Maybe wait for session to be initialized?
@@ -174,6 +215,9 @@ async function close() {
   if (sessionId()) {
     computeSession.delete();
     computeSession = undefined;
+
+    //Since the session is being closed, remove the cached session id
+    setContextValue("SAS.sessionId", undefined);
   }
 }
 

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -8,7 +8,7 @@ import {
   getContextValue,
   setContextValue,
 } from "../../components/ExtensionContext";
-import { ContextsApi, LogLine } from "./api/compute";
+import { ContextsApi, LogLine, SessionsApi } from "./api/compute";
 import { ComputeState, getApiConfig } from "./common";
 import { ComputeJob } from "./job";
 import { ComputeServer } from "./server";

--- a/client/src/connection/rest/job.ts
+++ b/client/src/connection/rest/job.ts
@@ -69,10 +69,14 @@ export class ComputeJob extends Compute {
       ifNoneMatch: options?.onChange ? this.etag : undefined,
     };
 
-    const resp = await this.api.getJobState(parms);
+    const resp = await this.api.getJobState(parms, {
+      validateStatus: (status) => {
+        return status >= 200 && status < 400;
+      },
+    });
     if (resp.status === 200) {
       //Set the new etag
-      this.etag = resp.etag;
+      this.etag = resp.headers.etag;
 
       //return the state
       return resp.data;

--- a/client/src/connection/rest/server.ts
+++ b/client/src/connection/rest/server.ts
@@ -95,7 +95,9 @@ export class ComputeServer extends Compute {
 
   async getSession(sessionId?: string): Promise<ComputeSession> {
     if (sessionId !== undefined) {
-      return new ComputeSession(sessionId);
+      const sess = new ComputeSession(sessionId);
+      await sess.self();
+      return sess;
     } else {
       return this.createSession();
     }

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -189,6 +189,5 @@ export function deactivate(): Thenable<void> | undefined {
   if (!client) {
     return undefined;
   }
-  closeSession();
   return client.stop();
 }

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -190,3 +190,19 @@ export function deactivate(): Thenable<void> | undefined {
   closeSession();
   return client.stop();
 }
+
+/*
+Set an extension context value.
+This function has the SAS extension context as "this"
+*/
+async function setContextValue(key: string, value: string): Promise<void> {
+  this.workspaceState.update(key, value);
+}
+
+/*
+Set an extension context value.
+This function has the SAS extension context as "this"
+*/
+async function getContextValue(key: string): Promise<string> {
+  return this.workspaceState.get(key);
+}

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -31,6 +31,7 @@ import {
 import { run, runSelected } from "../commands/run";
 import { SASAuthProvider } from "../components/AuthProvider";
 import ContentNavigator from "../components/ContentNavigator";
+import { setContext } from "../components/ExtensionContext";
 import LibraryNavigator from "../components/LibraryNavigator";
 import { legend, LogTokensProvider } from "../components/LogViewer";
 import { ConnectionType } from "../components/profile";
@@ -81,6 +82,7 @@ export function activate(context: ExtensionContext): void {
   // Start the client. This will also launch the server
   client.start();
 
+  setContext(context);
   const libraryNavigator = new LibraryNavigator(context);
   const contentNavigator = new ContentNavigator(context);
 
@@ -189,20 +191,4 @@ export function deactivate(): Thenable<void> | undefined {
   }
   closeSession();
   return client.stop();
-}
-
-/*
-Set an extension context value.
-This function has the SAS extension context as "this"
-*/
-async function setContextValue(key: string, value: string): Promise<void> {
-  this.workspaceState.update(key, value);
-}
-
-/*
-Set an extension context value.
-This function has the SAS extension context as "this"
-*/
-async function getContextValue(key: string): Promise<string> {
-  return this.workspaceState.get(key);
 }

--- a/package.json
+++ b/package.json
@@ -459,10 +459,6 @@
           "command": "SAS.runSelected"
         },
         {
-          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
-          "command": "SAS.runSelected"
-        },
-        {
           "when": "false",
           "command": "SAS.restoreResource"
         },

--- a/package.json
+++ b/package.json
@@ -340,12 +340,17 @@
         "title": "%commands.SAS.collapseAll%",
         "category": "SAS",
         "icon": "$(collapse-all)"
+      },
+      {
         "command": "SAS.collapseAllLibraries",
-        "command": "SAS.contextValue.set",
-        "category": "SAS"
+        "title": "%commands.SAS.collapseAll%",
+        "category": "SAS",
         "icon": "$(collapse-all)"
-        "command": "SAS.contextValue.get",
-        "title": "Get Context Value",
+      },
+      {
+        "command": "SAS.deleteTable",
+        "title": "%commands.SAS.deleteTable%",
+        "category": "SAS"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -459,6 +459,10 @@
           "command": "SAS.runSelected"
         },
         {
+          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+          "command": "SAS.runSelected"
+        },
+        {
           "when": "false",
           "command": "SAS.restoreResource"
         },

--- a/package.json
+++ b/package.json
@@ -340,17 +340,12 @@
         "title": "%commands.SAS.collapseAll%",
         "category": "SAS",
         "icon": "$(collapse-all)"
-      },
-      {
         "command": "SAS.collapseAllLibraries",
-        "title": "%commands.SAS.collapseAll%",
-        "category": "SAS",
-        "icon": "$(collapse-all)"
-      },
-      {
-        "command": "SAS.deleteTable",
-        "title": "%commands.SAS.deleteTable%",
+        "command": "SAS.contextValue.set",
         "category": "SAS"
+        "icon": "$(collapse-all)"
+        "command": "SAS.contextValue.get",
+        "title": "Get Context Value",
       }
     ],
     "keybindings": [


### PR DESCRIPTION
A sas session connection is made as needed by the extension. This session is maintained throughout the vscode session. Many things can cause the extension to reload (browser refresh, vscode reload, etc) and this causes a new connection to be established, which creates a brand new SAS session.

If an existing session is available, we should reconnect to it.

This is gated behind a REST profile option "reconnect"

**Summary**
Added a way to store key value pairs that persist through extension reloads. This uses the extension context.

If a sessionId is found, that session will be attempted to be reconnected to. If this succeeds, all future interaction will be
done on that session instead of creating a new on.

This also fixes a bug in JobState which causes unwanted server spam.

**Testing**
I made sure that Sessions will be reconnected to and that new sessions will be created if needed.
