### PR TITLE
fix: library summary accept header

### DIFF
--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -151,7 +151,11 @@ class LibraryModel {
                 sessionId: this.sessionId,
                 libref: item.id,
               },
-              requestOptions
+              {
+                headers: {
+                  Accept: "application/json",
+                },
+              }
             )
         );
 


### PR DESCRIPTION
**Summary**
Fix #309
The issue is part of regression introduced by #301
It turns out to be tricky to set the accept header for getting library summary we want on various Viya versions. Neither more specific mime type "application/vnd.sas.compute.library.summary+json" nor more broader default type works. "application/json" appears the only one that can get expected result on all endpoints I tested.
However "application/json" doesn't work for other requets. They still need "application/vnd.sas.collection+json"

**Testing**
Tested library view on both Viya3.5 and Viya4
