### PR TITLE
fix: use vscode.open to open sas content

### DIFF
--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -10,6 +10,8 @@ import {
   FileSystemProvider,
   FileType,
   ProviderResult,
+  Tab,
+  TabInputText,
   TextDocumentContentProvider,
   ThemeIcon,
   TreeDataProvider,
@@ -17,20 +19,18 @@ import {
   TreeItemCollapsibleState,
   Uri,
   window,
-  Tab,
-  TabInputText,
 } from "vscode";
 import { ContentModel } from "./ContentModel";
 import { ContentItem } from "./types";
 import {
   getCreationDate,
   getId,
+  isContainer as getIsContainer,
   getLabel,
+  getLink,
   getModifyDate,
   getUri,
-  isContainer as getIsContainer,
   resourceType,
-  getLink,
 } from "./utils";
 
 class ContentDataProvider
@@ -70,8 +70,10 @@ class ContentDataProvider
     this.refresh();
   }
 
-  public getTreeItem(item: ContentItem): TreeItem | Promise<TreeItem> {
+  public async getTreeItem(item: ContentItem): Promise<TreeItem> {
     const isContainer = getIsContainer(item);
+
+    const uri = await this.getUri(item, false);
 
     return {
       iconPath: this.iconPathForItem(item),
@@ -84,8 +86,8 @@ class ContentDataProvider
       command: isContainer
         ? undefined
         : {
-            command: "SAS.openSASfile",
-            arguments: [item],
+            command: "vscode.open",
+            arguments: [uri],
             title: "Open SAS File",
           },
     };

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -15,16 +15,16 @@ import {
 } from "vscode";
 import { profileConfig } from "../../commands/profile";
 import { ViyaProfile } from "../profile";
+import { SubscriptionProvider } from "../SubscriptionProvider";
 import { Messages } from "./const";
 import ContentDataProvider from "./ContentDataProvider";
 import { ContentModel } from "./ContentModel";
 import { ContentItem } from "./types";
 import {
-  getUri,
   isContainer as getIsContainer,
+  getUri,
   isItemInRecycleBin,
 } from "./utils";
-import { SubscriptionProvider } from "../SubscriptionProvider";
 
 const fileValidator = (value: string): string | null =>
   /^([^/<>;\\{}?#]+)\.\w+$/.test(
@@ -77,15 +77,6 @@ class ContentNavigator implements SubscriptionProvider {
   public getSubscriptions(): Disposable[] {
     return [
       this.treeView,
-      commands.registerCommand("SAS.openSASfile", async (item: ContentItem) => {
-        try {
-          await window.showTextDocument(
-            await this.contentDataProvider.getUri(item, item.__trash__)
-          );
-        } catch (error) {
-          await window.showErrorMessage(Messages.FileOpenError);
-        }
-      }),
       commands.registerCommand(
         "SAS.deleteResource",
         async (resource: ContentItem) => {

--- a/client/src/panels/DataTable/index.ts
+++ b/client/src/panels/DataTable/index.ts
@@ -1,10 +1,10 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 // Licensed under SAS Code Extension Terms, available at Code_Extension_Agreement.pdf
 
+import { sprintf } from "sprintf-js";
 import { Disposable, Uri, ViewColumn, WebviewPanel, window } from "vscode";
 import { Messages } from "../../components/LibraryNavigator/const";
 import { TableData, TableRow } from "../../components/LibraryNavigator/types";
-import { sprintf } from "sprintf-js";
 
 export enum Commands {
   ReceiveRowData = "SAS.DataTable.receiveRowData",

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -1,18 +1,18 @@
 import axios, { AxiosInstance } from "axios";
-import { StubbedInstance, stubInterface } from "ts-sinon";
 import { expect } from "chai";
 import * as sinon from "sinon";
+import { StubbedInstance, stubInterface } from "ts-sinon";
 import {
-  authentication,
   FileStat,
   FileType,
   ThemeIcon,
   TreeItem,
   Uri,
+  authentication,
 } from "vscode";
-import { ROOT_FOLDER } from "../../../src/components/ContentNavigator/const";
 import ContentDataProvider from "../../../src/components/ContentNavigator/ContentDataProvider";
 import { ContentModel } from "../../../src/components/ContentNavigator/ContentModel";
+import { ROOT_FOLDER } from "../../../src/components/ContentNavigator/const";
 import { ContentItem } from "../../../src/components/ContentNavigator/types";
 import { getUri } from "../../../src/components/ContentNavigator/utils";
 
@@ -94,13 +94,14 @@ describe("ContentDataProvider", async function () {
     );
 
     const treeItem = await dataProvider.getTreeItem(contentItem);
+    const uri = await dataProvider.getUri(contentItem, false);
     const expectedTreeItem: TreeItem = {
       iconPath: ThemeIcon.File,
       id: "uri://selffile",
       label: "testFile",
       command: {
-        command: "SAS.openSASfile",
-        arguments: [contentItem],
+        command: "vscode.open",
+        arguments: [uri],
         title: "Open SAS File",
       },
     };


### PR DESCRIPTION
**Summary**
This updates our code to use vscode.open instead of a custom open command. This takes advantage of preview mode and either opens in a preview w/ single click or opens for editing w/ a double-click

**Testing**
 - Tested opening files with preview mode on and off, and made sure functionality worked as expected
