### PR TITLE
fix: Add back library support for direct SAS connections.

### DIFF
--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -57,6 +57,12 @@ export enum ConnectionType {
  * Profile is an interface that represents a users profile.  Currently
  * supports two different authentication flows, token and password
  * flow with the clientId and clientSecret.
+ *
+ * Direct connect is also supported where a server is already started with
+ * a static serverId. Setting serverId in the profile indicates that a connection
+ * to that specific server with Id will be created. This overrides the context
+ * value. Normally this option should not be set by the user since it is most likely
+ * being set by an automated process.
  */
 export interface ViyaProfile {
   connectionType: ConnectionType.Rest;
@@ -64,6 +70,7 @@ export interface ViyaProfile {
   clientId?: string;
   clientSecret?: string;
   context?: string;
+  serverId?: string;
 }
 
 export interface SSHProfile {

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -146,10 +146,19 @@ function triggerProfileUpdate(): void {
   const activeProfileName = profileConfig.getActiveProfile();
   if (profileList[activeProfileName]) {
     updateStatusBarProfile(activeProfileStatusBarIcon);
+
+    const connectionType =
+      profileList[activeProfileName].connectionType || ConnectionType.Rest;
+
+    //Set the connection type
+    commands.executeCommand("setContext", "SAS.connectionType", connectionType);
+
+    //See if the connection is direct (ie. serverId)
     commands.executeCommand(
       "setContext",
-      "SAS.connectionType",
-      profileList[activeProfileName]?.connectionType || ConnectionType.Rest
+      "SAS.connection.direct",
+      connectionType === ConnectionType.Rest &&
+        "serverId" in profileList[activeProfileName]
     );
   } else {
     profileConfig.updateActiveProfileSetting("");

--- a/package.json
+++ b/package.json
@@ -590,12 +590,12 @@
         {
           "id": "sas-library-navigator",
           "name": "Libraries",
-          "when": "SAS.authorized && SAS.connectionType == rest"
+          "when": "(SAS.authorized && SAS.connectionType == rest) || SAS.connection.direct"
         },
         {
           "id": "sas-content-get-started",
           "name": "Sign In",
-          "when": "!SAS.authorized && SAS.connectionType == rest"
+          "when": "(!SAS.authorized && SAS.connectionType == rest) && !SAS.connection.direct"
         },
         {
           "id": "sas-content-invalid-connection",
@@ -607,7 +607,7 @@
     "viewsWelcome": [
       {
         "view": "sas-content-get-started",
-        "when": "!SAS.authorized && SAS.connectionType == rest",
+        "when": "(!SAS.authorized && SAS.connectionType == rest) && !SAS.connection.direct",
         "contents": "%views.SAS.welcome%",
         "enablement": "!SAS.authorizing"
       },


### PR DESCRIPTION
This was added in the original change for #143, but somehow it got overwritten.

This simply adds back the enabling of the library viewer when we have a direct connection.

**Summary**
Enable the library view when a direct connect is enabled. This does not require authorization to a Viya server, but it is using a REST connection

**Testing**
I made sure that the libraries are available when connecting in a direct fasion.
