### PR TITLE
feat: support user provided CA certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Allow user to provide trusted CA certificates ([#220](https://github.com/sassoftware/vscode-sas-extension/issues/220))
+
 ### Fixed
 
 - Fixed an issue where trailing slashes on viya endpoints caused connection issues ([#232](https://github.com/sassoftware/vscode-sas-extension/pull/232))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If you introduce breaking changes, please group them together in the "Changed" section using the **BREAKING:** prefix.
 
-## [v0.1.4] - 2023-04-28
+## [Unreleased]
 
 ### Added
 
 - Allow user to provide trusted CA certificates ([#220](https://github.com/sassoftware/vscode-sas-extension/issues/220))
+
+## [v0.1.4] - 2023-04-28
 
 ### Fixed
 

--- a/client/src/components/CAHelper.ts
+++ b/client/src/components/CAHelper.ts
@@ -14,18 +14,18 @@ export const installCAs = () => {
     return;
   }
 
-  const CAs = [].concat(tls.rootCertificates);
-  const originalLength = CAs.length;
+  const userCertificates = [];
   for (const filename of certFiles) {
     if (filename && filename.length) {
       try {
-        CAs.push(fs.readFileSync(filename));
+        userCertificates.push(fs.readFileSync(filename));
       } catch (e) {
         console.log(`Failed to read user provided certificate`, e);
       }
     }
   }
-  if (CAs.length !== originalLength) {
-    https.globalAgent.options.ca = CAs;
+  if (userCertificates.length > 0) {
+    https.globalAgent.options.ca =
+      tls.rootCertificates.concat(userCertificates);
   }
 };

--- a/client/src/components/CAHelper.ts
+++ b/client/src/components/CAHelper.ts
@@ -1,0 +1,31 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+// Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
+
+import * as fs from "fs";
+import * as https from "https";
+import * as tls from "tls";
+import { workspace } from "vscode";
+
+export const installCAs = () => {
+  const certFiles: string[] = workspace
+    .getConfiguration("SAS")
+    .get("userProvidedCertificates");
+  if (!certFiles || !certFiles.length) {
+    return;
+  }
+
+  const CAs = [].concat(tls.rootCertificates);
+  const originalLength = CAs.length;
+  for (const filename of certFiles) {
+    if (filename && filename.length) {
+      try {
+        CAs.push(fs.readFileSync(filename));
+      } catch (e) {
+        console.log(`Failed to read user provided certificate`, e);
+      }
+    }
+  }
+  if (CAs.length !== originalLength) {
+    https.globalAgent.options.ca = CAs;
+  }
+};

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -34,6 +34,7 @@ import ContentNavigator from "../components/ContentNavigator";
 import LibraryNavigator from "../components/LibraryNavigator";
 import { legend, LogTokensProvider } from "../components/LogViewer";
 import { ConnectionType } from "../components/profile";
+import { installCAs } from "../components/CAHelper";
 
 let client: LanguageClient;
 // Create Profile status bar item
@@ -80,6 +81,8 @@ export function activate(context: ExtensionContext): void {
 
   // Start the client. This will also launch the server
   client.start();
+
+  installCAs();
 
   const libraryNavigator = new LibraryNavigator(context);
   const contentNavigator = new ContentNavigator(context);

--- a/package.json
+++ b/package.json
@@ -117,6 +117,13 @@
             "default": true,
             "description": "%configuration.SAS.session.outputHtml%"
           },
+          "SAS.userProvidedCertificates": {
+            "type": "array",
+            "description": "%configuration.SAS.userProvidedCertificates%",
+            "items": {
+              "type": "string"
+            }
+          },
           "SAS.connectionProfiles": {
             "order": 1,
             "type": "object",

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,6 +11,7 @@
   "configuration.SAS.connectionProfiles.profiles.tokenFile": "SAS Viya Token File",
   "configuration.SAS.connectionProfiles.profiles.username": "SAS Viya User ID",
   "configuration.SAS.session.outputHtml": "Enable/disable ODS HTML5 output",
+  "configuration.SAS.userProvidedCertificates": "Provide trusted CA certificate files",
 
   "configuration.SAS.connectionProfiles.profiles.ssh.host": "SAS SSH Connection SSH Host",
   "configuration.SAS.connectionProfiles.profiles.ssh.username": "SAS SSH Connection username",


### PR DESCRIPTION
**Summary**
Fix #220
Add a configuration field so that user can provide their certificates

This page describes some background. But the VS Code extension provided by this page does NOT really work.
https://github.com/ukoloff/win-ca

I'll update the FAQ page once this merged.

**Testing**
1. Export a crt file from browser against an endpoint with self-signed certificate.
2. In VS Code settings UI, click "Add Item" under "User Provided Certificate" entry, enter the full file path for the crt file.
3. Restart VS Code and Sign in, success
