### PR TITLE
feat: autoexec support for viya connection

### DIFF
--- a/client/src/commands/closeSession.ts
+++ b/client/src/commands/closeSession.ts
@@ -1,7 +1,8 @@
 // Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { window } from "vscode";
-import { getSession, Session } from "../connection";
+import { getSession } from "../connection";
+import { Session } from "../connection/session";
 
 export async function closeSession(message?: string): Promise<void> {
   let session: Session;

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -254,11 +254,13 @@ class ContentNavigator implements SubscriptionProvider {
             const activeProfile = profileConfig.getProfileByName(
               profileConfig.getActiveProfile()
             );
-            if (
-              activeProfile.connectionType === ConnectionType.Rest &&
-              !activeProfile.serverId
-            ) {
-              await this.contentDataProvider.connect(activeProfile.endpoint);
+            if (activeProfile) {
+              if (
+                activeProfile.connectionType === ConnectionType.Rest &&
+                !activeProfile.serverId
+              ) {
+                await this.contentDataProvider.connect(activeProfile.endpoint);
+              }
             }
           }
         }

--- a/client/src/components/notebook/Controller.ts
+++ b/client/src/components/notebook/Controller.ts
@@ -66,11 +66,13 @@ export class NotebookController {
     execution.start(Date.now()); // Keep track of elapsed time to execute cell.
 
     const session = getSession();
+    session.onLogFn = (logLines) => {
+      logs = logs.concat(logLines);
+    };
+
     let logs = [];
     try {
-      const result = await session.run(getCode(cell.document), (logLines) => {
-        logs = logs.concat(logLines);
-      });
+      const result = await session.run(getCode(cell.document));
 
       execution.replaceOutput([
         new vscode.NotebookCellOutput([

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -117,6 +117,7 @@ export interface BaseProfile {
 
 export const toAutoExecLines = (autoExec: AutoExec[]): string[] => {
   const lines: string[] = [];
+
   for (const item of autoExec) {
     switch (item.type) {
       case AutoExecType.Line:

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -127,9 +127,10 @@ export const toAutoExecLines = (autoExec: AutoExec[]): string[] => {
         lines.push(...toAutoExecLinesFromPaths(item.filePath));
         break;
       default:
-        return [];
+        break;
     }
   }
+  return lines;
 };
 
 /**

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -91,8 +91,9 @@ export interface COMProfile extends BaseProfile {
 
 export type Profile = ViyaProfile | SSHProfile | COMProfile;
 
-export class BaseProfile {
+export interface BaseProfile {
   sasOptions?: string[];
+  autoExec?: string[];
 }
 
 /**

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -138,7 +138,7 @@ export const toAutoExecLines = (autoExec: AutoExec): string[] => {
  */
 const toAutoExecLinesFromPaths = (paths: string[]): string[] => {
   const lines: string[] = [];
-  for (const filePath in paths) {
+  for (const filePath of paths) {
     try {
       const content = readFileSync(filePath, "utf8").split(/\n|\r\n/);
       lines.push(...content);

--- a/client/src/components/profile.ts
+++ b/client/src/components/profile.ts
@@ -94,35 +94,40 @@ export interface COMProfile extends BaseProfile {
 export type Profile = ViyaProfile | SSHProfile | COMProfile;
 
 export enum AutoExecType {
-  Files = "files",
-  Lines = "lines",
+  File = "file",
+  Line = "line",
 }
 
-export type AutoExec = AutoExecLines | AutoExecFiles;
+export type AutoExec = AutoExecLine | AutoExecFile;
 
-export interface AutoExecLines {
-  type: AutoExecType.Lines;
-  lines: string[];
+export interface AutoExecLine {
+  type: AutoExecType.Line;
+  line: string;
 }
 
-export interface AutoExecFiles {
-  type: AutoExecType.Files;
-  filePaths: string[];
+export interface AutoExecFile {
+  type: AutoExecType.File;
+  filePath: string;
 }
 
 export interface BaseProfile {
   sasOptions?: string[];
-  autoExec?: AutoExec;
+  autoExec?: AutoExec[];
 }
 
-export const toAutoExecLines = (autoExec: AutoExec): string[] => {
-  switch (autoExec.type) {
-    case AutoExecType.Lines:
-      return autoExec.lines;
-    case AutoExecType.Files:
-      return toAutoExecLinesFromPaths(autoExec.filePaths);
-    default:
-      return [];
+export const toAutoExecLines = (autoExec: AutoExec[]): string[] => {
+  const lines: string[] = [];
+  for (const item of autoExec) {
+    switch (item.type) {
+      case AutoExecType.Line:
+        lines.push(item.line);
+        break;
+      case AutoExecType.File:
+        lines.push(...toAutoExecLinesFromPaths(item.filePath));
+        break;
+      default:
+        return [];
+    }
   }
 };
 
@@ -136,18 +141,16 @@ export const toAutoExecLines = (autoExec: AutoExec): string[] => {
  * @param paths string array of paths to read content from.
  * @returns string array of lines
  */
-const toAutoExecLinesFromPaths = (paths: string[]): string[] => {
+const toAutoExecLinesFromPaths = (filePath: string): string[] => {
   const lines: string[] = [];
-  for (const filePath of paths) {
-    try {
-      const content = readFileSync(filePath, "utf8").split(/\n|\r\n/);
-      lines.push(...content);
-    } catch (e) {
-      const err: Error = e;
-      console.warn(
-        `Error reading file: ${filePath}, error: ${err.message}, skipping...`
-      );
-    }
+  try {
+    const content = readFileSync(filePath, "utf8").split(/\n|\r\n/);
+    lines.push(...content);
+  } catch (e) {
+    const err: Error = e;
+    console.warn(
+      `Error reading file: ${filePath}, error: ${err.message}, skipping...`
+    );
   }
   return lines;
 };

--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -4,7 +4,7 @@
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import { LogLine, RunResult, Session } from "..";
+import { BaseConfig, LogLine, RunResult, Session } from "..";
 import { scriptContent } from "./script";
 
 const endCode = "--vscode-sas-extension-submit-end--";
@@ -20,8 +20,7 @@ let workDirectory: string;
 /**
  * Configuration parameters for this connection provider
  */
-export interface Config {
-  sasOptions?: string[];
+export interface Config extends BaseConfig {
   host: string;
 }
 

--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -9,6 +9,7 @@ import { scriptContent } from "./script";
 import { BaseSession, Session } from "../session";
 
 const endCode = "--vscode-sas-extension-submit-end--";
+let sessionInstance: COMSession;
 
 /**
  * Configuration parameters for this connection provider
@@ -25,10 +26,14 @@ export class COMSession extends BaseSession implements Session {
   private _runReject: ((reason?) => void) | undefined;
   private _workDirectory: string;
 
-  constructor(c: Config) {
+  constructor() {
     super();
-    this._config = c;
   }
+
+  public set config(value: Config) {
+    this._config = value;
+  }
+
   /**
    * Initialization logic that should be performed prior to execution.
    * @returns void promise.
@@ -255,8 +260,12 @@ do {
 /**
  * Creates a new SAS 9 Local Session.
  * @param c Instance denoting configuration parameters for this connection profile.
- * @returns  void
+ * @returns  created COM session.
  */
 export const getSession = (c: Config): Session => {
-  return new COMSession(c);
+  if (!sessionInstance) {
+    sessionInstance = new COMSession();
+  }
+  sessionInstance.config = c;
+  return sessionInstance;
 };

--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -6,7 +6,7 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 import { BaseConfig, RunResult } from "..";
 import { scriptContent } from "./script";
-import { BaseSession, Session } from "../session";
+import { Session } from "../session";
 
 const endCode = "--vscode-sas-extension-submit-end--";
 let sessionInstance: COMSession;
@@ -18,7 +18,7 @@ export interface Config extends BaseConfig {
   host: string;
 }
 
-export class COMSession extends BaseSession implements Session {
+export class COMSession extends Session {
   private _config: Config;
   private _shellProcess: ChildProcessWithoutNullStreams;
   private _html5FileName: string;
@@ -153,6 +153,13 @@ export class COMSession extends BaseSession implements Session {
       resolve();
     });
   };
+
+  /**
+   * Cancel a running code execution.
+   */
+  public cancel(): Promise<void> {
+    throw new Error("Not Implemented");
+  }
 
   /**
    * Formats the SAS Options provided in the profile into a format

--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -4,18 +4,11 @@
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import { BaseConfig, LogLine, RunResult, Session } from "..";
+import { BaseConfig, RunResult } from "..";
 import { scriptContent } from "./script";
+import { BaseSession, Session } from "../session";
 
 const endCode = "--vscode-sas-extension-submit-end--";
-
-let config: Config;
-let shellProcess: ChildProcessWithoutNullStreams;
-let onLogFn: (logs: LogLine[]) => void;
-let html5FileName: string;
-let runResolve: ((value?) => void) | undefined;
-let runReject: ((reason?) => void) | undefined;
-let workDirectory: string;
 
 /**
  * Configuration parameters for this connection provider
@@ -24,227 +17,240 @@ export interface Config extends BaseConfig {
   host: string;
 }
 
-/**
- * Initialization logic that should be performed prior to execution.
- * @returns void promise.
- */
-const setup = async (): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    runResolve = resolve;
-    runReject = reject;
+export class COMSession extends BaseSession implements Session {
+  private _config: Config;
+  private _shellProcess: ChildProcessWithoutNullStreams;
+  private _html5FileName: string;
+  private _runResolve: ((value?) => void) | undefined;
+  private _runReject: ((reason?) => void) | undefined;
+  private _workDirectory: string;
 
-    if (shellProcess && !shellProcess.killed) {
-      resolve();
-      return; //manually terminate to avoid executing the code below
-    }
+  constructor(c: Config) {
+    super();
+    this._config = c;
+  }
+  /**
+   * Initialization logic that should be performed prior to execution.
+   * @returns void promise.
+   */
+  public setup = async (): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      this._runResolve = resolve;
+      this._runReject = reject;
 
-    shellProcess = spawn("powershell.exe /nologo -Command -", {
-      shell: true,
-      env: process.env,
-    });
-    shellProcess.stdout.on("data", onShellStdOut);
-    shellProcess.stderr.on("data", onShellStdErr);
-    shellProcess.stdin.write(scriptContent + "\n", onWriteComplete);
-    shellProcess.stdin.write(
-      "$runner = New-Object -TypeName SASRunner\n",
-      onWriteComplete
-    );
+      if (this._shellProcess && !this._shellProcess.killed) {
+        resolve();
+        return; //manually terminate to avoid executing the code below
+      }
 
-    /*
+      this._shellProcess = spawn("powershell.exe /nologo -Command -", {
+        shell: true,
+        env: process.env,
+      });
+      this._shellProcess.stdout.on("data", this.onShellStdOut);
+      this._shellProcess.stderr.on("data", this.onShellStdErr);
+      this._shellProcess.stdin.write(
+        scriptContent + "\n",
+        this.onWriteComplete
+      );
+      this._shellProcess.stdin.write(
+        "$runner = New-Object -TypeName SASRunner\n",
+        this.onWriteComplete
+      );
+
+      /*
     There are cases where the higher level run command will invoke setup multiple times.
     Avoid re-initializing the session when this happens. In a first run scenario a work dir
     will not exist. The work dir should only be deleted when close is invoked.
     */
-    if (!workDirectory) {
-      shellProcess.stdin.write(`$profileHost = "${config.host}"\n`);
-      shellProcess.stdin.write(
-        "$runner.Setup($profileHost)\n",
-        onWriteComplete
-      );
-      shellProcess.stdin.write(
-        "$runner.ResolveSystemVars()\n",
-        onWriteComplete
-      );
-
-      if (config.sasOptions?.length > 0) {
-        const sasOptsInput = `$sasOpts=${formatSASOptions(
-          config.sasOptions
-        )}\n`;
-        shellProcess.stdin.write(sasOptsInput, onWriteComplete);
-        shellProcess.stdin.write(
-          `$runner.SetOptions($sasOpts)\n`,
-          onWriteComplete
+      if (!this._workDirectory) {
+        this._shellProcess.stdin.write(
+          `$profileHost = "${this._config.host}"\n`
         );
-      }
-    }
+        this._shellProcess.stdin.write(
+          "$runner.Setup($profileHost)\n",
+          this.onWriteComplete
+        );
+        this._shellProcess.stdin.write(
+          "$runner.ResolveSystemVars()\n",
+          this.onWriteComplete
+        );
 
-    // free objects in the scripting env
-    process.on("exit", async () => {
-      await close();
+        if (this._config.sasOptions?.length > 0) {
+          const sasOptsInput = `$sasOpts=${this.formatSASOptions(
+            this._config.sasOptions
+          )}\n`;
+          this._shellProcess.stdin.write(sasOptsInput, this.onWriteComplete);
+          this._shellProcess.stdin.write(
+            `$runner.SetOptions($sasOpts)\n`,
+            this.onWriteComplete
+          );
+        }
+      }
+
+      // free objects in the scripting env
+      process.on("exit", async () => {
+        close();
+      });
     });
-  });
-};
+  };
 
-/**
- * Formats the SAS Options provided in the profile into a format
- * that the shell process can understand.
- * @param sasOptions SAS Options array from the connection profile.
- * @returns a string  denoting powershell syntax for an array literal.
- */
-const formatSASOptions = (sasOptions: string[]): string => {
-  const optionsVariable = `@("${sasOptions.join(`","`)}")`;
-  return optionsVariable;
-};
+  /**
+   * Executes the given input code.
+   * @param code A string of SAS code to execute.
+   * @param onLog A callback handler responsible for marshalling log lines back to the higher level extension API.
+   * @returns A promise that eventually resolves to contain the given {@link RunResult} for the input code execution.
+   */
+  public run = async (code: string): Promise<RunResult> => {
+    return new Promise((resolve, reject) => {
+      this._runResolve = resolve;
+      this._runReject = reject;
 
-/**
- * Handles stderr output from the powershell child process.
- * @param chunk a buffer of stderr output from the child process.
- */
-const onShellStdErr = (chunk: Buffer): void => {
-  const msg = chunk.toString();
-  console.warn("shellProcess stderr: " + msg);
-  runReject(
-    new Error(
-      "There was an error executing the SAS Program.\nSee console log for more details."
-    )
-  );
-};
+      //write ODS output to work so that the session cleans up after itself
+      const codeWithODSPath = code.replace(
+        "ods html5;",
+        `ods html5 path="${this._workDirectory}";`
+      );
 
-/**
- * Generic call for use on stdin write completion.
- * @param err The error encountered on the write attempt. Undefined if no error occurred.
- */
-const onWriteComplete = (err: Error): void => {
-  if (err) {
-    runReject?.(err);
-  }
-};
+      //write an end mnemonic so that the handler knows when execution has finished
+      const codeWithEnd = `${codeWithODSPath}\n%put ${endCode};`;
+      const codeToRun = `$code=@"\n${codeWithEnd}\n"@\n`;
 
-/**
- * Handles stdout output from the powershell child process.
- * @param data a buffer of stdout output from the child process.
- */
-const onShellStdOut = (data: Buffer): void => {
-  const output = data.toString().trimEnd();
-  const outputLines = output.split(/\n|\r\n/);
-  if (onLogFn) {
-    outputLines.forEach((line: string) => {
-      if (!line) {
-        return;
-      }
-      if (line.endsWith(endCode)) {
-        // run completed
-        fetchResults();
-      } else {
-        html5FileName =
-          line.match(/NOTE: .+ HTML5.* Body .+: (.+)\.htm/)?.[1] ??
-          html5FileName;
-        onLogFn?.([{ type: "normal", line }]);
-      }
+      this._shellProcess.stdin.write(codeToRun);
+      this._shellProcess.stdin.write(`$runner.Run($code)\n`, async (error) => {
+        if (error) {
+          this._runReject(error);
+        }
+
+        await this.fetchLog();
+      });
     });
-  } else {
-    outputLines.forEach((line) => {
-      if (line.startsWith("WORKDIR=")) {
-        const parts = line.split("WORKDIR=");
-        workDirectory = parts[1].trim();
-        runResolve();
-        return;
-      }
-    });
-  }
-};
+  };
 
-/**
- * Flushes the SAS log in chunks of [chunkSize] length,
- * writing each chunk to stdout.
- */
-const fetchLog = async (): Promise<void> => {
-  shellProcess.stdin.write(
-    `
+  /**
+   * Cleans up resources for the given local SAS session.
+   * @returns void promise.
+   */
+  public close = async (): Promise<void> => {
+    return new Promise((resolve) => {
+      if (this._shellProcess) {
+        this._shellProcess.stdin.write(
+          "$runner.Close()\n",
+          this.onWriteComplete
+        );
+        this._shellProcess.kill();
+        this._shellProcess = undefined;
+
+        this._workDirectory = undefined;
+        this._runReject = undefined;
+        this._runResolve = undefined;
+      }
+      resolve();
+    });
+  };
+
+  /**
+   * Formats the SAS Options provided in the profile into a format
+   * that the shell process can understand.
+   * @param sasOptions SAS Options array from the connection profile.
+   * @returns a string  denoting powershell syntax for an array literal.
+   */
+  private formatSASOptions = (sasOptions: string[]): string => {
+    const optionsVariable = `@("${sasOptions.join(`","`)}")`;
+    return optionsVariable;
+  };
+
+  /**
+   * Flushes the SAS log in chunks of [chunkSize] length,
+   * writing each chunk to stdout.
+   */
+  private fetchLog = async (): Promise<void> => {
+    this._shellProcess.stdin.write(
+      `
 do {
   $chunkSize = 32768
   $log = $runner.FlushLog($chunkSize)
   Write-Host $log
 } while ($log.Length -gt 0)\n
   `,
-    onWriteComplete
-  );
-};
-
-/**
- * Executes the given input code.
- * @param code A string of SAS code to execute.
- * @param onLog A callback handler responsible for marshalling log lines back to the higher level extension API.
- * @returns A promise that eventually resolves to contain the given {@link RunResult} for the input code execution.
- */
-const run = async (
-  code: string,
-  onLog?: (logs: LogLine[]) => void
-): Promise<RunResult> => {
-  onLogFn = onLog;
-  return new Promise((resolve, reject) => {
-    runResolve = resolve;
-    runReject = reject;
-
-    //write ODS output to work so that the session cleans up after itself
-    const codeWithODSPath = code.replace(
-      "ods html5;",
-      `ods html5 path="${workDirectory}";`
+      this.onWriteComplete
     );
+  };
 
-    //write an end mnemonic so that the handler knows when execution has finished
-    const codeWithEnd = `${codeWithODSPath}\n%put ${endCode};`;
-    const codeToRun = `$code=@"\n${codeWithEnd}\n"@\n`;
+  /**
+   * Handles stderr output from the powershell child process.
+   * @param chunk a buffer of stderr output from the child process.
+   */
+  private onShellStdErr = (chunk: Buffer): void => {
+    const msg = chunk.toString();
+    console.warn("shellProcess stderr: " + msg);
+    this._runReject(
+      new Error(
+        "There was an error executing the SAS Program.\nSee console log for more details."
+      )
+    );
+  };
 
-    shellProcess.stdin.write(codeToRun);
-    shellProcess.stdin.write(`$runner.Run($code)\n`, async (error) => {
-      if (error) {
-        runReject(error);
-      }
-
-      await fetchLog();
-    });
-  });
-};
-
-/**
- * Cleans up resources for the given local SAS session.
- * @returns void promise.
- */
-const close = async (): Promise<void> => {
-  return new Promise((resolve) => {
-    if (shellProcess) {
-      shellProcess.stdin.write("$runner.Close()\n", onWriteComplete);
-      shellProcess.kill();
-      shellProcess = undefined;
-
-      workDirectory = undefined;
-      runReject = undefined;
-      runResolve = undefined;
-      onLogFn = undefined;
+  /**
+   * Handles stdout output from the powershell child process.
+   * @param data a buffer of stdout output from the child process.
+   */
+  private onShellStdOut = (data: Buffer): void => {
+    const output = data.toString().trimEnd();
+    const outputLines = output.split(/\n|\r\n/);
+    if (this._onLogFn) {
+      outputLines.forEach((line: string) => {
+        if (!line) {
+          return;
+        }
+        if (line.startsWith("WORKDIR=")) {
+          const parts = line.split("WORKDIR=");
+          this._workDirectory = parts[1].trim();
+          this._runResolve();
+          return;
+        }
+        if (line.endsWith(endCode)) {
+          // run completed
+          this.fetchResults();
+        } else {
+          this._html5FileName =
+            line.match(/NOTE: .+ HTML5.* Body .+: (.+)\.htm/)?.[1] ??
+            this._html5FileName;
+          this._onLogFn?.([{ type: "normal", line }]);
+        }
+      });
     }
-    resolve();
-  });
-};
+  };
 
-/**
- * Not implemented.
- */
-const sessionId = (): string => {
-  throw new Error("Not Implemented");
-};
+  /**
+   * Generic call for use on stdin write completion.
+   * @param err The error encountered on the write attempt. Undefined if no error occurred.
+   */
+  private onWriteComplete = (err: Error): void => {
+    if (err) {
+      this._runReject?.(err);
+    }
+  };
 
-/**
- * Fetches the ODS output results for the latest html results file.
- */
-const fetchResults = () => {
-  const htmlResults = readFileSync(
-    resolve(workDirectory, html5FileName + ".htm"),
-    { encoding: "utf-8" }
-  );
-  const runResult: RunResult = { html5: htmlResults, title: "Results" };
-  runResolve(runResult);
-};
+  /**
+   * Not implemented.
+   */
+  public sessionId = (): string => {
+    throw new Error("Not Implemented");
+  };
+
+  /**
+   * Fetches the ODS output results for the latest html results file.
+   */
+  private fetchResults = () => {
+    const htmlResults = readFileSync(
+      resolve(this._workDirectory, this._html5FileName + ".htm"),
+      { encoding: "utf-8" }
+    );
+    const runResult: RunResult = { html5: htmlResults, title: "Results" };
+    this._runResolve(runResult);
+  };
+}
 
 /**
  * Creates a new SAS 9 Local Session.
@@ -252,11 +258,5 @@ const fetchResults = () => {
  * @returns  void
  */
 export const getSession = (c: Config): Session => {
-  config = c;
-  return {
-    setup,
-    run,
-    close,
-    sessionId,
-  };
+  return new COMSession(c);
 };

--- a/client/src/connection/index.ts
+++ b/client/src/connection/index.ts
@@ -28,6 +28,11 @@ export interface Session {
   sessionId?(): string | undefined;
 }
 
+export interface BaseConfig {
+  sasOptions?: string[];
+  autoExecLines?: string[];
+}
+
 export function getSession(): Session {
   if (!profileConfig) {
     profileConfig = new ProfileConfig();

--- a/client/src/connection/index.ts
+++ b/client/src/connection/index.ts
@@ -5,10 +5,16 @@ import {
   LogLine as ComputeLogLine,
   LogLineTypeEnum as ComputeLogLineTypeEnum,
 } from "./rest/api/compute";
-import { getSession as getRestSession } from "./rest";
+import { getSession as getRestSession, Config as RestConfig } from "./rest";
 import { getSession as getSSHSession } from "./ssh";
 import { getSession as getCOMSession } from "./com";
-import { AuthType, ConnectionType, ProfileConfig } from "../components/profile";
+import {
+  AuthType,
+  ConnectionType,
+  ProfileConfig,
+  ViyaProfile,
+  toAutoExecLines,
+} from "../components/profile";
 
 let profileConfig: ProfileConfig;
 
@@ -47,7 +53,7 @@ export function getSession(): Session {
 
   switch (validProfile.profile?.connectionType) {
     case ConnectionType.Rest:
-      return getRestSession(validProfile.profile);
+      return getRestSession(toRestConfig(validProfile.profile));
     case ConnectionType.SSH:
       return getSSHSession(validProfile.profile);
     case ConnectionType.COM:
@@ -55,4 +61,15 @@ export function getSession(): Session {
     default:
       throw new Error("Invalid connectionType. Check Profile settings.");
   }
+}
+
+/**
+ * Translates a {@link ViyaProfile} interface to a {@link RestConfig} interface.
+ * @param profile an input {@link ViyaProfile} to translate.
+ * @returns RestConfig instance derived from the input profile.
+ */
+function toRestConfig(profile: ViyaProfile): RestConfig {
+  const mapped: RestConfig = profile;
+  mapped.autoExecLines = toAutoExecLines(profile.autoExec);
+  return mapped;
 }

--- a/client/src/connection/index.ts
+++ b/client/src/connection/index.ts
@@ -15,23 +15,17 @@ import {
   ViyaProfile,
   toAutoExecLines,
 } from "../components/profile";
+import { Session } from "./session";
 
 let profileConfig: ProfileConfig;
 
 export type LogLine = ComputeLogLine;
 export type LogLineTypeEnum = ComputeLogLineTypeEnum;
+export type OnLogFn = (logs: LogLine[]) => void;
 
 export interface RunResult {
   html5?: string;
   title?: string;
-}
-
-export interface Session {
-  setup(): Promise<void>;
-  run(code: string, onLog?: (logs: LogLine[]) => void): Promise<RunResult>;
-  cancel?(): Promise<void>;
-  close(): Promise<void> | void;
-  sessionId?(): string | undefined;
 }
 
 export interface BaseConfig {

--- a/client/src/connection/index.ts
+++ b/client/src/connection/index.ts
@@ -64,6 +64,8 @@ export function getSession(): Session {
  */
 function toRestConfig(profile: ViyaProfile): RestConfig {
   const mapped: RestConfig = profile;
-  mapped.autoExecLines = toAutoExecLines(profile.autoExec);
+  if (profile.autoExec) {
+    mapped.autoExecLines = toAutoExecLines(profile.autoExec);
+  }
   return mapped;
 }

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -13,7 +13,7 @@ import { ComputeState, getApiConfig } from "./common";
 import { ComputeJob } from "./job";
 import { ComputeServer } from "./server";
 import { ComputeSession } from "./session";
-import { BaseSession, Session } from "../session";
+import { Session } from "../session";
 
 let sessionInstance: RestSession;
 
@@ -26,7 +26,7 @@ export interface Config extends BaseConfig {
   reconnect?: boolean;
 }
 
-class RestSession extends BaseSession implements Session {
+class RestSession extends Session {
   private _config: Config;
   private _computeSession: ComputeSession | undefined;
 

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { authentication } from "vscode";
-import { BaseConfig, RunResult, Session } from "..";
+import { BaseConfig, RunResult } from "..";
 import { SASAuthProvider } from "../../components/AuthProvider";
 import {
   getContextValue,
@@ -13,6 +13,7 @@ import { ComputeState, getApiConfig } from "./common";
 import { ComputeJob } from "./job";
 import { ComputeServer } from "./server";
 import { ComputeSession } from "./session";
+import { BaseSession, Session } from "../session";
 
 export interface Config extends BaseConfig {
   endpoint: string;
@@ -23,173 +24,246 @@ export interface Config extends BaseConfig {
   reconnect?: boolean;
 }
 
-let config: Config;
-let computeSession: ComputeSession | undefined;
+class RestSession extends BaseSession implements Session {
+  private _config: Config;
+  private _computeSession: ComputeSession | undefined;
 
-async function reconnectComputeSession(): Promise<ComputeSession> {
-  let session: ComputeSession = undefined;
-
-  if (!config.reconnect) {
-    return undefined;
+  constructor(c: Config) {
+    super();
+    this._config = c;
   }
 
-  //Grab the sessionId
-  const sessionId: string = await getContextValue("SAS.sessionId");
-
-  if (sessionId === undefined) {
-    //No sessionId in the cache means nothing to reconnect to
-    return undefined;
-  }
-
-  //At this point a sessionId was retrieved, so try and re-connect
-
-  if (config.serverId) {
-    const computeServer = new ComputeServer(config.serverId);
-
-    try {
-      session = await computeServer.getSession(sessionId);
-    } catch (error) {
-      console.log(
-        `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
-      );
-    }
-  } else {
+  public setup = async (): Promise<void> => {
     const apiConfig = getApiConfig();
-    const sessions = SessionsApi(apiConfig);
+    let formattedOpts: string[] = [];
+    const autoExecLines = this._config.autoExecLines || [];
 
-    try {
-      const mySession = (await sessions.getSession({ sessionId: sessionId }))
-        .data;
-      session = ComputeSession.fromInterface(mySession);
-    } catch (error) {
-      console.log(
-        `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
-      );
-    }
-  }
-
-  if (session === undefined) {
-    //If we tried to reconnect and failed, set the cached sessionId to undefined
-    setContextValue("SAS.sessionId", undefined);
-  }
-
-  return session;
-}
-
-async function setup(): Promise<void> {
-  const apiConfig = getApiConfig();
-  let formattedOpts: string[] = [];
-  const autoExecLines = config.autoExecLines || [];
-
-  if (config.sasOptions) {
-    formattedOpts = formatSASOptions();
-  }
-
-  if (!config.serverId) {
-    const session = await authentication.getSession(SASAuthProvider.id, [], {
-      createIfNone: true,
-    });
-    apiConfig.accessToken = session.accessToken;
-  }
-
-  if (computeSession && computeSession.sessionId) {
-    const state = await computeSession
-      .getState()
-      .catch(() => (computeSession = undefined));
-    if (state === ComputeState.Error) {
-      await computeSession.cancel();
-    } else if (computeSession !== undefined) {
-      //This might look weird, but I dont know how to detect the session being in
-      //syntax check mode right now so we need to send the cancel every time to make
-      //sure the session is in a good state.
-      await computeSession.cancel();
-    }
-  }
-
-  if (computeSession) {
-    return;
-  }
-
-  //Set the locale in the base options so it appears on all api calls
-  const locale = JSON.parse(process.env.VSCODE_NLS_CONFIG ?? "{}").locale;
-  apiConfig.baseOptions.headers = { "Accept-Language": locale };
-
-  //Check to see if we can reconnect to a session first
-  computeSession = await reconnectComputeSession();
-  if (computeSession) {
-    //reconnected to a running session, so just return
-    return;
-  }
-
-  //Start a new session
-  if (config.serverId) {
-    const server1 = new ComputeServer(config.serverId);
-    server1.options = formattedOpts;
-    server1.autoExecLines = config.autoExecLines;
-    computeSession = await server1.getSession();
-
-    //Maybe wait for session to be initialized?
-  } else {
-    //Create session from context
-    const contextsApi = ContextsApi(apiConfig);
-    const contextName = config.context || "SAS Job Execution compute context";
-    const context = (
-      await contextsApi.getContexts({
-        filter: `eq(name,'${contextName}')`,
-      })
-    ).data.items[0];
-    if (!context?.id) {
-      throw new Error("Compute Context not found: " + contextName);
+    if (this._config.sasOptions) {
+      formattedOpts = this.formatSASOptions();
     }
 
-    const sess = (
-      await contextsApi.createSession(
-        {
-          contextId: context.id,
-          sessionRequest: {
-            environment: {
-              options: [...formattedOpts],
-              autoExecLines: [...autoExecLines],
+    if (!this._config.serverId) {
+      const session = await authentication.getSession(SASAuthProvider.id, [], {
+        createIfNone: true,
+      });
+      apiConfig.accessToken = session.accessToken;
+    }
+
+    if (this._computeSession && this._computeSession.sessionId) {
+      const state = await this._computeSession
+        .getState()
+        .catch(() => (this._computeSession = undefined));
+      if (state === ComputeState.Error) {
+        await this._computeSession.cancel();
+      } else if (this._computeSession !== undefined) {
+        //This might look weird, but I dont know how to detect the session being in
+        //syntax check mode right now so we need to send the cancel every time to make
+        //sure the session is in a good state.
+        await this._computeSession.cancel();
+      }
+    }
+
+    if (this._computeSession) {
+      return;
+    }
+
+    //Set the locale in the base options so it appears on all api calls
+    const locale = JSON.parse(process.env.VSCODE_NLS_CONFIG ?? "{}").locale;
+    apiConfig.baseOptions.headers = { "Accept-Language": locale };
+
+    //Check to see if we can reconnect to a session first
+    this._computeSession = await this.reconnectComputeSession();
+    if (this._computeSession) {
+      //reconnected to a running session, so just return
+      return;
+    }
+
+    //Start a new session
+    if (this._config.serverId) {
+      const server1 = new ComputeServer(this._config.serverId);
+      server1.options = formattedOpts;
+      server1.autoExecLines = this._config.autoExecLines;
+      this._computeSession = await server1.getSession();
+
+      //Maybe wait for session to be initialized?
+    } else {
+      //Create session from context
+      const contextsApi = ContextsApi(apiConfig);
+      const contextName =
+        this._config.context || "SAS Job Execution compute context";
+      const context = (
+        await contextsApi.getContexts({
+          filter: `eq(name,'${contextName}')`,
+        })
+      ).data.items[0];
+      if (!context?.id) {
+        throw new Error("Compute Context not found: " + contextName);
+      }
+
+      const sess = (
+        await contextsApi.createSession(
+          {
+            contextId: context.id,
+            sessionRequest: {
+              environment: {
+                options: [...formattedOpts],
+                autoExecLines: [...autoExecLines],
+              },
             },
           },
-        },
-        { headers: { "accept-language": locale } }
-      )
-    ).data;
-    computeSession = ComputeSession.fromInterface(sess);
-  }
+          { headers: { "accept-language": locale } }
+        )
+      ).data;
+      this._computeSession = ComputeSession.fromInterface(sess);
+    }
 
-  //Save the current sessionId
-  setContextValue("SAS.sessionId", computeSession.sessionId);
-}
+    //Save the current sessionId
+    setContextValue("SAS.sessionId", this._computeSession.sessionId);
+  };
 
-/**
- * Formats the connection profile sasOptions into a format that the compute
- * API can understand.
- *
- * Examples:
- *
- * ```
- * ["-PAGESIZE=MAX"] -> ["-PAGESIZE MAX"]
- * ["-NOTERMINAL"] -> ["-NOTERMINAL"]
- * ```
- *
- * @returns formatted SAS Options
- */
-function formatSASOptions() {
-  const formattedOpts = config.sasOptions.map((opt) => {
-    let formatted = opt;
-    formatted = formatted.replace(/=/gi, " ");
-    return formatted;
-  });
-  return formattedOpts;
-}
+  public run = async (code: string) => {
+    if (!this._computeSession?.sessionId) {
+      throw new Error();
+    }
 
-async function cancel(): Promise<void> {
-  if (computeSession) {
-    await computeSession.self();
-    await computeSession.cancel();
-  }
+    //Get the job
+    const job = await this._computeSession.execute({ code: [code] });
+    let state = await job.getState();
+
+    const retLog = printLog(job, this._onLogFn);
+
+    //Wait until the job is complete
+    do {
+      state = await job.getState({ onChange: true, wait: 2 });
+    } while (await job.isDone(state));
+
+    //Clear out the logs
+    await retLog;
+
+    //Now get the results
+    const results = state === ComputeState.Error ? [] : await job.results();
+
+    const res: RunResult = {
+      html5: "",
+      title: "",
+    };
+
+    /*
+      We can return more than just html, but for right now we are only returning
+      the last HTML file that we get.
+      The last one is returned so that the one created from the vscode injected ods statement is
+      always returned.
+    */
+    for (const result of results.reverse()) {
+      const link = result.links[0];
+      if (link?.type === "text/html") {
+        const html5 = (await job.requestLink<string>(link)).data;
+
+        //Make sure that the html has a valid body
+        if (html5.search('<*id="IDX*.+">') !== -1) {
+          res.html5 = html5;
+          res.title = result.name;
+        }
+
+        break;
+      }
+    }
+
+    return res;
+  };
+
+  public close = async () => {
+    if (this.sessionId()) {
+      this._computeSession.delete();
+      this._computeSession = undefined;
+
+      //Since the session is being closed, remove the cached session id
+      setContextValue("SAS.sessionId", undefined);
+    }
+  };
+
+  public sessionId = (): string => {
+    return this._computeSession && this._computeSession.sessionId;
+  };
+
+  public cancel = async (): Promise<void> => {
+    if (this._computeSession) {
+      await this._computeSession.self();
+      await this._computeSession.cancel();
+    }
+  };
+
+  /**
+   * Formats the connection profile sasOptions into a format that the compute
+   * API can understand.
+   *
+   * Examples:
+   *
+   * ```
+   * ["-PAGESIZE=MAX"] -> ["-PAGESIZE MAX"]
+   * ["-NOTERMINAL"] -> ["-NOTERMINAL"]
+   * ```
+   *
+   * @returns formatted SAS Options
+   */
+  private formatSASOptions = (): string[] => {
+    const formattedOpts = this._config.sasOptions.map((opt) => {
+      let formatted = opt;
+      formatted = formatted.replace(/=/gi, " ");
+      return formatted;
+    });
+    return formattedOpts;
+  };
+
+  private reconnectComputeSession = async (): Promise<ComputeSession> => {
+    let session: ComputeSession = undefined;
+
+    if (!this._config.reconnect) {
+      return undefined;
+    }
+
+    //Grab the sessionId
+    const sessionId: string = await getContextValue("SAS.sessionId");
+
+    if (sessionId === undefined) {
+      //No sessionId in the cache means nothing to reconnect to
+      return undefined;
+    }
+
+    //At this point a sessionId was retrieved, so try and re-connect
+
+    if (this._config.serverId) {
+      const computeServer = new ComputeServer(this._config.serverId);
+
+      try {
+        session = await computeServer.getSession(sessionId);
+      } catch (error) {
+        console.log(
+          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
+        );
+      }
+    } else {
+      const apiConfig = getApiConfig();
+      const sessions = SessionsApi(apiConfig);
+
+      try {
+        const mySession = (await sessions.getSession({ sessionId: sessionId }))
+          .data;
+        session = ComputeSession.fromInterface(mySession);
+      } catch (error) {
+        console.log(
+          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
+        );
+      }
+    }
+
+    if (session === undefined) {
+      //If we tried to reconnect and failed, set the cached sessionId to undefined
+      setContextValue("SAS.sessionId", undefined);
+    }
+
+    return session;
+  };
 }
 
 /*
@@ -202,80 +276,8 @@ async function printLog(job: ComputeJob, onLog?: (logs: LogLine[]) => void) {
   }
 }
 
-async function run(code: string, onLog?: (logs: LogLine[]) => void) {
-  if (!computeSession?.sessionId) {
-    throw new Error();
-  }
-
-  //Get the job
-  const job = await computeSession.execute({ code: [code] });
-  let state = await job.getState();
-
-  const retLog = printLog(job, onLog);
-
-  //Wait until the job is complete
-  do {
-    state = await job.getState({ onChange: true, wait: 2 });
-  } while (await job.isDone(state));
-
-  //Clear out the logs
-  await retLog;
-
-  //Now get the results
-  const results = state === ComputeState.Error ? [] : await job.results();
-
-  const res: RunResult = {
-    html5: "",
-    title: "",
-  };
-
-  /*
-    We can return more than just html, but for right now we are only returning
-    the last HTML file that we get.
-    The last one is returned so that the one created from the vscode injected ods statement is
-    always returned.
-  */
-  for (const result of results.reverse()) {
-    const link = result.links[0];
-    if (link?.type === "text/html") {
-      const html5 = (await job.requestLink<string>(link)).data;
-
-      //Make sure that the html has a valid body
-      if (html5.search('<*id="IDX*.+">') !== -1) {
-        res.html5 = html5;
-        res.title = result.name;
-      }
-
-      break;
-    }
-  }
-
-  return res;
-}
-
-function sessionId() {
-  return computeSession && computeSession.sessionId;
-}
-
-async function close() {
-  if (sessionId()) {
-    computeSession.delete();
-    computeSession = undefined;
-
-    //Since the session is being closed, remove the cached session id
-    setContextValue("SAS.sessionId", undefined);
-  }
-}
-
 export function getSession(c: Config): Session {
-  config = c;
-  getApiConfig().basePath = config.endpoint + "/compute";
+  getApiConfig().basePath = c.endpoint + "/compute";
 
-  return {
-    setup,
-    run,
-    cancel,
-    close,
-    sessionId,
-  };
+  return new RestSession(c);
 }

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -80,7 +80,7 @@ class RestSession extends Session {
     this._computeSession = await this.reconnectComputeSession();
     if (this._computeSession) {
       //reconnected to a running session, so just return
-      this.printSessionLog(this._computeSession);
+      await this.printSessionLog(this._computeSession);
       return;
     }
 
@@ -121,7 +121,8 @@ class RestSession extends Session {
         )
       ).data;
       this._computeSession = ComputeSession.fromInterface(sess);
-      this.printSessionLog(this._computeSession);
+      const sessionLog = this.printSessionLog(this._computeSession);
+      await sessionLog;
     }
 
     //Save the current sessionId

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -15,6 +15,8 @@ import { ComputeServer } from "./server";
 import { ComputeSession } from "./session";
 import { BaseSession, Session } from "../session";
 
+let sessionInstance: RestSession;
+
 export interface Config extends BaseConfig {
   endpoint: string;
   clientId?: string;
@@ -28,9 +30,12 @@ class RestSession extends BaseSession implements Session {
   private _config: Config;
   private _computeSession: ComputeSession | undefined;
 
-  constructor(c: Config) {
+  constructor() {
     super();
-    this._config = c;
+  }
+
+  public set config(value: Config) {
+    this._config = value;
   }
 
   public setup = async (): Promise<void> => {
@@ -279,5 +284,10 @@ async function printLog(job: ComputeJob, onLog?: (logs: LogLine[]) => void) {
 export function getSession(c: Config): Session {
   getApiConfig().basePath = c.endpoint + "/compute";
 
-  return new RestSession(c);
+  if (!sessionInstance) {
+    sessionInstance = new RestSession();
+  }
+  sessionInstance.config = c;
+
+  return sessionInstance;
 }

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -126,7 +126,7 @@ async function setup(): Promise<void> {
   if (config.serverId) {
     const server1 = new ComputeServer(config.serverId);
     server1._options = formattedOpts;
-    server1;
+    server1._autoExecLines = config.autoExecLines;
     computeSession = await server1.getSession();
 
     //Maybe wait for session to be initialized?

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { authentication } from "vscode";
-import { RunResult, Session } from "..";
+import { BaseConfig, RunResult, Session } from "..";
 import { SASAuthProvider } from "../../components/AuthProvider";
 import {
   getContextValue,
@@ -14,15 +14,13 @@ import { ComputeJob } from "./job";
 import { ComputeServer } from "./server";
 import { ComputeSession } from "./session";
 
-export interface Config {
+export interface Config extends BaseConfig {
   endpoint: string;
   clientId?: string;
   clientSecret?: string;
   context?: string;
   serverId?: string;
   reconnect?: boolean;
-  sasOptions?: string[];
-  autoExecLines?: string[];
 }
 
 let config: Config;
@@ -81,6 +79,7 @@ async function reconnectComputeSession(): Promise<ComputeSession> {
 async function setup(): Promise<void> {
   const apiConfig = getApiConfig();
   let formattedOpts: string[] = [];
+  const autoExecLines = config.autoExecLines || [];
 
   if (config.sasOptions) {
     formattedOpts = formatSASOptions();
@@ -125,8 +124,8 @@ async function setup(): Promise<void> {
   //Start a new session
   if (config.serverId) {
     const server1 = new ComputeServer(config.serverId);
-    server1._options = formattedOpts;
-    server1._autoExecLines = config.autoExecLines;
+    server1.options = formattedOpts;
+    server1.autoExecLines = config.autoExecLines;
     computeSession = await server1.getSession();
 
     //Maybe wait for session to be initialized?
@@ -150,7 +149,7 @@ async function setup(): Promise<void> {
           sessionRequest: {
             environment: {
               options: [...formattedOpts],
-              autoExecLines: [...config.autoExecLines],
+              autoExecLines: [...autoExecLines],
             },
           },
         },

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -22,6 +22,7 @@ export interface Config {
   serverId?: string;
   reconnect?: boolean;
   sasOptions?: string[];
+  autoExecLines?: string[];
 }
 
 let config: Config;
@@ -125,6 +126,7 @@ async function setup(): Promise<void> {
   if (config.serverId) {
     const server1 = new ComputeServer(config.serverId);
     server1._options = formattedOpts;
+    server1;
     computeSession = await server1.getSession();
 
     //Maybe wait for session to be initialized?
@@ -145,7 +147,12 @@ async function setup(): Promise<void> {
       await contextsApi.createSession(
         {
           contextId: context.id,
-          sessionRequest: { environment: { options: [...formattedOpts] } },
+          sessionRequest: {
+            environment: {
+              options: [...formattedOpts],
+              autoExecLines: [...config.autoExecLines],
+            },
+          },
         },
         { headers: { "accept-language": locale } }
       )

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { authentication } from "vscode";
-import { BaseConfig, RunResult } from "..";
+import { BaseConfig, OnLogFn, RunResult } from "..";
 import { SASAuthProvider } from "../../components/AuthProvider";
 import {
   getContextValue,
   setContextValue,
 } from "../../components/ExtensionContext";
-import { ContextsApi, LogLine, SessionsApi } from "./api/compute";
+import { ContextsApi, SessionsApi } from "./api/compute";
 import { ComputeState, getApiConfig } from "./common";
 import { ComputeJob } from "./job";
 import { ComputeServer } from "./server";
@@ -274,7 +274,7 @@ class RestSession extends Session {
 /*
 Prints the job log in an async manner.
 */
-async function printLog(job: ComputeJob, onLog?: (logs: LogLine[]) => void) {
+async function printLog(job: ComputeJob, onLog?: OnLogFn) {
   const logs = await job.getLogStream();
   for await (const log of logs) {
     onLog(log);

--- a/client/src/connection/rest/server.ts
+++ b/client/src/connection/rest/server.ts
@@ -16,6 +16,7 @@ export class ComputeServer extends Compute {
   api;
   _self: Server & BaseCompute;
   _options?: string[];
+  _autoExecLines?: string[];
 
   constructor(id: string) {
     super();
@@ -35,6 +36,10 @@ export class ComputeServer extends Compute {
 
   set options(value: string[]) {
     this._options = value;
+  }
+
+  set autoExecLines(value: string[]) {
+    this._autoExecLines = value;
   }
 
   static fromInterface(server: Server): ComputeServer {
@@ -86,7 +91,7 @@ export class ComputeServer extends Compute {
       attributes: {},
       environment: {
         options: [...DEFAULT_COMPUTE_OPTS, ...this._options],
-        autoExecLines: [],
+        autoExecLines: [...this._autoExecLines],
       },
     };
 

--- a/client/src/connection/rest/server.ts
+++ b/client/src/connection/rest/server.ts
@@ -91,7 +91,7 @@ export class ComputeServer extends Compute {
       attributes: {},
       environment: {
         options: [...DEFAULT_COMPUTE_OPTS, ...this._options],
-        autoExecLines: [...this._autoExecLines],
+        autoExecLines: this._autoExecLines || [],
       },
     };
 

--- a/client/src/connection/rest/session.ts
+++ b/client/src/connection/rest/session.ts
@@ -190,7 +190,7 @@ export class ComputeSession extends Compute {
     //To clear out the log, we yeild all lines until there is not "next" link
     do {
       if (resp.status === 200) {
-        nextLink = resp.links?.find((link) => link.rel === "next");
+        nextLink = resp.data.links?.find((link) => link.rel === "next");
         const items = resp.data.items;
         yield items;
 

--- a/client/src/connection/rest/session.ts
+++ b/client/src/connection/rest/session.ts
@@ -15,6 +15,8 @@ import {
   LogsApi,
   JobRequest,
   JobsApiAxiosParamCreator,
+  LogLine,
+  Link,
 } from "./api/compute";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { ComputeJob } from "./job";
@@ -170,5 +172,34 @@ export class ComputeSession extends Compute {
    */
   async delete(): Promise<void> {
     await this.followLink("delete");
+  }
+
+  async *getLogStream(options?: {
+    timeout?: number;
+  }): AsyncGenerator<LogLine[]> {
+    const timeout = options?.timeout ?? 10;
+    const start = 0;
+
+    let nextLink: Link = undefined;
+    let resp = await this.logs.getSessionLog({
+      sessionId: this.sessionId,
+      start: start,
+      timeout: timeout,
+    });
+
+    //To clear out the log, we yeild all lines until there is not "next" link
+    do {
+      if (resp.status === 200) {
+        nextLink = resp.links?.find((link) => link.rel === "next");
+        const items = resp.data.items;
+        yield items;
+
+        if (nextLink) {
+          resp = await this.requestLink(nextLink);
+        }
+      } else {
+        break;
+      }
+    } while (nextLink !== undefined);
   }
 }

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -3,18 +3,18 @@
 
 import { LogLine, OnLogFn, RunResult } from ".";
 
-export class BaseSession {
-  _onLogFn: OnLogFn;
+export abstract class Session {
+  protected _onLogFn: OnLogFn;
   public set onLogFn(value: (logs: LogLine[]) => void) {
     this._onLogFn = value;
   }
-}
 
-export interface Session {
-  onLogFn: (logs: LogLine[]) => void;
-  setup(): Promise<void>;
-  run(code: string, onLog?: (logs: LogLine[]) => void): Promise<RunResult>;
-  cancel?(): Promise<void>;
-  close(): Promise<void> | void;
-  sessionId?(): string | undefined;
+  abstract setup(): Promise<void>;
+  abstract run(
+    code: string,
+    onLog?: (logs: LogLine[]) => void
+  ): Promise<RunResult>;
+  abstract cancel?(): Promise<void>;
+  abstract close(): Promise<void> | void;
+  abstract sessionId?(): string | undefined;
 }

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -1,3 +1,6 @@
+// Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { LogLine, OnLogFn, RunResult } from ".";
 
 export class BaseSession {

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -1,19 +1,16 @@
 // Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { LogLine, OnLogFn, RunResult } from ".";
+import { OnLogFn, RunResult } from ".";
 
 export abstract class Session {
   protected _onLogFn: OnLogFn;
-  public set onLogFn(value: (logs: LogLine[]) => void) {
+  public set onLogFn(value: OnLogFn) {
     this._onLogFn = value;
   }
 
   abstract setup(): Promise<void>;
-  abstract run(
-    code: string,
-    onLog?: (logs: LogLine[]) => void
-  ): Promise<RunResult>;
+  abstract run(code: string): Promise<RunResult>;
   abstract cancel?(): Promise<void>;
   abstract close(): Promise<void> | void;
   abstract sessionId?(): string | undefined;

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -1,0 +1,17 @@
+import { LogLine, OnLogFn, RunResult } from ".";
+
+export class BaseSession {
+  _onLogFn: OnLogFn;
+  public set onLogFn(value: (logs: LogLine[]) => void) {
+    this._onLogFn = value;
+  }
+}
+
+export interface Session {
+  onLogFn: (logs: LogLine[]) => void;
+  setup(): Promise<void>;
+  run(code: string, onLog?: (logs: LogLine[]) => void): Promise<RunResult>;
+  cancel?(): Promise<void>;
+  close(): Promise<void> | void;
+  sessionId?(): string | undefined;
+}

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Client, ClientChannel, ConnectConfig } from "ssh2";
-import { RunResult, Session, LogLine, BaseConfig } from "..";
+import { RunResult, BaseConfig } from "..";
+import { BaseSession, Session } from "../session";
 
 const endCode = "--vscode-sas-extension-submit-end--";
 const sasLaunchTimeout = 10000;
@@ -27,18 +28,18 @@ export function getSession(c: Config): Session {
   return sessionInstance;
 }
 
-export class SSHSession implements Session {
+export class SSHSession extends BaseSession implements Session {
   private conn: Client;
   private stream: ClientChannel | undefined;
   private _config: Config;
   private resolve: ((value?) => void) | undefined;
   private reject: ((reason?) => void) | undefined;
-  private onLog: ((logs: LogLine[]) => void) | undefined;
   private logs: string[] = [];
   private html5FileName = "";
   private timer: NodeJS.Timeout;
 
   constructor(c?: Config) {
+    super();
     this._config = c;
     this.conn = new Client();
   }
@@ -80,14 +81,10 @@ export class SSHSession implements Session {
     });
   };
 
-  public run = (
-    code: string,
-    onLog?: (logs: LogLine[]) => void
-  ): Promise<RunResult> => {
-    this.onLog = onLog;
+  public run = (code: string): Promise<RunResult> => {
     this.html5FileName = "";
     if (this.logs.length) {
-      this.onLog?.(this.logs.map((line) => ({ type: "normal", line })));
+      this._onLogFn(this.logs.map((line) => ({ type: "normal", line })));
       this.logs = [];
     }
 
@@ -164,7 +161,6 @@ export class SSHSession implements Session {
   };
 
   private onStreamClose = (): void => {
-    this.onLog = undefined;
     this.stream = undefined;
     this.resolve = undefined;
     this.reject = undefined;
@@ -176,8 +172,16 @@ export class SSHSession implements Session {
 
   private onStreamData = (data: Buffer): void => {
     const output = data.toString().trimEnd();
+
+    this.logs.push(output);
+    if (output.endsWith("?")) {
+      this.clearTimer();
+      this.resolve?.();
+      return;
+    }
+
     const outputLines = output.split(/\n|\r\n/);
-    if (this.onLog) {
+    if (this._onLogFn) {
       outputLines.forEach((line) => {
         if (!line) {
           return;
@@ -190,15 +194,9 @@ export class SSHSession implements Session {
           this.html5FileName =
             line.match(/NOTE: .+ HTML5.* Body .+: (.+)\.htm/)?.[1] ??
             this.html5FileName;
-          this.onLog?.([{ type: "normal", line }]);
+          this._onLogFn([{ type: "normal", line }]);
         }
       });
-    } else {
-      this.logs.push(output);
-      if (output.endsWith("?")) {
-        this.clearTimer();
-        this.resolve?.();
-      }
     }
   };
 

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -2,17 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Client, ClientChannel, ConnectConfig } from "ssh2";
-import { RunResult, Session, LogLine } from "..";
+import { RunResult, Session, LogLine, BaseConfig } from "..";
 
 const endCode = "--vscode-sas-extension-submit-end--";
 const sasLaunchTimeout = 10000;
 let sessionInstance: SSHSession;
 
-export interface Config {
+export interface Config extends BaseConfig {
   host: string;
   username: string;
   saspath: string;
-  sasOptions?: string[];
   port: number;
 }
 

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -3,7 +3,7 @@
 
 import { Client, ClientChannel, ConnectConfig } from "ssh2";
 import { RunResult, BaseConfig } from "..";
-import { BaseSession, Session } from "../session";
+import { Session } from "../session";
 
 const endCode = "--vscode-sas-extension-submit-end--";
 const sasLaunchTimeout = 10000;
@@ -28,7 +28,7 @@ export function getSession(c: Config): Session {
   return sessionInstance;
 }
 
-export class SSHSession extends BaseSession implements Session {
+export class SSHSession extends Session {
   private conn: Client;
   private stream: ClientChannel | undefined;
   private _config: Config;
@@ -44,9 +44,13 @@ export class SSHSession extends BaseSession implements Session {
     this.conn = new Client();
   }
 
-  sessionId?(): string {
+  public sessionId? = (): string => {
     throw new Error("Method not implemented.");
-  }
+  };
+
+  public cancel? = (): Promise<void> => {
+    throw new Error("Method not implemented.");
+  };
 
   set config(newValue: Config) {
     this._config = newValue;

--- a/client/test/connection/com/index.test.ts
+++ b/client/test/connection/com/index.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
 import * as proc from "child_process";
 import * as fs from "fs";
-import { Session } from "../../../src/connection";
 import { getSession } from "../../../src/connection/com";
 import { scriptContent } from "../../../src/connection/com/script";
 
 import { SinonSandbox, SinonStub, createSandbox } from "sinon";
+import { Session } from "../../../src/connection/session";
 
 describe("COM connection", () => {
   let sandbox: SinonSandbox;
@@ -53,6 +53,9 @@ describe("COM connection", () => {
     };
 
     session = getSession(config);
+    session.onLogFn = () => {
+      return;
+    };
   });
 
   afterEach(() => {
@@ -66,7 +69,7 @@ describe("COM connection", () => {
     it("creates a well-formed local session", async () => {
       const setupPromise = session.setup();
 
-      onDataCallback(Buffer.from(`WORKDIR="/work/dir"`));
+      onDataCallback(Buffer.from(`WORKDIR="/work/dir"\n`));
 
       await setupPromise;
 

--- a/client/test/connection/com/index.test.ts
+++ b/client/test/connection/com/index.test.ts
@@ -114,10 +114,7 @@ describe("COM connection", () => {
       fsStub.returns("content");
 
       const runPromise = session.run(
-        "ods html5;\nproc print data=sashelp.cars;\nrun;",
-        () => {
-          return;
-        }
+        "ods html5;\nproc print data=sashelp.cars;\nrun;"
       );
 
       //simulate log message for body file

--- a/client/test/connection/ssh/index.test.ts
+++ b/client/test/connection/ssh/index.test.ts
@@ -27,6 +27,9 @@ describe("ssh connection", () => {
     };
 
     session = new SSHSession(config);
+    session.onLogFn = () => {
+      return;
+    };
   });
 
   afterEach(() => {
@@ -158,6 +161,9 @@ describe("ssh connection", () => {
     };
 
     const session = new SSHSession(config);
+    session.onLogFn = () => {
+      return;
+    };
 
     beforeEach(() => {
       streamStub = stubInterface<ClientChannel>();

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
                               "filePaths"
                             ],
                             "properties": {
-                              "lines": {
+                              "filePaths": {
                                 "type": "array",
                                 "default": [],
                                 "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.filePaths%"

--- a/package.json
+++ b/package.json
@@ -157,6 +157,71 @@
                         "ssh",
                         "com"
                       ]
+                    },
+                    "sasOptions": {
+                      "type": "array",
+                      "default": null,
+                      "description": "%configuration.SAS.connectionProfiles.profiles.sasOptions%"
+                    },
+                    "autoExec": {
+                      "type": "object",
+                      "default": null,
+                      "description": "%configuration.SAS.connectionProfiles.profiles.autoExec%",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "default": "lines",
+                          "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.type%",
+                          "enum": [
+                            "lines",
+                            "files"
+                          ]
+                        }
+                      },
+                      "allOf": [
+                        {
+                          "if": {
+                            "properties": {
+                              "type": {
+                                "const": "lines"
+                              }
+                            }
+                          },
+                          "then": {
+                            "required": [
+                              "lines"
+                            ],
+                            "properties": {
+                              "lines": {
+                                "type": "array",
+                                "default": [],
+                                "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.lines%"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "if": {
+                            "properties": {
+                              "type": {
+                                "const": "files"
+                              }
+                            }
+                          },
+                          "then": {
+                            "required": [
+                              "filePaths"
+                            ],
+                            "properties": {
+                              "lines": {
+                                "type": "array",
+                                "default": [],
+                                "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.filePaths%"
+                              }
+                            }
+                          }
+                        }
+                      ]
                     }
                   },
                   "allOf": [
@@ -237,7 +302,7 @@
                           "sasOptions": {
                             "type": "array",
                             "default": [],
-                            "description": "%configuration.SAS.connectionProfiles.profiles.ssh.sasOptions%"
+                            "description": "%configuration.SAS.connectionProfiles.profiles.sasOptions%"
                           }
                         }
                       }
@@ -259,11 +324,6 @@
                             "type": "string",
                             "default": "",
                             "description": "%configuration.SAS.connectionProfiles.profiles.com.host%"
-                          },
-                          "sasOptions": {
-                            "type": "array",
-                            "default": [],
-                            "description": "%configuration.SAS.connectionProfiles.profiles.clientSecret%"
                           }
                         }
                       }

--- a/package.json
+++ b/package.json
@@ -164,64 +164,67 @@
                       "description": "%configuration.SAS.connectionProfiles.profiles.sasOptions%"
                     },
                     "autoExec": {
-                      "type": "object",
-                      "default": null,
+                      "type": "array",
+                      "default": [],
                       "description": "%configuration.SAS.connectionProfiles.profiles.autoExec%",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "default": "lines",
-                          "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.type%",
-                          "enum": [
-                            "lines",
-                            "files"
-                          ]
-                        }
-                      },
-                      "allOf": [
-                        {
-                          "if": {
-                            "properties": {
-                              "type": {
-                                "const": "lines"
-                              }
-                            }
-                          },
-                          "then": {
-                            "required": [
-                              "lines"
-                            ],
-                            "properties": {
-                              "lines": {
-                                "type": "array",
-                                "default": [],
-                                "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.lines%"
-                              }
-                            }
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "default": "line",
+                            "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.type%",
+                            "enum": [
+                              "line",
+                              "file"
+                            ]
                           }
                         },
-                        {
-                          "if": {
-                            "properties": {
-                              "type": {
-                                "const": "files"
+                        "allOf": [
+                          {
+                            "if": {
+                              "properties": {
+                                "type": {
+                                  "const": "line"
+                                }
+                              }
+                            },
+                            "then": {
+                              "required": [
+                                "line"
+                              ],
+                              "properties": {
+                                "lines": {
+                                  "type": "string",
+                                  "default": "",
+                                  "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.line%"
+                                }
                               }
                             }
                           },
-                          "then": {
-                            "required": [
-                              "filePaths"
-                            ],
-                            "properties": {
-                              "filePaths": {
-                                "type": "array",
-                                "default": [],
-                                "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.filePaths%"
+                          {
+                            "if": {
+                              "properties": {
+                                "type": {
+                                  "const": "file"
+                                }
+                              }
+                            },
+                            "then": {
+                              "required": [
+                                "filePath"
+                              ],
+                              "properties": {
+                                "filePaths": {
+                                  "type": "string",
+                                  "default": "",
+                                  "description": "%configuration.SAS.connectionProfiles.profiles.autoExec.filePath%"
+                                }
                               }
                             }
                           }
-                        }
-                      ]
+                        ]
+                      }
                     }
                   },
                   "allOf": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,7 @@
 {
   "configuration.SAS.connectionProfiles.profiles.autoExec": "SAS Connection AutoExec",
-  "configuration.SAS.connectionProfiles.profiles.autoExec.filePaths": "SAS Connection AutoExec File paths",
-  "configuration.SAS.connectionProfiles.profiles.autoExec.lines": "SAS Connection AutoExec Lines",
+  "configuration.SAS.connectionProfiles.profiles.autoExec.filePath": "SAS Connection AutoExec File path",
+  "configuration.SAS.connectionProfiles.profiles.autoExec.line": "SAS Connection AutoExec Line",
   "configuration.SAS.connectionProfiles.profiles.autoExec.type": "SAS Connection AutoExec type",
 
   "configuration.SAS.connectionProfiles": "Define the connection profiles to connect to SAS Viya servers. If you define more than one profile, you can switch between them.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,7 @@
 {
   "configuration.SAS.connectionProfiles.profiles.autoExec": "SAS Connection AutoExec",
-  "configuration.SAS.connectionProfiles.profiles.autoExec.lines": "SAS Connection AutoExec Lines",
   "configuration.SAS.connectionProfiles.profiles.autoExec.filePaths": "SAS Connection AutoExec File paths",
+  "configuration.SAS.connectionProfiles.profiles.autoExec.lines": "SAS Connection AutoExec Lines",
   "configuration.SAS.connectionProfiles.profiles.autoExec.type": "SAS Connection AutoExec type",
 
   "configuration.SAS.connectionProfiles": "Define the connection profiles to connect to SAS Viya servers. If you define more than one profile, you can switch between them.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,4 +1,9 @@
 {
+  "configuration.SAS.connectionProfiles.profiles.autoExec": "SAS Connection AutoExec",
+  "configuration.SAS.connectionProfiles.profiles.autoExec.lines": "SAS Connection AutoExec Lines",
+  "configuration.SAS.connectionProfiles.profiles.autoExec.filePaths": "SAS Connection AutoExec File paths",
+  "configuration.SAS.connectionProfiles.profiles.autoExec.type": "SAS Connection AutoExec type",
+
   "configuration.SAS.connectionProfiles": "Define the connection profiles to connect to SAS Viya servers. If you define more than one profile, you can switch between them.",
   "configuration.SAS.connectionProfiles.activeProfile": "Active SAS Connection Profile",
   "configuration.SAS.connectionProfiles.profiles": "SAS Connection Profiles",
@@ -8,6 +13,7 @@
   "configuration.SAS.connectionProfiles.profiles.context": "SAS Viya Context",
   "configuration.SAS.connectionProfiles.profiles.endpoint": "SAS Viya Connection Profile Endpoint",
   "configuration.SAS.connectionProfiles.profiles.name": "SAS Connection Profile Name",
+  "configuration.SAS.connectionProfiles.profiles.sasOptions": "SAS Connection SAS options",
   "configuration.SAS.connectionProfiles.profiles.tokenFile": "SAS Viya Token File",
   "configuration.SAS.connectionProfiles.profiles.username": "SAS Viya User ID",
   "configuration.SAS.session.outputHtml": "Enable/disable ODS HTML5 output",
@@ -17,10 +23,8 @@
   "configuration.SAS.connectionProfiles.profiles.ssh.username": "SAS SSH Connection username",
   "configuration.SAS.connectionProfiles.profiles.ssh.saspath": "SAS SSH Connection executable path",
   "configuration.SAS.connectionProfiles.profiles.ssh.port": "SAS SSH Connection port",
-  "configuration.SAS.connectionProfiles.profiles.ssh.sasOptions": "SAS SSH Connection SAS system options",
 
   "configuration.SAS.connectionProfiles.profiles.com.host": "SAS COM Connection Host",
-  "configuration.SAS.connectionProfiles.profiles.com.sasOptions": "SAS COM Connection SAS options",
 
   "commands.SAS.addFileResource": "New File...",
   "commands.SAS.addFolderResource": "New Folder...",


### PR DESCRIPTION
**Summary**
Adds autoexec support to the rest connection profle. AutoExec can be setup in multiple ways, by referencing one or more external files that are readable by vscode:

``` json
     "rest-profile-1": {
        "connectionType": "rest",
        "endpoint": <...omitted...>,
        "autoExec": [{
          "type": "file", 
          "filePath":"/file/path/one.sas"
        },{
          "type":"file",
          "filePath": "/file/path/two.sas"}
         ]
      }
```

By directly embedding SAS lines into the connection profile:
``` json
     "rest-profile": {
        "connectionType": "rest",
        "endpoint": <...omitted...>,
        "autoExec": [{
          "type": "line", 
          "line":"libname _all_ list;"
        },{
          "type":"line",
          "line": "%put _all_;"}
         ]
      }
```
Or by using a mix of the two approaches:

``` json
     "rest-profile": {
        "connectionType": "rest",
        "endpoint": <...omitted...>,
        "autoExec": [{
          "type": "line", 
          "line":"libname _all_ list;"
        },{
          "type":"file",
          "filePath": "/file/path/two.sas"}
         ]
      }
```

**Testing**
1.) For each example profile above:
2.) Create a connection profile with the specific autoexec form.
3.) Run the following test code:
``` sas
proc print data=sashelp.cars;
run;
```
4.) Check the SAS Log Window in VSCode. Ensure that the session log lines are output including relevant autoexec output.

TODO:
- [x] Show log earlier in execution cycle so that the user can see startup log and autoexec log