### PR TITLE
validate the new name before rename

### DIFF
--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -246,6 +246,19 @@ export class ContentModel {
       }
     }
 
+    const validationUri = getLink(item.links, "PUT", "validateRename").uri;
+    if (validationUri) {
+      try {
+        await this.connection.put(
+          validationUri
+            .replace("{newname}", encodeURI(name))
+            .replace("{newtype}", getTypeName(item))
+        );
+      } catch (error) {
+        return;
+      }
+    }
+
     try {
       const patchResponse = await this.connection.patch(
         uri,

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -246,7 +246,7 @@ export class ContentModel {
       }
     }
 
-    const validationUri = getLink(item.links, "PUT", "validateRename").uri;
+    const validationUri = getLink(item.links, "PUT", "validateRename")?.uri;
     if (validationUri) {
       try {
         await this.connection.put(


### PR DESCRIPTION
**Summary**
fix the issue #191 
validate the new name with folder service before requesting the rename action

**Testing**
As described in #191 
Add unit tests