### PR TITLE
fix: fix miscellaneous bugs for 0.1.3 deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ To access SAS Content:
 
 **Notes**:
 
-- # SAS Content requires a profile with a connection to a Viya instance.
+- SAS Content requires a profile with a connection to a Viya instance.
 
 ### Accessing Libraries and Tables
 

--- a/client/src/components/AuthProvider.ts
+++ b/client/src/components/AuthProvider.ts
@@ -46,8 +46,8 @@ export class SASAuthProvider implements AuthenticationProvider, Disposable {
 
     const session: SASAuthSession = JSON.parse(stored);
     const activeProfile = profileConfig.getActiveProfileDetail();
-    const profile = activeProfile.profile;
-    if (profile.connectionType !== ConnectionType.Rest) {
+    const profile = activeProfile?.profile;
+    if (!profile || profile.connectionType !== ConnectionType.Rest) {
       return [];
     }
     const tokens = await refreshToken(profile, {

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -140,7 +140,7 @@ class ContentNavigator implements SubscriptionProvider {
           window.showErrorMessage(Messages.EmptyRecycleBinError);
         }
       }),
-      commands.registerCommand("SAS.refreshResources", () =>
+      commands.registerCommand("SAS.refreshContent", () =>
         this.contentDataProvider.refresh()
       ),
       commands.registerCommand(
@@ -242,7 +242,7 @@ class ContentNavigator implements SubscriptionProvider {
           this.contentDataProvider.refresh();
         }
       ),
-      commands.registerCommand("SAS.collapseAll", () => {
+      commands.registerCommand("SAS.collapseAllContent", () => {
         commands.executeCommand(
           "workbench.actions.treeView.sas-content-navigator.collapseAll"
         );

--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -62,6 +62,11 @@ class LibraryNavigator implements SubscriptionProvider {
           window.showErrorMessage(error.message);
         }
       }),
+      commands.registerCommand("SAS.collapseAllLibraries", () => {
+        commands.executeCommand(
+          "workbench.actions.treeView.sas-library-navigator.collapseAll"
+        );
+      }),
     ];
   }
 

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -132,13 +132,14 @@ export class ProfileConfig {
       .get(EXTENSION_DEFINE_PROFILES_CONFIG_KEY)[EXTENSION_PROFILES_CONFIG_KEY];
 
     if (!profileList) {
-      workspace
-        .getConfiguration(EXTENSION_CONFIG_KEY)
-        .update(
-          EXTENSION_DEFINE_PROFILES_CONFIG_KEY,
-          {},
-          ConfigurationTarget.Global
-        );
+      workspace.getConfiguration(EXTENSION_CONFIG_KEY).update(
+        EXTENSION_DEFINE_PROFILES_CONFIG_KEY,
+        {
+          activeProfile: "",
+          profiles: {},
+        },
+        ConfigurationTarget.Global
+      );
       return false;
     }
     return true;
@@ -633,8 +634,8 @@ const input: ProfilePromptInput = {
  * @returns {@link ConnectionType}
  */
 function mapQuickPickToEnum(connectionTypePickInput: string): ConnectionType {
-  /* 
-     Having a translation layer here allows the profile types to potentially evolve separately from the 
+  /*
+     Having a translation layer here allows the profile types to potentially evolve separately from the
      underlying technology used to implement the connection. Down the road its quite possible to have
      more than one selectable quick pick input that uses the same underlying connection methods..
   */

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -144,6 +144,11 @@ function triggerProfileUpdate(): void {
     );
   } else {
     profileConfig.updateActiveProfileSetting("");
+    commands.executeCommand(
+      "setContext",
+      "SAS.connectionType",
+      ConnectionType.Rest
+    );
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -558,25 +558,25 @@
         {
           "id": "sas-content-get-started",
           "name": "Sign In",
-          "when": "!SAS.authorized && (SAS.connectionType == rest || !SAS.connectionType)"
+          "when": "!SAS.authorized && SAS.connectionType == rest"
         },
         {
           "id": "sas-content-invalid-connection",
           "name": "Sign In",
-          "when": "!SAS.authorized && SAS.connectionType != rest && SAS.connectionType"
+          "when": "!SAS.authorized && SAS.connectionType != rest"
         }
       ]
     },
     "viewsWelcome": [
       {
         "view": "sas-content-get-started",
-        "when": "!SAS.authorized && (SAS.connectionType == rest || !SAS.connectionType)",
+        "when": "!SAS.authorized && SAS.connectionType == rest",
         "contents": "%views.SAS.welcome%",
         "enablement": "!SAS.authorizing"
       },
       {
         "view": "sas-content-invalid-connection",
-        "when": "SAS.connectionType && SAS.connectionType != rest",
+        "when": "SAS.connectionType != rest",
         "contents": "%views.SAS.unsupportedConnection%"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -336,7 +336,13 @@
         "icon": "$(refresh)"
       },
       {
-        "command": "SAS.collapseAll",
+        "command": "SAS.collapseAllContent",
+        "title": "%commands.SAS.collapseAll%",
+        "category": "SAS",
+        "icon": "$(collapse-all)"
+      },
+      {
+        "command": "SAS.collapseAllLibraries",
         "title": "%commands.SAS.collapseAll%",
         "category": "SAS",
         "icon": "$(collapse-all)"
@@ -355,7 +361,7 @@
           "group": "navigation@0"
         },
         {
-          "command": "SAS.collapseAll",
+          "command": "SAS.collapseAllContent",
           "when": "view == sas-content-navigator",
           "group": "navigation@1"
         },
@@ -363,6 +369,11 @@
           "command": "SAS.refreshLibraries",
           "when": "view == sas-library-navigator",
           "group": "navigation@0"
+        },
+        {
+          "command": "SAS.collapseAllLibraries",
+          "when": "view == sas-library-navigator",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [
@@ -465,7 +476,11 @@
         },
         {
           "when": "false",
-          "command": "SAS.collapseAll"
+          "command": "SAS.collapseAllContent"
+        },
+        {
+          "when": "false",
+          "command": "SAS.collapseAllLibraries"
         },
         {
           "when": "false",
@@ -543,25 +558,25 @@
         {
           "id": "sas-content-get-started",
           "name": "Sign In",
-          "when": "!SAS.authorized && SAS.connectionType == rest"
+          "when": "!SAS.authorized && (SAS.connectionType == rest || !SAS.connectionType)"
         },
         {
           "id": "sas-content-invalid-connection",
           "name": "Sign In",
-          "when": "!SAS.authorized && SAS.connectionType != rest"
+          "when": "!SAS.authorized && SAS.connectionType != rest && SAS.connectionType"
         }
       ]
     },
     "viewsWelcome": [
       {
         "view": "sas-content-get-started",
-        "when": "!SAS.authorized && SAS.connectionType == rest",
+        "when": "!SAS.authorized && (SAS.connectionType == rest || !SAS.connectionType)",
         "contents": "%views.SAS.welcome%",
         "enablement": "!SAS.authorizing"
       },
       {
         "view": "sas-content-invalid-connection",
-        "when": "SAS.connectionType != rest",
+        "when": "SAS.connectionType && SAS.connectionType != rest",
         "contents": "%views.SAS.unsupportedConnection%"
       }
     ]


### PR DESCRIPTION
**Summary**
This fixes some inconsistencies and bugs around the 0.1.3 deployment. Here's the summary:
 - Fixes an issue in a readme
 - Fixes a missing refresh command for SAS content
 - Adds the ability to collapse libraries
 - Fixes a console error when there is no active profile
 - Fixes a bug where _no_ profile resulted in endlessly writing to user settings
 - Fixes a bug where _no_ profile didn't allow users to sign in using the SAS sign in view

**Testing**
 - [x] Made sure sign in was possible with no profile
 - [x] Made sure there were no console errors or issues when writing an empty profile
 - [x] Made sure sas content and libraries were both collapsible
 - [x] Made sure the readme looked as expected
