### PR TITLE
fix: fix trailing slash on viya profile endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Fixed an issue where logins were resulting in a 404 ([#232](https://github.com/sassoftware/vscode-sas-extension/pull/232)).
+- Fixed an issue where trailing slashes on viya endpoints caused connection issues ([#232](https://github.com/sassoftware/vscode-sas-extension/pull/232)).
 
 ## [v0.1.3] - 2023-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If you introduce breaking changes, please group them together in the "Changed" section using the **BREAKING:** prefix.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue where logins were resulting in a 404 [#232](https://github.com/sassoftware/vscode-sas-extension/pull/232).
+
 ## [v0.1.3] - 2023-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Fixed an issue where logins were resulting in a 404 [#232](https://github.com/sassoftware/vscode-sas-extension/pull/232).
+- Fixed an issue where logins were resulting in a 404 ([#232](https://github.com/sassoftware/vscode-sas-extension/pull/232)).
 
 ## [v0.1.3] - 2023-04-13
 

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -112,15 +112,15 @@ export class ProfileConfig {
     if (profiles) {
       for (const key in profiles) {
         const profile = profiles[key];
+        if (profile.connectionType === undefined) {
+          profile.connectionType = ConnectionType.Rest;
+          await this.upsertProfile(key, profile);
+        }
         if (
           profile.connectionType === ConnectionType.Rest &&
           /\/$/.test(profile.endpoint)
         ) {
           profile.endpoint = profile.endpoint.replace(/\/$/, "");
-          await this.upsertProfile(key, profile);
-        }
-        if (profile.connectionType === undefined) {
-          profile.connectionType = ConnectionType.Rest;
           await this.upsertProfile(key, profile);
         }
       }

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -112,6 +112,13 @@ export class ProfileConfig {
     if (profiles) {
       for (const key in profiles) {
         const profile = profiles[key];
+        if (
+          profile.connectionType === ConnectionType.Rest &&
+          /\/$/.test(profile.endpoint)
+        ) {
+          profile.endpoint = profile.endpoint.replace(/\/$/, "");
+          await this.upsertProfile(key, profile);
+        }
         if (profile.connectionType === undefined) {
           profile.connectionType = ConnectionType.Rest;
           await this.upsertProfile(key, profile);
@@ -402,6 +409,7 @@ export class ProfileConfig {
       if (!profileClone.endpoint) {
         return;
       }
+      profileClone.endpoint = profileClone.endpoint.replace(/\/$/, "");
 
       profileClone.context = await createInputTextBox(
         ProfilePromptType.ComputeContext,

--- a/client/src/connection/rest/auth.ts
+++ b/client/src/connection/rest/auth.ts
@@ -23,7 +23,6 @@ export async function refreshToken(
   const rootApi = RootApi(
     new Configuration({
       basePath: config.endpoint + "/compute",
-      accessToken: tokens.access_token,
     })
   );
   await rootApi.headersForRoot().catch((err) => {

--- a/client/src/connection/rest/auth.ts
+++ b/client/src/connection/rest/auth.ts
@@ -23,6 +23,7 @@ export async function refreshToken(
   const rootApi = RootApi(
     new Configuration({
       basePath: config.endpoint + "/compute",
+      accessToken: tokens.access_token,
     })
   );
   await rootApi.headersForRoot().catch((err) => {

--- a/client/test/components/profile/profile.test.ts
+++ b/client/test/components/profile/profile.test.ts
@@ -103,7 +103,7 @@ describe("Profiles", async function () {
           connectionType: "ssh",
         },
         testViyaProfile: {
-          endpoint: "https://test-host.sas.com",
+          endpoint: "https://test-host.sas.com/",
           clientId: "sas.test",
           clientSecret: "",
           context: "SAS Studio context",
@@ -161,6 +161,26 @@ describe("Profiles", async function () {
         const profile = profiles[key];
         if (profile.connectionType === undefined) {
           assert.fail(`Found undefined connectionType in profile named ${key}`);
+        }
+      }
+    });
+
+    it("removes trailing slash from endpoint on legacy profiles", async () => {
+      await profileConfig.migrateLegacyProfiles();
+
+      const profiles = profileConfig.getAllProfiles();
+      expect(Object.keys(profiles).length).to.be.greaterThan(0);
+
+      for (const key in profiles) {
+        const profile = profiles[key];
+        if (
+          profile.connectionType === ConnectionType.Rest &&
+          /\/$/.test(profile.endpoint)
+        ) {
+          console.log('profile', profile);
+          assert.fail(
+            `Found trailing slash in endpoint of profile named ${key}`
+          );
         }
       }
     });

--- a/client/test/components/profile/profile.test.ts
+++ b/client/test/components/profile/profile.test.ts
@@ -177,7 +177,6 @@ describe("Profiles", async function () {
           profile.connectionType === ConnectionType.Rest &&
           /\/$/.test(profile.endpoint)
         ) {
-          console.log('profile', profile);
           assert.fail(
             `Found trailing slash in endpoint of profile named ${key}`
           );


### PR DESCRIPTION
**Summary**
This fixes an issue where trailing slashes can lead to 404/connection errors. This solves the issue in two ways:
 - It trims slashes when creating new profiles
 - It upgrades legacy profiles to add a trailing slash

**Testing**
 - [x] Test migrating legacy profile with trailing slash on endpoint
 - [x] Test creating new profile with trailing slash on endpoint
