### PR TITLE
fix: remove foreach when iterating with promise

### DIFF
--- a/client/src/connection/index.ts
+++ b/client/src/connection/index.ts
@@ -38,5 +38,5 @@ export function getSession(): Session {
     return getSSHSession(validProfile.profile);
   }
 
-  throw new Error("Invalid endpoint");
+  throw new Error("Invalid connectionType. Check Profile settings.");
 }

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -118,24 +118,8 @@ export function activate(context: ExtensionContext): void {
     }
   });
 
-  migrateRestProfiles();
+  profileConfig.migrateLegacyProfiles();
   triggerProfileUpdate();
-}
-
-/**
- * Helper function to ensure that profiles have a supported connectionType.
- * Profiles without a connectionType defined will be treated as Rest/Viya profiles.
- */
-function migrateRestProfiles() {
-  const profiles = profileConfig.getAllProfiles();
-
-  Object.keys(profiles).forEach((k) => {
-    const profile = profiles[k];
-    if (profile.connectionType === undefined) {
-      profile.connectionType = ConnectionType.Rest;
-      profileConfig.upsertProfile(k, profile);
-    }
-  });
 }
 
 function triggerProfileUpdate(): void {
@@ -146,7 +130,7 @@ function triggerProfileUpdate(): void {
     commands.executeCommand(
       "setContext",
       "SAS.connectionType",
-      profileList[activeProfileName].connectionType || ConnectionType.Rest
+      profileList[activeProfileName]?.connectionType || ConnectionType.Rest
     );
   } else {
     profileConfig.updateActiveProfileSetting("");

--- a/client/test/components/profile/profile.test.ts
+++ b/client/test/components/profile/profile.test.ts
@@ -189,6 +189,7 @@ describe("Profiles", async function () {
       );
     });
   });
+
   describe("No Profile", async function () {
     beforeEach(async () => {
       testProfileNewName = "testProfile";

--- a/client/test/components/profile/profile.test.ts
+++ b/client/test/components/profile/profile.test.ts
@@ -241,6 +241,7 @@ describe("Profiles", async function () {
           ConfigurationTarget.Global
         );
     });
+
     describe("CRUD Operations", async function () {
       it("add a new profile", async function () {
         // Arrange
@@ -526,6 +527,7 @@ describe("Profiles", async function () {
       });
     });
   });
+
   describe("Overloaded Profile", async function () {
     beforeEach(async () => {
       testProfileName = "testProfile";
@@ -595,6 +597,7 @@ describe("Profiles", async function () {
       });
     });
   });
+
   describe("SSH Profile", async function () {
     beforeEach(async () => {
       testProfileName = "testProfile";

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -12,30 +12,32 @@ describe("lsp", () => {
 
   it("provides completion items", async () => {
     // Executing the command `vscode.executeCompletionItemProvider` to simulate triggering completion
-    const actualCompletionList = (await vscode.commands.executeCommand(
-      "vscode.executeCompletionItemProvider",
-      docUri,
-      new vscode.Position(0, 0)
-    )) as vscode.CompletionList;
+    const actualCompletionList: vscode.CompletionList =
+      await vscode.commands.executeCommand(
+        "vscode.executeCompletionItemProvider",
+        docUri,
+        new vscode.Position(0, 0)
+      );
     assert.ok(actualCompletionList.items.length > 0);
   });
 
   it("provides hover", async () => {
     // Executing the command `vscode.executeHoverProvider` to simulate mouse hovering
-    const [actualHover] = (await vscode.commands.executeCommand(
+    const [actualHover]: vscode.Hover[] = await vscode.commands.executeCommand(
       "vscode.executeHoverProvider",
       docUri,
       new vscode.Position(0, 0)
-    )) as vscode.Hover[];
+    );
     assert.ok(actualHover.contents[0]);
   });
 
   it("provides document symbol", async () => {
     // Executing the command `vscode.executeDocumentSymbolProvider` to simulate outline
-    const actualDocumentSymbol = (await vscode.commands.executeCommand(
-      "vscode.executeDocumentSymbolProvider",
-      docUri
-    )) as vscode.DocumentSymbol[];
+    const actualDocumentSymbol: vscode.DocumentSymbol[] =
+      await vscode.commands.executeCommand(
+        "vscode.executeDocumentSymbolProvider",
+        docUri
+      );
     assert.ok(actualDocumentSymbol.length > 0);
   });
 });


### PR DESCRIPTION
**Summary**
- Removes code that was errantly not migrating all legacy profiles over. This was due to use of foreach inside of a promise, which will not run to completion.
- Additionally add a validator to profile validator to detect a missing connectionType property when `getSession()` is called during execution.


**Testing**
- [x] add unit test for calling function directly against a given set of legacy profiles
- [x] add unit test for  positive case where a legacy profile is missing connectionType property.
- [x] manual verification: launched the extension with multiple profiles that did not have a connectionType key. The expected result is that on extension activation, these profiles are migrated as expected to be rest profile.
