### PR TITLE
fix: fix copyright check script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Added support for `npm run copyright:check --fix`. This automatically prepends files with the corrrect copyright information.
+- Added support for `npm run copyright:check --fix`. This automatically prepends files with the correct copyright information.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If you introduce breaking changes, please group them together in the "Changed" section using the **BREAKING:** prefix.
 
+## [Unreleased]
+
+### Added
+
+- Added support for `npm run copyright:check --fix`. This automatically prepends files with the corrrect copyright information.
+
+### Fixed
+
+- Fixed an issue with `npm run copyright:check` where some files were not being validated.
+
 ## [v1.0.0] - 2023-06-16
 
 ### Added

--- a/client/src/components/ExtensionContext.ts
+++ b/client/src/components/ExtensionContext.ts
@@ -1,3 +1,6 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { ExtensionContext } from "vscode";
 
 let context: ExtensionContext;

--- a/client/src/connection/rest/identities.ts
+++ b/client/src/connection/rest/identities.ts
@@ -1,3 +1,6 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import axios from "axios";
 
 export interface User {

--- a/tools/check-copyright.mjs
+++ b/tools/check-copyright.mjs
@@ -3,13 +3,13 @@ import glob from "glob";
 
 // These files will not be checked for copyright information
 const filesToIgnore = [
+  "**/dist/**",
   "**/node_modules/**",
   "**/out/**",
-  "**/dist/**",
-  "tools/*",
+  "**/test/**",
   "*.config.js",
   "*.test.tsx?",
-  "**/test/**",
+  "tools/**",
 ];
 
 const COPYRIGHT_REGEX = /^\/\/ Copyright © ([0-9-\s]+), SAS Institute/;

--- a/tools/check-copyright.mjs
+++ b/tools/check-copyright.mjs
@@ -1,34 +1,49 @@
-import { exec } from "child_process";
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
+import glob from "glob";
 
-const INCLUDED_FILE_TYPES = /.*\.(mjs|js|ts|tsx|jsx)$/;
-const EXCLUDED_FILE_TYPES = /.*(\.test\.tsx?|check-copyright\.mjs)$/;
+// These files will not be checked for copyright information
+const filesToIgnore = [
+  "**/node_modules/**",
+  "**/out/**",
+  "**/dist/**",
+  "tools/*",
+  "*.config.js",
+  "*.test.tsx?",
+  "**/test/**",
+];
+
 const COPYRIGHT_REGEX = /^\/\/ Copyright © ([0-9-\s]+), SAS Institute/;
+const COPYRIGHT_TEMPLATE = `// Copyright © ${new Date().getFullYear()}, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
-const processChanges = (changedFiles) => {
-  const filesToCheck = changedFiles
-    .map((file) => file.trim())
-    .filter(
-      (file) =>
-        INCLUDED_FILE_TYPES.test(file) && !EXCLUDED_FILE_TYPES.test(file)
-    );
+`;
 
+const processChanges = (filesToCheck, fix = false) => {
   let invalidFiles = [];
   filesToCheck.map((file) => {
     const fileContents = readFileSync(file);
     if (!COPYRIGHT_REGEX.test(fileContents.toString())) {
       invalidFiles.push(file);
+      if (fix) {
+        writeFileSync(file, `${COPYRIGHT_TEMPLATE}${fileContents}`);
+      }
     }
   });
 
   if (invalidFiles.length > 0) {
-    console.log("The following files are missing copyright information");
+    console.log(
+      fix
+        ? "The following files have been updated with copyright information"
+        : "The following files are missing copyright information"
+    );
     console.log(invalidFiles.map((file) => `- ${file}`).join("\n"));
     process.exit(1);
   }
 };
 
-await exec(
-  `git diff origin/HEAD --diff-filter=A --name-only`,
-  async (error, stdout, stderr) => processChanges(stdout.split("\n"))
+await processChanges(
+  glob.sync("**/*.{mjs,js,ts,tsx,jsx}", {
+    ignore: filesToIgnore,
+  }),
+  process.env.npm_config_fix || false
 );


### PR DESCRIPTION
**Summary**
This updates our copyright check script to run on all _valid_ files, instead of those added in a recent commit. You can run this check manually via `npm run copyright:check`. This is also ran via github actions.

Additionally, this adds a fix flag (`npm run copyright:check --fix`) that will automatically prepend copyright information to files that are missing it.

**Testing**
- [x] Make sure github actions fails build (on first commit)
- [x] Make sure github actions passed on next build (after running `--fix`)
- [x] Make sure copyright appears on files
