### PR TITLE
fix: indent bugfix (#363)

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -24,7 +24,7 @@
     ["\"", "\""]
   ],
   "indentationRules": {
-    "increaseIndentPattern": "^\\s*(data|proc|%macro)\\b.*;$",
+    "increaseIndentPattern": "(data|proc|%macro)\\b[^;]*;(\\s|/\\*.*\\*/|\\*[^;]*;)*$",
     "decreaseIndentPattern": "^\\s*(run;|quit;|%mend;)$"
   },
   "wordPattern": "(-?\\d*\\.\\d\\w*)|(\\%?[^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)"


### PR DESCRIPTION
**Summary**
Issue #363 
&emsp;Refined the Regex to make the indent more accurate. 
&emsp;The Regex is a powerful tool, but still has many restrictions. I can't make it meet 100% senarios, but I think it's definitely enough for everyday use. For absolute accurate, I suggest to do it programmatically rather than using Regex.
Below are some correct and wrong cases.

**Testing**
**CORRECT:**
data a.b;run;
stmt;

data a.b;run; proc/\*123\*/ c;
&emsp;stmt;

proc contents data=x; run;
stmt;

data a.b;
&emsp;stmt;
run;

/\*comment\*/ data a.b;
&emsp;stmt;
run;

*comment; data a.b; /\*comment\*/
&emsp;stmt;
run;

*comment; data a.b; *comment;
&emsp;stmt;
run;

proc c; stmt1; run; data c.d; /\*comment \*/
&emsp;stmt2;
run;

data a.b; /\*comment\*/ \*/
&emsp;stmt;

**INCORRECT:**
/\* Should indent
\* This case can be resolved by copying the comment Regex part into the data/proc step Regex, but could make 
the Regex too complecated
\*/
data /\*;abc\*/ a;
stmt;

/\* Should indent\*/
data a.b; set c;
stmt;

/\* Should indent\*/
data a.b;;
stmt;