### PR TITLE
Make each tree item has unique id

### DIFF
--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -128,7 +128,7 @@ export class ContentModel {
 
     return result.items.map((childItem: ContentItem) => ({
       ...childItem,
-      uid: `${childItem.id}${item.name}`.replace(/\s/g, ""),
+      uid: `${item.uid}/${childItem.name}`.replace(/\s/g, ""),
       permission: getPermission(childItem),
       __trash__: isTrash,
     }));
@@ -487,6 +487,7 @@ export class ContentModel {
         }
         this.delegateFolders[sDelegate] = {
           ...result.data,
+          uid: result.data.name.replace(/\s/g, ""),
           permission: getPermission(result.data),
         };
 

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -126,9 +126,9 @@ export class ContentModel {
     }
     const isTrash = TRASH_FOLDER === getTypeName(item) || item.__trash__;
 
-    return result.items.map((childItem: ContentItem) => ({
+    return result.items.map((childItem: ContentItem, index) => ({
       ...childItem,
-      uid: `${item.uid}/${childItem.name}`,
+      uid: `${item.uid}/${index}`,
       permission: getPermission(childItem),
       __trash__: isTrash,
     }));
@@ -476,7 +476,7 @@ export class ContentModel {
     let numberCompletedServiceCalls = 0;
 
     return new Promise<ContentItem[]>((resolve) => {
-      supportedDelegateFolders.forEach(async (sDelegate) => {
+      supportedDelegateFolders.forEach(async (sDelegate, index) => {
         let result;
         if (sDelegate === "@sasRoot") {
           result = {
@@ -487,7 +487,7 @@ export class ContentModel {
         }
         this.delegateFolders[sDelegate] = {
           ...result.data,
-          uid: result.data.name,
+          uid: `${index}`,
           permission: getPermission(result.data),
         };
 

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -128,7 +128,7 @@ export class ContentModel {
 
     return result.items.map((childItem: ContentItem) => ({
       ...childItem,
-      uid: `${item.uid}/${childItem.name}`.replace(/\s/g, ""),
+      uid: `${item.uid}/${childItem.name}`,
       permission: getPermission(childItem),
       __trash__: isTrash,
     }));
@@ -487,7 +487,7 @@ export class ContentModel {
         }
         this.delegateFolders[sDelegate] = {
           ...result.data,
-          uid: result.data.name.replace(/\s/g, ""),
+          uid: result.data.name,
           permission: getPermission(result.data),
         };
 

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -207,12 +207,13 @@ describe("ContentDataProvider", async function () {
             type: "test",
           },
         ],
+        uid: "My Favorites",
       })
     );
 
     expect(children.length).to.equal(1);
     expect(children[0]).to.deep.include(childItem);
-    expect(children[0].uid).to.equal("abc123@myFavorites");
+    expect(children[0].uid).to.equal("MyFavorites/testFile");
   });
 
   it("stat - returns file data", async function () {

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -213,7 +213,7 @@ describe("ContentDataProvider", async function () {
 
     expect(children.length).to.equal(1);
     expect(children[0]).to.deep.include(childItem);
-    expect(children[0].uid).to.equal("MyFavorites/testFile");
+    expect(children[0].uid).to.equal("My Favorites/testFile");
   });
 
   it("stat - returns file data", async function () {

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -207,13 +207,13 @@ describe("ContentDataProvider", async function () {
             type: "test",
           },
         ],
-        uid: "My Favorites",
+        uid: "1",
       })
     );
 
     expect(children.length).to.equal(1);
     expect(children[0]).to.deep.include(childItem);
-    expect(children[0].uid).to.equal("My Favorites/testFile");
+    expect(children[0].uid).to.equal("1/0");
   });
 
   it("stat - returns file data", async function () {


### PR DESCRIPTION
**Summary**
Fix #264 
A file/folder resource could be shown up in different tree path (like /My Folder/folder1 and /SAS Content/Users/.../My Folder/folder1). The Tree view requires that each node must have unique id but currently the same resource in the different path has same id so the error occurs

**Testing**
As described in #264 
