### PR TITLE
feat: ssh agent auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Authentication status now persisted in VS Code ([#94](https://github.com/sassoftware/vscode-sas-extension/issues/94))
 - Added SAS content navigator. You are now able to browse, edit, create, delete, and run files on a SAS server using a Viya connection ([#56](https://github.com/sassoftware/vscode-sas-extension/issues/56)).
+- Added support for running SAS code on a remote 9.4 linux server using ssh and -nodms ([#61](https://github.com/sassoftware/vscode-sas-extension/issues/61)).
 
 ## [v0.1.2] - 2023-02-01
 

--- a/README.md
+++ b/README.md
@@ -154,14 +154,13 @@ The following commands are supported for profiles:
 
 #### Profile Anatomy (SAS 9.4 Remote)
 
-| Name                 | Description                          | Additional Notes                                                                                                           |
-| -------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| **Name**             | Name of the profile                  | This will display on the status bar                                                                                        |
-| **Host**             | SSH Server Host                      | This will appear when hovering over the status bar                                                                         |
-| **Username**         | SSH Server Username                  | A username to use when establishing the SSH connection to the server                                                       |
-| **Port**             | SSH Server Port                      | The ssh port of the SSH server. Default value is 22                                                                        |
-| **SAS Path**         | Path to SAS Executable on the server | Must be a fully qualified path on the SSH server to a SAS executable                                                       |
-| **SSH Agent Socket** | Local Path to SSH agent socket       | Requires a SSH public/private key pair. The public key must be copied to the SSH Server Host and registered with ssh-agent |
+| Name         | Description                          | Additional Notes                                                     |
+| ------------ | ------------------------------------ | -------------------------------------------------------------------- |
+| **Name**     | Name of the profile                  | This will display on the status bar                                  |
+| **Host**     | SSH Server Host                      | This will appear when hovering over the status bar                   |
+| **Username** | SSH Server Username                  | A username to use when establishing the SSH connection to the server |
+| **Port**     | SSH Server Port                      | The ssh port of the SSH server. Default value is 22                  |
+| **SAS Path** | Path to SAS Executable on the server | Must be a fully qualified path on the SSH server to a SAS executable |
 
 #### Add New SAS Profile
 
@@ -217,7 +216,7 @@ To run a SAS program:
 
    1.5. Paste the authorization code in VS Code where indicated at the top of the screen.
 
-3. For a secure connection to SAS 9.4 remote we use the supplied ssh-agent socket to authenticate to the remote server via SSH.
+3. For a secure connection to SAS 9.4 remote, a public / private ssh key pair is required. The socket defined in the environment variable `SSH_AUTH_SOCK` is used to communicate with ssh-agent to authenticate the ssh session. The private key must be registered with ssh-agent.
 4. VS Code connects to SAS and runs the code.
 5. The results are displayed in the application.
 6. The SAS output log and error information are displayed in the applicaiton.

--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ The following commands are supported for profiles:
 
 #### Profile Anatomy (SAS 9.4 Remote)
 
-| Name                 | Description                          | Additional Notes                                                                             |
-| -------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------- |
-| **Name**             | Name of the profile                  | This will display on the status bar                                                          |
-| **Host**             | SSH Server Host                      | This will appear when hovering over the status bar                                           |
-| **Username**         | SSH Server Username                  | A username to use when establishing the SSH connection to the server                         |
-| **Port**             | SSH Server Port                      | The ssh port of the SSH server. Default value is 22                                          |
-| **SAS Path**         | Path to SAS Executable on the server | Must be a fully qualified path on the SSH server to a SAS executable                         |
-| **Private Key Path** | Local Path to SSH private key file   | Requires a SSH public/private key pair. The public key must be copied to the SSH Server Host |
+| Name                 | Description                          | Additional Notes                                                                                                           |
+| -------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| **Name**             | Name of the profile                  | This will display on the status bar                                                                                        |
+| **Host**             | SSH Server Host                      | This will appear when hovering over the status bar                                                                         |
+| **Username**         | SSH Server Username                  | A username to use when establishing the SSH connection to the server                                                       |
+| **Port**             | SSH Server Port                      | The ssh port of the SSH server. Default value is 22                                                                        |
+| **SAS Path**         | Path to SAS Executable on the server | Must be a fully qualified path on the SSH server to a SAS executable                                                       |
+| **SSH Agent Socket** | Local Path to SSH agent socket       | Requires a SSH public/private key pair. The public key must be copied to the SSH Server Host and registered with ssh-agent |
 
 #### Add New SAS Profile
 
@@ -217,7 +217,7 @@ To run a SAS program:
 
    1.5. Paste the authorization code in VS Code where indicated at the top of the screen.
 
-3. For a secure connection to SAS 9.4 remote we use the supplied private key to authenticate to the remote server via SSH.
+3. For a secure connection to SAS 9.4 remote we use the supplied ssh-agent socket to authenticate to the remote server via SSH.
 4. VS Code connects to SAS and runs the code.
 5. The results are displayed in the application.
 6. The SAS output log and error information are displayed in the applicaiton.

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -72,7 +72,6 @@ export interface SSHProfile {
   saspath: string;
   port: number;
   username: string;
-  agentSocket: string;
   sasOptions: string[];
 }
 
@@ -355,10 +354,6 @@ export class ProfileConfig {
         return pv;
       }
 
-      if (!profile.agentSocket) {
-        pv.error = "Missing agent socket in active profile.";
-        return pv;
-      }
       if (!profile.saspath) {
         pv.error = "Missing sas path in active profile.";
         return pv;
@@ -454,10 +449,6 @@ export class ProfileConfig {
         await createInputTextBox(ProfilePromptType.Port, DEFAULT_SSH_PORT)
       );
 
-      profileClone.agentSocket = await createInputTextBox(
-        ProfilePromptType.AgentSocket,
-        process.env.SSH_AUTH_SOCK || ""
-      );
       await this.upsertProfile(name, profileClone);
     }
   }
@@ -503,7 +494,6 @@ export enum ProfilePromptType {
   SASPath,
   Port,
   Username,
-  AgentSocket,
 }
 
 /**
@@ -634,11 +624,6 @@ const input: ProfilePromptInput = {
     title: "SAS Server Username",
     placeholder: "Enter your username",
     description: "Enter your SAS server username.",
-  },
-  [ProfilePromptType.AgentSocket]: {
-    title: "Agent Socket",
-    placeholder: "Enter the agent socket path",
-    description: "Enter the local path of the ssh agent socket.",
   },
 };
 

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -72,7 +72,7 @@ export interface SSHProfile {
   saspath: string;
   port: number;
   username: string;
-  privateKeyPath: string;
+  agentSocket: string;
   sasOptions: string[];
 }
 
@@ -355,8 +355,8 @@ export class ProfileConfig {
         return pv;
       }
 
-      if (!profile.privateKeyPath) {
-        pv.error = "Missing private key file in active profile.";
+      if (!profile.agentSocket) {
+        pv.error = "Missing agent socket in active profile.";
         return pv;
       }
       if (!profile.saspath) {
@@ -454,9 +454,9 @@ export class ProfileConfig {
         await createInputTextBox(ProfilePromptType.Port, DEFAULT_SSH_PORT)
       );
 
-      profileClone.privateKeyPath = await createInputTextBox(
-        ProfilePromptType.PrivateKeyPath,
-        profileClone.privateKeyPath
+      profileClone.agentSocket = await createInputTextBox(
+        ProfilePromptType.AgentSocket,
+        process.env.SSH_AUTH_SOCK || ""
       );
       await this.upsertProfile(name, profileClone);
     }
@@ -503,7 +503,7 @@ export enum ProfilePromptType {
   SASPath,
   Port,
   Username,
-  PrivateKeyPath,
+  AgentSocket,
 }
 
 /**
@@ -635,10 +635,10 @@ const input: ProfilePromptInput = {
     placeholder: "Enter your username",
     description: "Enter your SAS server username.",
   },
-  [ProfilePromptType.PrivateKeyPath]: {
-    title: "Private Key File",
-    placeholder: "Enter the local path",
-    description: "Enter the local path to a private key file.",
+  [ProfilePromptType.AgentSocket]: {
+    title: "Agent Socket",
+    placeholder: "Enter the agent socket path",
+    description: "Enter the local path of the ssh agent socket.",
   },
 };
 

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -24,14 +24,14 @@ export function getSession(c: Config): Session {
   if (!sessionInstance) {
     sessionInstance = new SSHSession();
   }
-  sessionInstance.config = c;
+  sessionInstance.setConfig(c);
   return sessionInstance;
 }
 
 export class SSHSession implements Session {
   private conn: Client;
   private stream: ClientChannel | undefined;
-  public config: Config;
+  private config: Config;
   private resolve: ((value?) => void) | undefined;
   private reject: ((reason?) => void) | undefined;
   private onLog: ((logs: LogLine[]) => void) | undefined;
@@ -43,6 +43,10 @@ export class SSHSession implements Session {
     this.config = c;
     this.conn = new Client();
   }
+
+  public setConfig = (config: Config) => {
+    this.config = config;
+  };
 
   public setup = (): Promise<void> => {
     return new Promise((pResolve, pReject) => {
@@ -60,6 +64,9 @@ export class SSHSession implements Session {
         username: this.config.username,
         readyTimeout: sasLaunchTimeout,
         agent: process.env.SSH_AUTH_SOCK || undefined,
+        debug: (message: string) => {
+          console.log(message);
+        },
       };
 
       this.conn

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -3,7 +3,6 @@
 
 import { Client, ClientChannel, ConnectConfig } from "ssh2";
 import { RunResult, Session, LogLine } from "..";
-import { readFileSync } from "fs";
 
 const endCode = "--vscode-sas-extension-submit-end--";
 const sasLaunchTimeout = 10000;
@@ -15,7 +14,7 @@ export interface Config {
   saspath: string;
   sasOptions: string[];
   port: number;
-  privateKeyPath: string;
+  agentSocket: string;
 }
 
 export function getSession(c: Config): Session {
@@ -55,8 +54,8 @@ export class SSHSession implements Session {
         host: this.config.host,
         port: this.config.port,
         username: this.config.username,
-        privateKey: readFileSync(this.config.privateKeyPath),
         readyTimeout: sasLaunchTimeout,
+        agent: this.config.agentSocket,
       };
 
       this.conn

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -64,9 +64,6 @@ export class SSHSession implements Session {
         username: this.config.username,
         readyTimeout: sasLaunchTimeout,
         agent: process.env.SSH_AUTH_SOCK || undefined,
-        debug: (message: string) => {
-          console.log(message);
-        },
       };
 
       this.conn

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -24,14 +24,14 @@ export function getSession(c: Config): Session {
   if (!sessionInstance) {
     sessionInstance = new SSHSession();
   }
-  sessionInstance.setConfig(c);
+  sessionInstance.config = c;
   return sessionInstance;
 }
 
 export class SSHSession implements Session {
   private conn: Client;
   private stream: ClientChannel | undefined;
-  private config: Config;
+  private _config: Config;
   private resolve: ((value?) => void) | undefined;
   private reject: ((reason?) => void) | undefined;
   private onLog: ((logs: LogLine[]) => void) | undefined;
@@ -40,13 +40,13 @@ export class SSHSession implements Session {
   private timer: NodeJS.Timeout;
 
   constructor(c?: Config) {
-    this.config = c;
+    this._config = c;
     this.conn = new Client();
   }
 
-  public setConfig = (config: Config) => {
-    this.config = config;
-  };
+  set config(newValue: Config) {
+    this._config = newValue;
+  }
 
   public setup = (): Promise<void> => {
     return new Promise((pResolve, pReject) => {
@@ -59,9 +59,9 @@ export class SSHSession implements Session {
       }
 
       const cfg: ConnectConfig = {
-        host: this.config.host,
-        port: this.config.port,
-        username: this.config.username,
+        host: this._config.host,
+        port: this._config.port,
+        username: this._config.username,
         readyTimeout: sasLaunchTimeout,
         agent: process.env.SSH_AUTH_SOCK || undefined,
       };
@@ -218,11 +218,11 @@ export class SSHSession implements Session {
 
     const resolvedSasOpts: string[] = ["-nodms", "-terminal", "-nosyntaxcheck"];
 
-    if (this.config.sasOptions) {
-      resolvedSasOpts.push(...this.config.sasOptions);
+    if (this._config.sasOptions) {
+      resolvedSasOpts.push(...this._config.sasOptions);
     }
     const execSasOpts: string = resolvedSasOpts.join(" ");
 
-    this.stream.write(`${execArgs} ${this.config.saspath} ${execSasOpts} \n`);
+    this.stream.write(`${execArgs} ${this._config.saspath} ${execSasOpts} \n`);
   };
 }

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -17,6 +17,10 @@ export interface Config {
 }
 
 export function getSession(c: Config): Session {
+  if (!process.env.SSH_AUTH_SOCK) {
+    throw new Error("SSH_AUTH_SOCK not set. Check Environment Variables.");
+  }
+
   if (!sessionInstance) {
     sessionInstance = new SSHSession();
   }
@@ -48,12 +52,6 @@ export class SSHSession implements Session {
       if (this.stream) {
         this.resolve?.({});
         return;
-      }
-
-      if (!process.env.SSH_AUTH_SOCK) {
-        this.reject?.(
-          new Error("SSH_AUTH_SOCK not set. Check Environment Variables.")
-        );
       }
 
       const cfg: ConnectConfig = {

--- a/client/test/components/profile/profile.test.ts
+++ b/client/test/components/profile/profile.test.ts
@@ -87,7 +87,8 @@ describe("Profiles", async function () {
           port: 22,
           sasPath: "sasPath",
           sasOptions: ["-nonews"],
-          privateKeyFile: "privateKeyFile",
+          agentSocket: "/agent/socket",
+          connectionType: "ssh",
         },
       },
     };
@@ -618,7 +619,7 @@ describe("Profiles", async function () {
           connectionType: ConnectionType.SSH,
           host: "ssh.host",
           port: 22,
-          privateKeyPath: "/private/key/path",
+          agentSocket: "/private/key/path",
           sasOptions: ["-nonews"],
           saspath: "/sas/path",
           username: "username",
@@ -865,11 +866,11 @@ describe("Profiles", async function () {
         wantPlaceHolder: "Enter your username",
       },
       {
-        name: "Private Key File",
-        prompt: ProfilePromptType.PrivateKeyPath,
-        wantTitle: "Private Key File",
-        wantDescription: "Enter the local path to a private key file.",
-        wantPlaceHolder: "Enter the local path",
+        name: "Agent Socket",
+        prompt: ProfilePromptType.AgentSocket,
+        wantTitle: "Agent Socket",
+        wantDescription: "Enter the local path of the ssh agent socket.",
+        wantPlaceHolder: "Enter the agent socket path",
       },
     ];
 

--- a/client/test/components/profile/profile.test.ts
+++ b/client/test/components/profile/profile.test.ts
@@ -87,7 +87,6 @@ describe("Profiles", async function () {
           port: 22,
           sasPath: "sasPath",
           sasOptions: ["-nonews"],
-          agentSocket: "/agent/socket",
           connectionType: "ssh",
         },
       },
@@ -102,7 +101,6 @@ describe("Profiles", async function () {
           sasPath: "sasPath",
           sasOptions: ["-nonews"],
           connectionType: "ssh",
-          privateKeyFile: "privateKeyFile",
         },
         testViyaProfile: {
           endpoint: "https://test-host.sas.com",
@@ -619,7 +617,6 @@ describe("Profiles", async function () {
           connectionType: ConnectionType.SSH,
           host: "ssh.host",
           port: 22,
-          agentSocket: "/private/key/path",
           sasOptions: ["-nonews"],
           saspath: "/sas/path",
           username: "username",
@@ -864,13 +861,6 @@ describe("Profiles", async function () {
         wantTitle: "SAS Server Username",
         wantDescription: "Enter your SAS server username.",
         wantPlaceHolder: "Enter your username",
-      },
-      {
-        name: "Agent Socket",
-        prompt: ProfilePromptType.AgentSocket,
-        wantTitle: "Agent Socket",
-        wantDescription: "Enter the local path of the ssh agent socket.",
-        wantPlaceHolder: "Enter the agent socket path",
       },
     ];
 

--- a/client/test/connection/ssh/index.test.ts
+++ b/client/test/connection/ssh/index.test.ts
@@ -1,14 +1,12 @@
 import * as sinon from "sinon";
 import { Client, ClientChannel } from "ssh2";
-import * as fs from "fs";
 import { SSHSession } from "../../../src/connection/ssh";
-import { assertThrowsAsync, getTestFixtureContent } from "../../utils";
+import { assertThrowsAsync } from "../../utils";
 import { assert, expect } from "chai";
 import { StubbedInstance, stubInterface } from "ts-sinon";
 
 describe("ssh connection", () => {
   const seconds = 1000;
-  let keyContent: string;
   let sandbox: sinon.SinonSandbox;
   let session: SSHSession;
   let streamOnStub;
@@ -25,13 +23,10 @@ describe("ssh connection", () => {
       port: 22,
       saspath: "/path/to/sas_u8",
       sasOptions: [],
-      privateKeyPath: "/path/to/key",
+      agentSocket: "/agent/socket",
     };
 
     session = new SSHSession(config);
-
-    keyContent = getTestFixtureContent("keyContent.txt").toString();
-    sandbox.stub(fs, "readFileSync").returns(keyContent);
   });
 
   afterEach(() => {
@@ -47,7 +42,7 @@ describe("ssh connection", () => {
         port: 22,
         saspath: "/path/to/sas_u8",
         sasOptions: [],
-        privateKeyPath: "../../testFixture/keyContent.txt",
+        agentSocket: "/agent/socket",
       };
 
       sandbox.stub(Client.prototype, "connect").callsFake(function () {
@@ -86,7 +81,7 @@ describe("ssh connection", () => {
         port: 22,
         saspath: "/path/to/sas_u8",
         sasOptions: [],
-        privateKeyPath: "/path/to/key",
+        agentSocket: "/agent/socket",
       };
 
       sandbox.stub(Client.prototype, "connect").callsFake(function () {
@@ -107,7 +102,7 @@ describe("ssh connection", () => {
         port: 22,
         saspath: "/path/to/sas_u8",
         sasOptions: [],
-        privateKeyPath: "/path/to/key",
+        agentSocket: "/agent/socket",
       };
 
       sandbox.stub(Client.prototype, "connect").callsFake(function () {
@@ -134,7 +129,7 @@ describe("ssh connection", () => {
         port: 22,
         saspath: "/path/to/sas_u8",
         sasOptions: [],
-        privateKeyPath: "/path/to/key",
+        agentSocket: "/agent/socket",
       };
 
       sandbox.stub(Client.prototype, "connect").callsFake(function () {
@@ -160,7 +155,7 @@ describe("ssh connection", () => {
       port: 22,
       saspath: "/path/to/sas_u8",
       sasOptions: [],
-      privateKeyPath: "../../testFixture/keyContent.txt",
+      agentSocket: "/agent/socket",
     };
 
     const session = new SSHSession(config);

--- a/client/test/connection/ssh/index.test.ts
+++ b/client/test/connection/ssh/index.test.ts
@@ -42,7 +42,6 @@ describe("ssh connection", () => {
         port: 22,
         saspath: "/path/to/sas_u8",
         sasOptions: [],
-        agentSocket: "/agent/socket",
       };
 
       sandbox.stub(Client.prototype, "connect").callsFake(function () {

--- a/client/test/connection/ssh/index.test.ts
+++ b/client/test/connection/ssh/index.test.ts
@@ -326,7 +326,7 @@ describe("ssh connection", () => {
   describe("getSession", () => {
     let config;
     beforeEach(() => {
-      process.env.SSH_AUTH_SOCKET = "val";
+      process.env.SSH_AUTH_SOCK = "val";
       config = {
         host: "host",
         username: "username",
@@ -337,7 +337,7 @@ describe("ssh connection", () => {
     });
 
     afterEach(() => {
-      delete process.env.SSH_AUTH_SOCKET;
+      delete process.env.SSH_AUTH_SOCK;
     });
 
     it("builds a well-formed ssh session instance", () => {

--- a/client/test/connection/ssh/index.test.ts
+++ b/client/test/connection/ssh/index.test.ts
@@ -336,6 +336,10 @@ describe("ssh connection", () => {
       };
     });
 
+    afterEach(() => {
+      delete process.env.SSH_AUTH_SOCKET;
+    });
+
     it("builds a well-formed ssh session instance", () => {
       const session = getSession(config);
 

--- a/client/test/connection/ssh/index.test.ts
+++ b/client/test/connection/ssh/index.test.ts
@@ -1,6 +1,6 @@
 import * as sinon from "sinon";
 import { Client, ClientChannel } from "ssh2";
-import { SSHSession } from "../../../src/connection/ssh";
+import { getSession, SSHSession } from "../../../src/connection/ssh";
 import { assertThrowsAsync } from "../../utils";
 import { assert, expect } from "chai";
 import { StubbedInstance, stubInterface } from "ts-sinon";
@@ -320,6 +320,26 @@ describe("ssh connection", () => {
 
       expect(streamStub.write.calledWith("endsas;\n")).to.be.true;
       expect(streamStub.close.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getSession", () => {
+    let config;
+    beforeEach(() => {
+      process.env.SSH_AUTH_SOCKET = "val";
+      config = {
+        host: "host",
+        username: "username",
+        saspath: "saspath",
+        sasOptions: ["-nonews"],
+        port: 22,
+      };
+    });
+
+    it("builds a well-formed ssh session instance", () => {
+      const session = getSession(config);
+
+      expect(session).to.not.equal(undefined);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -199,8 +199,7 @@
                           "host",
                           "saspath",
                           "username",
-                          "port",
-                          "privateKeyPath"
+                          "port"
                         ],
                         "properties": {
                           "host": {
@@ -224,11 +223,6 @@
                             "description": "%configuration.SAS.connectionProfiles.profiles.ssh.port%",
                             "exclusiveMinimum": 1,
                             "exclusiveMaximum": 65535
-                          },
-                          "privateKeyPath": {
-                            "type": "string",
-                            "default": "",
-                            "description": "%configuration.SAS.connectionProfiles.profiles.ssh.privateKeyPath%"
                           },
                           "sasOptions": {
                             "type": "array",

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,7 +16,6 @@
   "configuration.SAS.connectionProfiles.profiles.ssh.username": "SAS SSH Connection username",
   "configuration.SAS.connectionProfiles.profiles.ssh.saspath": "SAS SSH Connection executable path",
   "configuration.SAS.connectionProfiles.profiles.ssh.port": "SAS SSH Connection port",
-  "configuration.SAS.connectionProfiles.profiles.ssh.privateKeyPath": "SAS SSH Connection private key path",
   "configuration.SAS.connectionProfiles.profiles.ssh.sasOptions": "SAS SSH Connection SAS system options",
 
   "commands.SAS.addFileResource": "New File...",


### PR DESCRIPTION
**Summary**
- Adds support for encrypted private keys that are registered with ssh-agent
- Private Key file is removed from the connection profile and new connection prompts and is now instead defined in the global ssh config
- SSH Connection Provider is updated to read process.env.SSH_AUTH_SOCK (env var) and set Client agent property to this value at connection time

# Testing (Developer) #
## Integration ##
### Windows (OpenSSH installed as a Windows Feature) ###
1. Enabled open ssh client optional feature
2. Created env variable SSH_AUTH_SOCK with value //./pipe/openssh-ssh-agent (windows uses a named pipe for the auth sock)
3. Ensure ssh-agent service is running, set startup type to automatic
4. Define an entry in $HOME/.ssh/config of the form:
```  
    Host host.machine.name 
        AddKeysToAgent yes
        IdentityFile /path/to/private/key/with/passphrase 
``` 
5. Add the private key to ssh-agent: `ssh-add /path/to/private/key/with/passphrase`
6. Define a connection profile in settings.json for a remote server:

```
    "ssh_test": {
        "connectionType": "ssh",  
        "host": "host.machine.name",  
        "saspath": "/path/to/sas/executable",  
        "username": "username",  
        "port": 22
    } 
```
7. Run test code using ssh_test connection profile. Should get 428 observations and results tab displayed.
```
    proc print data=sashelp.cars;  
    run;  
```

### macOS ###
1. Start ssh-agent in the background:
```
    eval "$(ssh-agent -s)"
```
2. Ensure that SSH_AUTH_SOCK has a value
```
   echo $SSH_AUTH_SOCK
```
4. Define an entry in $HOME/.ssh/config of the form:
```  
    Host host.machine.name 
        AddKeysToAgent yes
        UseKeychain yes
        IdentityFile /path/to/private/key/with/passphrase 
```
5. Add the private key to ssh-agent: `ssh-add /path/to/private/key/with/passphrase`
6. Define a connection profile in settings.json for a remote server:
```
    "ssh_test": {
        "connectionType": "ssh",  
        "host": "host.machine.name",  
        "saspath": "/path/to/sas/executable",  
        "username": "username",  
        "port": 22
    } 
```
7. Run test code using ssh_test connection profile. Should get 428 observations and results tab displayed.
```
    proc print data=sashelp.cars;  
    run;  
```