### PR TITLE
 fix: regex to match html5 file name in local COM

### DIFF
--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -226,7 +226,7 @@ do {
           this.fetchResults();
         } else {
           this._html5FileName =
-            line.match(/NOTE: .+ HTML5.* Body .+: (.+)\.htm/)?.[1] ??
+            line.match(/NOTE: .+ HTML5.* Body.+: (.+)\.htm/)?.[1] ??
             this._html5FileName;
           this._onLogFn?.([{ type: "normal", line }]);
         }

--- a/client/src/connection/com/script.ts
+++ b/client/src/connection/com/script.ts
@@ -57,7 +57,7 @@ class SASRunner{
         }
     }
 
-    [ref] $errorIndices = [int[]]::new($names.Length)
+    [ref]$errorIndices = [int[]]::new($names.Length)
     [ref]$errors = [string[]]::new($names.Length)
     [ref]$errorCodes = [int[]]::new($names.Length)
 


### PR DESCRIPTION
**Summary**
As issue https://github.com/sassoftware/vscode-sas-extension/issues/346, if I use a local of zh_CN, then there is no space after 'HTML5 Body', the regex can't match this line and can't find the output html filename.

For example,
```
NOTE: ����д�� HTML5 Body�����壩�ļ�: sashtml.htm
```

Sorry I haven't learned to how to test it.

**Testing**
I test it in 
- SAS 9.4M7 from OA
- vscode 1.79.2
- using local COM
