### PR TITLE
refactor: Session Log Streaming

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -2,19 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  OutputChannel,
+  Position,
   ProgressLocation,
+  Selection,
   ViewColumn,
+  commands,
   window,
   workspace,
-  commands,
-  Position,
-  Selection,
 } from "vscode";
-import { appendLog } from "../components/LogViewer";
+import type { BaseLanguageClient } from "vscode-languageclient";
+import { LogFn as LogChannelFn } from "../components/LogChannel";
 import { getSession } from "../connection";
 import { profileConfig, switchProfile } from "./profile";
-import type { BaseLanguageClient } from "vscode-languageclient";
 
 interface FoldingBlock {
   startLine: number;
@@ -23,7 +22,6 @@ interface FoldingBlock {
   endCol: number;
 }
 
-let outputChannel: OutputChannel;
 let running = false;
 
 function getCode(outputHtml: boolean, selected = false): string {
@@ -115,16 +113,7 @@ async function runCode(selected?: boolean) {
   const code = getCode(outputHtml, selected);
 
   const session = getSession();
-  session.onLogFn = (logs) => {
-    if (!outputChannel) {
-      outputChannel = window.createOutputChannel("SAS Log", "sas-log");
-    }
-    outputChannel.show();
-    for (const line of logs) {
-      appendLog(line.type);
-      outputChannel.appendLine(line.line);
-    }
-  };
+  session.onLogFn = LogChannelFn;
 
   await window.withProgress(
     {

--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -7,6 +7,7 @@ import { ProgressLocation, window } from "vscode";
 import { getSession } from "../../connection";
 import { DataAccessApi } from "../../connection/rest/api/compute";
 import { getApiConfig } from "../../connection/rest/common";
+import { LogFn as LogChannelFn } from "../LogChannel";
 import PaginatedResultSet from "./PaginatedResultSet";
 import { DefaultRecordLimit, Messages } from "./const";
 import { LibraryItem, LibraryItemType, TableData } from "./types";
@@ -23,6 +24,7 @@ class LibraryModel {
 
   public async connect(): Promise<void> {
     const session = getSession();
+    session.onLogFn = LogChannelFn;
 
     await window.withProgress(
       {

--- a/client/src/components/LogChannel.ts
+++ b/client/src/components/LogChannel.ts
@@ -1,0 +1,14 @@
+import { appendLog } from "./LogViewer";
+import { OutputChannel, window } from "vscode";
+
+let outputChannel: OutputChannel;
+export const LogFn = (logs) => {
+  if (!outputChannel) {
+    outputChannel = window.createOutputChannel("SAS Log", "sas-log");
+  }
+  outputChannel.show();
+  for (const line of logs) {
+    appendLog(line.type);
+    outputChannel.appendLine(line.line);
+  }
+};

--- a/client/src/components/LogChannel.ts
+++ b/client/src/components/LogChannel.ts
@@ -1,5 +1,6 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import { appendLog } from "./LogViewer";
 import { OutputChannel, window } from "vscode";
 

--- a/client/src/components/LogChannel.ts
+++ b/client/src/components/LogChannel.ts
@@ -1,3 +1,5 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { appendLog } from "./LogViewer";
 import { OutputChannel, window } from "vscode";
 

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -117,7 +117,7 @@ class RestSession extends Session {
               },
             },
           },
-          { headers: { "accept-language": locale } }
+          { headers: { "accept-language": locale } },
         )
       ).data;
       this._computeSession = ComputeSession.fromInterface(sess);
@@ -247,7 +247,7 @@ class RestSession extends Session {
         session = await computeServer.getSession(sessionId);
       } catch (error) {
         console.log(
-          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
+          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`,
         );
       }
     } else {
@@ -260,7 +260,7 @@ class RestSession extends Session {
         session = ComputeSession.fromInterface(mySession);
       } catch (error) {
         console.log(
-          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
+          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`,
         );
       }
     }

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -117,12 +117,13 @@ class RestSession extends Session {
               },
             },
           },
-          { headers: { "accept-language": locale } },
+          { headers: { "accept-language": locale } }
         )
       ).data;
       this._computeSession = ComputeSession.fromInterface(sess);
-      await this.printSessionLog(this._computeSession);
     }
+
+    await this.printSessionLog(this._computeSession);
 
     //Save the current sessionId
     setContextValue("SAS.sessionId", this._computeSession.sessionId);
@@ -246,7 +247,7 @@ class RestSession extends Session {
         session = await computeServer.getSession(sessionId);
       } catch (error) {
         console.log(
-          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`,
+          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
         );
       }
     } else {
@@ -259,7 +260,7 @@ class RestSession extends Session {
         session = ComputeSession.fromInterface(mySession);
       } catch (error) {
         console.log(
-          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`,
+          `Attempt to reconnect to session ${sessionId} failed. A new session will be started`
         );
       }
     }

--- a/client/src/connection/rest/session.ts
+++ b/client/src/connection/rest/session.ts
@@ -221,7 +221,6 @@ export class ComputeSession extends Compute {
     let resp = await this.logs.getSessionLog({
       sessionId: this.sessionId,
       start: start,
-      timeout: timeout,
     });
 
     //To clear out the log, we yeild all lines until there is not "next" link

--- a/client/src/connection/rest/session.ts
+++ b/client/src/connection/rest/session.ts
@@ -227,7 +227,7 @@ export class ComputeSession extends Compute {
     //To clear out the log, we yeild all lines until there is not "next" link
     do {
       if (resp.status === 200) {
-        nextLink = resp.links?.find((link) => link.rel === "next");
+        nextLink = resp.data.links?.find((link) => link.rel === "next");
         const items = resp.data.items;
         yield items;
 

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -4,7 +4,7 @@
 import { OnLogFn, RunResult } from ".";
 
 export abstract class Session {
-  protected _onLogFn: OnLogFn;
+  protected _onLogFn: OnLogFn | undefined;
   public set onLogFn(value: OnLogFn) {
     this._onLogFn = value;
   }


### PR DESCRIPTION
**Summary**
Check the session job status before streaming the log to avoid various timing problems. Additionally, LibraryModel is currently creating a session. Modify LibraryModel to attach the log handler when LibraryModel creates a session in order to see the session log when LibraryModel invokes session setup. Fixes current issues where if the user opens the Library Panel first, before executing code, then the session log will not be output to the channel. Additionally, when running the actual sas file, it would also not be seen there, which is not desired behavior.

**Testing**
Test case in #369 
