### PR TITLE
feat: support cancelling running job

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -128,9 +128,14 @@ async function runCode(selected?: boolean) {
     {
       location: ProgressLocation.Notification,
       title: "SAS code running...",
+      cancellable: typeof session.cancel === "function",
     },
-    () =>
-      session
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (_progress, cancellationToken) => {
+      cancellationToken.onCancellationRequested(() => {
+        session.cancel?.();
+      });
+      return session
         .run(code, (logs) => {
           if (!outputChannel) {
             outputChannel = window.createOutputChannel("SAS Log", "sas-log");
@@ -151,7 +156,8 @@ async function runCode(selected?: boolean) {
             );
             odsResult.webview.html = results.html5;
           }
-        })
+        });
+    }
   );
 }
 

--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -130,7 +130,6 @@ async function runCode(selected?: boolean) {
       title: "SAS code running...",
       cancellable: typeof session.cancel === "function",
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (_progress, cancellationToken) => {
       cancellationToken.onCancellationRequested(() => {
         session.cancel?.();

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -183,7 +183,7 @@ async function run(code: string, onLog?: (logs: LogLine[]) => void) {
   await retLog;
 
   //Now get the results
-  const results = await job.results();
+  const results = state === ComputeState.Error ? [] : await job.results();
 
   const res: RunResult = {
     html5: "",


### PR DESCRIPTION
**Summary**
Support #187
Currently only for Rest. (I guess SSH can't really cancel like Rest. It can only close session.)

**Testing**
Click the `Cancel` button on the `SAS code running...` progress notification.
