### PR TITLE
feat: SAS Options support for rest connection profiles

### DIFF
--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -68,7 +68,7 @@ export enum ConnectionType {
  * being set by an automated process.
  */
 export interface ViyaProfile extends BaseProfile {
-  readonly connectionType: ConnectionType.Rest;
+  connectionType: ConnectionType.Rest;
   endpoint: string;
   clientId?: string;
   clientSecret?: string;
@@ -77,7 +77,7 @@ export interface ViyaProfile extends BaseProfile {
 }
 
 export interface SSHProfile extends BaseProfile {
-  readonly connectionType: ConnectionType.SSH;
+  connectionType: ConnectionType.SSH;
   host: string;
   saspath: string;
   port: number;
@@ -85,14 +85,13 @@ export interface SSHProfile extends BaseProfile {
 }
 
 export interface COMProfile extends BaseProfile {
-  readonly connectionType: ConnectionType.COM;
+  connectionType: ConnectionType.COM;
   host: string;
 }
 
 export type Profile = ViyaProfile | SSHProfile | COMProfile;
 
 export class BaseProfile {
-  readonly connectionType: ConnectionType;
   sasOptions?: string[];
 }
 
@@ -132,11 +131,8 @@ export class ProfileConfig {
       for (const key in profiles) {
         const profile = profiles[key];
         if (profile.connectionType === undefined) {
-          const migrated = {
-            connectionType: ConnectionType.Rest,
-            ...profile,
-          };
-          await this.upsertProfile(key, migrated);
+          profile.connectionType = ConnectionType.Rest;
+          await this.upsertProfile(key, profile);
         }
         if (
           profile.connectionType === ConnectionType.Rest &&

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -67,8 +67,8 @@ export enum ConnectionType {
  * value. Normally this option should not be set by the user since it is most likely
  * being set by an automated process.
  */
-export interface ViyaProfile {
-  connectionType: ConnectionType.Rest;
+export interface ViyaProfile extends BaseProfile {
+  readonly connectionType: ConnectionType.Rest;
   endpoint: string;
   clientId?: string;
   clientSecret?: string;
@@ -76,22 +76,25 @@ export interface ViyaProfile {
   serverId?: string;
 }
 
-export interface SSHProfile {
-  connectionType: ConnectionType.SSH;
+export interface SSHProfile extends BaseProfile {
+  readonly connectionType: ConnectionType.SSH;
   host: string;
   saspath: string;
   port: number;
   username: string;
-  sasOptions: string[];
 }
 
-export interface COMProfile {
-  connectionType: ConnectionType.COM;
+export interface COMProfile extends BaseProfile {
+  readonly connectionType: ConnectionType.COM;
   host: string;
-  sasOptions: string[];
 }
 
 export type Profile = ViyaProfile | SSHProfile | COMProfile;
+
+export class BaseProfile {
+  readonly connectionType: ConnectionType;
+  sasOptions?: string[];
+}
 
 /**
  * Profile detail is an interface that encapsulates the name of the profile
@@ -129,8 +132,11 @@ export class ProfileConfig {
       for (const key in profiles) {
         const profile = profiles[key];
         if (profile.connectionType === undefined) {
-          profile.connectionType = ConnectionType.Rest;
-          await this.upsertProfile(key, profile);
+          const migrated = {
+            connectionType: ConnectionType.Rest,
+            ...profile,
+          };
+          await this.upsertProfile(key, migrated);
         }
         if (
           profile.connectionType === ConnectionType.Rest &&

--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -18,7 +18,7 @@ let workDirectory: string;
  * Configuration parameters for this connection provider
  */
 export interface Config {
-  sasOptions: string[];
+  sasOptions?: string[];
   host: string;
 }
 

--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -64,7 +64,7 @@ const setup = async (): Promise<void> => {
         onWriteComplete
       );
 
-      if (config.sasOptions.length > 0) {
+      if (config.sasOptions?.length > 0) {
         const sasOptsInput = `$sasOpts=${formatSASOptions(
           config.sasOptions
         )}\n`;

--- a/client/src/connection/rest/server.ts
+++ b/client/src/connection/rest/server.ts
@@ -6,9 +6,16 @@ import { ServersApi, Server, Link } from "./api/compute";
 import { ComputeSession } from "./session";
 import axios, { AxiosResponse } from "axios";
 
+const DEFAULT_COMPUTE_OPTS = [
+  "-validmemname EXTEND",
+  "-validvarname ANY",
+  "-memsize 0",
+];
+
 export class ComputeServer extends Compute {
   api;
   _self: Server & BaseCompute;
+  _options?: string[];
 
   constructor(id: string) {
     super();
@@ -24,6 +31,10 @@ export class ComputeServer extends Compute {
 
   get links(): Array<Link> {
     return this._self?.links || [];
+  }
+
+  set options(value: string[]) {
+    this._options = value;
   }
 
   static fromInterface(server: Server): ComputeServer {
@@ -74,7 +85,7 @@ export class ComputeServer extends Compute {
       description: "This is a session",
       attributes: {},
       environment: {
-        options: ["-validmemname EXTEND", "-validvarname ANY", "-memsize 0"],
+        options: [...DEFAULT_COMPUTE_OPTS, ...this._options],
         autoExecLines: [],
       },
     };

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -12,7 +12,7 @@ export interface Config {
   host: string;
   username: string;
   saspath: string;
-  sasOptions: string[];
+  sasOptions?: string[];
   port: number;
 }
 

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -222,7 +222,7 @@ export class SSHSession implements Session {
 
     const resolvedSasOpts: string[] = ["-nodms", "-terminal", "-nosyntaxcheck"];
 
-    if (this._config.sasOptions) {
+    if (this._config.sasOptions?.length > 0) {
       resolvedSasOpts.push(...this._config.sasOptions);
     }
     const execSasOpts: string = resolvedSasOpts.join(" ");


### PR DESCRIPTION
**Summary**
Promotes sasOptions to a new BaseProfile interface so that all Connection Providers have access to it. Rest Connection Provider inspects new sasOptions profile to set them on the compute session api request if present.

**Testing**

1. Create a new rest connection profile with the following sasOptions: ```["-PAGESIZE=MAX"]```
Example:
```
"rest-conn": {
        "connectionType": "rest",
        "endpoint": "[...]",
        "reconnect": "true",
        "sasOptions": [
          "-PAGESIZE MAX"
        ]
      },
```
2. Run the following test code:
```proc print data=sashelp.cars; run;```
Should get 428 observations. Should see the Result tab with ODS results.
3. Run the following test code:
```proc options option=PAGESIZE value; run;```

Should get the following log output:
```
1    ods html5;
NOTE: Writing HTML5 Body file: sashtml.htm
2    proc options option=PAGESIZE value; run;

    SAS (r) Proprietary Software Release V.04.00M0D06132023

Option Value Information For SAS Option PAGESIZE
    Value: 32767
    Scope: SAS Session
    How option value set: SAS Session Startup Command Line

NOTE: PROCEDURE OPTIONS used (Total process time):
      real time           0.00 seconds
      cpu time            0.00 seconds
      

3    
4    ;run;quit;ods html5 close;
```
4. Close the connection. 
5. Change the sasOptions connection profile property to ```["-PAGESIZE MAX"]```.
6. Repeat steps 1-3 and verify that the same log output is observed.
