### PR TITLE
fix: get all pages of results

### DIFF
--- a/client/src/components/utils.ts
+++ b/client/src/components/utils.ts
@@ -17,3 +17,33 @@ export function deferred<T>() {
   });
   return deferred;
 }
+
+/**
+ * Run tasks with limited concurrency
+ * @param tasks array of tasks to run
+ * @param limit limit of tasks that can run in parallel
+ * @returns a promise like `Promise.all`
+ */
+export function throttle<T>(tasks: Array<() => Promise<T>>, limit: number) {
+  const total = tasks.length;
+  const results: T[] = Array(total);
+  let count = 0;
+  return new Promise<T[]>((resolve, reject) => {
+    function run() {
+      const index = total - tasks.length;
+      if (index === total) {
+        if (count === total) {
+          resolve(results);
+        }
+        return;
+      }
+      const task = tasks.shift();
+      task().then((result) => {
+        results[index] = result;
+        ++count;
+        run();
+      }, reject);
+    }
+    Array(limit).fill(0).forEach(run);
+  });
+}


### PR DESCRIPTION
**Summary**
Fix #330
There can be many ODS graphs in the result list. We should retrieve all pages of results.

**Testing**
Test case in #330
