### PR TITLE
fix: address various auth issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ After executing the `SAS.updateProfile` command:
 
 To update the name of a profile, please delete and recreate it.
 
+#### Notes:
+
+- There is a potential issue with switching between multiple profiles on Windows. For more information, see [#215](https://github.com/sassoftware/vscode-sas-extension/issues/215)
+
 ### Running SAS Code
 
 After configuring the SAS extension for your SAS environment, run your SAS program and view the log and results.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ To update the name of a profile, please delete and recreate it.
 
 #### Notes:
 
-- There is a potential issue with switching between multiple profiles on Windows. For more information, see [#215](https://github.com/sassoftware/vscode-sas-extension/issues/215)
+- There is a potential issue with switching between multiple profiles on Windows. For more information, see [#215](https://github.com/sassoftware/vscode-sas-extension/issues/215).
 
 ### Running SAS Code
 

--- a/client/src/components/AuthProvider.ts
+++ b/client/src/components/AuthProvider.ts
@@ -16,7 +16,7 @@ import { getTokens, refreshToken } from "../connection/rest/auth";
 import { getCurrentUser } from "../connection/rest/identities";
 import { ConnectionType } from "../components/profile";
 
-const SECRET_KEY = "SASAuth-3";
+const SECRET_KEY = "SASAuth-1";
 
 interface SASAuthSession extends AuthenticationSession {
   refreshToken?: string;

--- a/client/src/components/AuthProvider.ts
+++ b/client/src/components/AuthProvider.ts
@@ -111,7 +111,6 @@ export class SASAuthProvider implements AuthenticationProvider, Disposable {
       ? JSON.parse(storedSessionData)
       : {};
     const profileName = profileConfig.getActiveProfile();
-    console.log("aint this a bitch");
     if (!profileName) {
       return;
     }

--- a/client/src/components/AuthProvider.ts
+++ b/client/src/components/AuthProvider.ts
@@ -53,6 +53,7 @@ export class SASAuthProvider implements AuthenticationProvider, Disposable {
     const profileName = profileConfig.getActiveProfile();
     const session = sessions[profileName];
     if (!session) {
+      commands.executeCommand("setContext", "SAS.authorized", false);
       return [];
     }
 
@@ -124,11 +125,11 @@ export class SASAuthProvider implements AuthenticationProvider, Disposable {
     const sessions = await this.getStoredSessions();
     const profileName = profileConfig.getActiveProfile() || "";
     if (!sessions) {
-      await this.secretStorage.delete(SECRET_KEY);
-    } else {
-      delete sessions[profileName];
-      await this.secretStorage.store(SECRET_KEY, JSON.stringify(sessions));
+      return;
     }
+
+    delete sessions[profileName];
+    await this.secretStorage.store(SECRET_KEY, JSON.stringify(sessions));
 
     commands.executeCommand("setContext", "SAS.authorized", false);
   }
@@ -141,10 +142,6 @@ export class SASAuthProvider implements AuthenticationProvider, Disposable {
       return;
     }
 
-    const storedSessions = storedSessionData
-      ? JSON.parse(storedSessionData)
-      : {};
-
-    return storedSessions;
+    return JSON.parse(storedSessionData);
   }
 }

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -4,6 +4,7 @@
 import { sprintf } from "sprintf-js";
 import {
   commands,
+  ConfigurationChangeEvent,
   Disposable,
   ExtensionContext,
   TextDocumentChangeEvent,
@@ -247,6 +248,16 @@ class ContentNavigator implements SubscriptionProvider {
           "workbench.actions.treeView.sas-content-navigator.collapseAll"
         );
       }),
+      workspace.onDidChangeConfiguration(
+        async (event: ConfigurationChangeEvent) => {
+          if (event.affectsConfiguration("SAS.connectionProfiles")) {
+            const activeProfile: ViyaProfile = profileConfig.getProfileByName(
+              profileConfig.getActiveProfile()
+            );
+            await this.contentDataProvider.connect(activeProfile.endpoint);
+          }
+        }
+      ),
     ];
   }
 

--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -3,11 +3,13 @@
 
 import {
   commands,
+  ConfigurationChangeEvent,
   Disposable,
   ExtensionContext,
   TreeView,
   Uri,
   window,
+  workspace,
 } from "vscode";
 import DataTable from "../../panels/DataTable";
 import DragAndDropController from "../DragAndDropController";
@@ -66,6 +68,11 @@ class LibraryNavigator implements SubscriptionProvider {
         commands.executeCommand(
           "workbench.actions.treeView.sas-library-navigator.collapseAll"
         );
+      }),
+      workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
+        if (event.affectsConfiguration("SAS.connectionProfiles")) {
+          this.refresh();
+        }
       }),
     ];
   }

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -122,11 +122,22 @@ export function activate(context: ExtensionContext): void {
   updateStatusBarProfile(activeProfileStatusBarIcon);
 
   // If configFile setting is changed, update watcher to watch new configuration file
-  workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
-    if (event.affectsConfiguration("SAS.connectionProfiles")) {
-      triggerProfileUpdate();
+  workspace.onDidChangeConfiguration(
+    async (event: ConfigurationChangeEvent) => {
+      if (event.affectsConfiguration("SAS.connectionProfiles")) {
+        console.log("Things are affected. Connection profile thing");
+        commands.executeCommand("setContext", "SAS.authorized", false);
+        // if (
+        //   event.affectsConfiguration("SAS.connectionProfiles.activeProfile")
+        // ) {
+        //   console.log("Things are affected. Closing session");
+        //   await closeSession();
+        //   commands.executeCommand("setContext", "SAS.authorized", false);
+        // }
+        triggerProfileUpdate();
+      }
     }
-  });
+  );
 
   profileConfig.migrateLegacyProfiles();
   triggerProfileUpdate();

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -117,7 +117,6 @@ export function activate(context: ExtensionContext): void {
     // If configFile setting is changed, update watcher to watch new configuration file
     workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
       if (event.affectsConfiguration("SAS.connectionProfiles")) {
-        commands.executeCommand("setContext", "SAS.authorized", false);
         triggerProfileUpdate();
       }
     })

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -125,15 +125,7 @@ export function activate(context: ExtensionContext): void {
   workspace.onDidChangeConfiguration(
     async (event: ConfigurationChangeEvent) => {
       if (event.affectsConfiguration("SAS.connectionProfiles")) {
-        console.log("Things are affected. Connection profile thing");
         commands.executeCommand("setContext", "SAS.authorized", false);
-        // if (
-        //   event.affectsConfiguration("SAS.connectionProfiles.activeProfile")
-        // ) {
-        //   console.log("Things are affected. Closing session");
-        //   await closeSession();
-        //   commands.executeCommand("setContext", "SAS.authorized", false);
-        // }
         triggerProfileUpdate();
       }
     }

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -113,23 +113,20 @@ export function activate(context: ExtensionContext): void {
     ),
     activeProfileStatusBarIcon,
     ...libraryNavigator.getSubscriptions(),
-    ...contentNavigator.getSubscriptions()
+    ...contentNavigator.getSubscriptions(),
+    // If configFile setting is changed, update watcher to watch new configuration file
+    workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
+      if (event.affectsConfiguration("SAS.connectionProfiles")) {
+        commands.executeCommand("setContext", "SAS.authorized", false);
+        triggerProfileUpdate();
+      }
+    })
   );
 
   // Reset first to set "No Active Profiles"
   resetStatusBarItem(activeProfileStatusBarIcon);
   // Update status bar if profile is found
   updateStatusBarProfile(activeProfileStatusBarIcon);
-
-  // If configFile setting is changed, update watcher to watch new configuration file
-  workspace.onDidChangeConfiguration(
-    async (event: ConfigurationChangeEvent) => {
-      if (event.affectsConfiguration("SAS.connectionProfiles")) {
-        commands.executeCommand("setContext", "SAS.authorized", false);
-        triggerProfileUpdate();
-      }
-    }
-  );
 
   profileConfig.migrateLegacyProfiles();
   triggerProfileUpdate();


### PR DESCRIPTION
**Summary**
This addresses a couple things:
 - It un-authorizes a user (thus, hiding sas content / libraries) when switching a profile
 - If adds a namespace for session storage. Right now, this is using "profile name" to store the information
 - It updates `SECRET_KEY` to blow out the original cache
 - It refreshes libraries when a profile is changed, and makes sure our event subscriber for changing a profile is cleaned up by vscode

**Testing**
- Tested setting up and switching between multiple profiles
- Made sure sas content and libraries were updated when logging back in (NOTE: Right now, you can see stale libraries when switching profiles. Once a new compute session is generated, they should be refreshed. That's expected behavior for this pass)
