### PR TITLE
Fixed inputTextBox closing with empty client ID

### DIFF
--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -426,9 +426,6 @@ export class ProfileConfig {
         ProfilePromptType.ClientId,
         profileClone.clientId
       );
-      if (profileClone.clientId === "") {
-        delete profileClone.clientId;
-      }
 
       if (profileClone.clientId) {
         profileClone.clientSecret = await createInputTextBox(
@@ -602,7 +599,7 @@ const input: ProfilePromptInput = {
   [ProfilePromptType.ClientId]: {
     title: "Client ID",
     placeholder: "Enter a client ID",
-    description: "Enter the registered client ID. An example is myapp.client.",
+    description: "Enter the registered client ID. An example is myapp.client. For SAS Viya 2022.11 and later, you can leave Client ID empty and simply press Enter",
   },
   [ProfilePromptType.ClientSecret]: {
     title: "Client Secret",


### PR DESCRIPTION
For SAS Viya 2022.11 and later, you can leave Client ID empty, but in interactive mode, pressing Enter with an empty box will interrupt editing instead of saving.

![Zrzut ekranu 2023-04-21 144944](https://user-images.githubusercontent.com/973799/233651846-e100f4e6-b6bb-4bad-ac7a-75f355e72f57.png)

