### PR TITLE
fix: replace equals with space for compute options

### DIFF
--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -173,7 +173,7 @@ async function setup(): Promise<void> {
 function formatSASOptions() {
   const formattedOpts = config.sasOptions.map((opt) => {
     let formatted = opt;
-    formatted = formatted.replace(/-/gi, "");
+    formatted = formatted.replace(/=/gi, " ");
     return formatted;
   });
   return formattedOpts;


### PR DESCRIPTION
**Summary**
Fixes a bug in formatting of compute api sas options.

**Testing**
Given the following rest profiles, each should set PAGESIZE value to 32767. The connection will need to be closed in between each test case.

``` json
"rest-conn": {
        "connectionType": "rest",
        "endpoint": <...omitted...>,
        "sasOptions": [
          "-PAGESIZE MAX"
        ]
}
```

``` json
"rest-conn": {
        "connectionType": "rest",
        "endpoint": <...omitted...>,
        "sasOptions": [
          "-PAGESIZE=MAX"
        ]
}
```
``` json
"rest-conn": {
        "connectionType": "rest",
        "endpoint": <...omitted...>,
        "sasOptions": [
          "PAGESIZE=MAX"
        ]
}
```
``` json
"rest-conn": {
        "connectionType": "rest",
        "endpoint": <...omitted...>,
        "sasOptions": [
          "PAGESIZE MAX"
        ]
}
```
The option value is verified by running the following sas code:
``` sas
proc options option=PAGESIZE value; run;

```

