### PR TITLE
setContext without command

### DIFF
--- a/client/src/components/ExtensionContext.ts
+++ b/client/src/components/ExtensionContext.ts
@@ -1,0 +1,24 @@
+import { ExtensionContext } from "vscode";
+
+let context: ExtensionContext;
+
+export function setContext(c: ExtensionContext) {
+  context = c;
+}
+
+/*
+ * Set an extension context value.
+ */
+export async function setContextValue(
+  key: string,
+  value: string
+): Promise<void> {
+  context.workspaceState.update(key, value);
+}
+
+/*
+ * Get an extension context value.
+ */
+export async function getContextValue(key: string): Promise<string> {
+  return context.workspaceState.get(key);
+}

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -1,9 +1,13 @@
 // Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 // Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
 
-import { authentication, commands } from "vscode";
+import { authentication } from "vscode";
 import { RunResult, Session } from "..";
 import { SASAuthProvider } from "../../components/AuthProvider";
+import {
+  getContextValue,
+  setContextValue,
+} from "../../components/ExtensionContext";
 import { ContextsApi, LogLine } from "./api/compute";
 import { ComputeState, getApiConfig } from "./common";
 import { ComputeJob } from "./job";
@@ -57,10 +61,7 @@ async function setup() {
     const server1 = new ComputeServer(config.serverId);
 
     //if we have a session already, get it
-    let sessionId: string = await commands.executeCommand<string>(
-      "SAS.contextValue.get",
-      "SAS.sessionId"
-    );
+    let sessionId: string = await getContextValue("SAS.sessionId");
     if (!config.reconnect) {
       sessionId = undefined;
     }
@@ -72,11 +73,7 @@ async function setup() {
         console.log(
           `Attempt to reconnect to session ${sessionId} failed. Starting a new session`
         );
-        commands.executeCommand(
-          "SAS.contextValue.set",
-          "SAS.sessionId",
-          undefined
-        );
+        setContextValue("SAS.sessionId", undefined);
       }
     }
     computeSession = await server1.getSession();
@@ -105,11 +102,7 @@ async function setup() {
   }
 
   //Save the current sessionId
-  commands.executeCommand(
-    "SAS.contextValue.set",
-    "SAS.sessionId",
-    computeSession.sessionId
-  );
+  setContextValue("SAS.sessionId", computeSession.sessionId);
 }
 
 /*

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -31,6 +31,7 @@ import {
 import { run, runSelected } from "../commands/run";
 import { SASAuthProvider } from "../components/AuthProvider";
 import ContentNavigator from "../components/ContentNavigator";
+import { setContext } from "../components/ExtensionContext";
 import { legend, LogTokensProvider } from "../components/LogViewer";
 import { ConnectionType } from "../components/profile";
 
@@ -80,6 +81,8 @@ export function activate(context: ExtensionContext): void {
   // Start the client. This will also launch the server
   client.start();
 
+  setContext(context);
+
   context.subscriptions.push(
     commands.registerCommand("SAS.run", run),
     commands.registerCommand("SAS.runSelected", runSelected),
@@ -102,11 +105,6 @@ export function activate(context: ExtensionContext): void {
       legend
     ),
     activeProfileStatusBarIcon
-  );
-
-  context.subscriptions.push(
-    commands.registerCommand("SAS.contextValue.set", setContextValue, context),
-    commands.registerCommand("SAS.contextValue.get", getContextValue, context)
   );
 
   new ContentNavigator(context);
@@ -196,20 +194,4 @@ export function deactivate(): Thenable<void> | undefined {
   }
   closeSession();
   return client.stop();
-}
-
-/*
-Set an extension context value.
-This function has the SAS extension context as "this"
-*/
-async function setContextValue(key: string, value: string): Promise<void> {
-  this.workspaceState.update(key, value);
-}
-
-/*
-Set an extension context value.
-This function has the SAS extension context as "this"
-*/
-async function getContextValue(key: string): Promise<string> {
-  return this.workspaceState.get(key);
 }

--- a/package.json
+++ b/package.json
@@ -330,16 +330,6 @@
         "title": "%commands.SAS.collapseAll%",
         "category": "SAS",
         "icon": "$(collapse-all)"
-      },
-      {
-        "command": "SAS.contextValue.set",
-        "title": "Set Context Value",
-        "category": "SAS"
-      },
-      {
-        "command": "SAS.contextValue.get",
-        "title": "Get Context Value",
-        "category": "SAS"
       }
     ],
     "menus": {


### PR DESCRIPTION
Commands are usually for end users or cross-extensions communication. Seems not necessary for internal calls.
This PR is just illustrating the idea to wrap the extension context. What should be exposed can be discussed.
For example instead of exposing a general `set/getContextValue`. We can expose just `set/getSessionId` and maintain the context key (SAS.sessionId) internally. So each invocation won't need to find the context key.
