### PR TITLE
fix: able to show content on 2023.03 (#328)

### DIFF
--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -574,10 +574,15 @@ export class ContentModel {
   }
 
   private async getViyaCadence(): Promise<string> {
-    const { data } = await this.connection.get(
-      "/deploymentData/cadenceVersion",
-    );
-    return data.cadenceVersion;
+    try {
+      const { data } = await this.connection.get(
+        "/deploymentData/cadenceVersion",
+      );
+      return data.cadenceVersion;
+    } catch (e) {
+      console.error("fail to retrieve the viya cadence");
+    }
+    return "unknown";
   }
 }
 

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -225,6 +225,10 @@ describe("ContentDataProvider", async function () {
     });
     const dataProvider = createDataProvider();
 
+    axiosInstance.get.withArgs("/deploymentData/cadenceVersion").resolves({
+      data: { cadenceVersion: "2023.07" },
+    });
+
     axiosInstance.get
       .withArgs(
         "uri://myFavorites?limit=1000000&filter=in(contentType,'file','RootFolder','folder','myFolder','favoritesFolder','userFolder','userRoot','trashFolder')&sortBy=eq(contentType,'folder'):descending,name:primary:ascending,type:ascending",


### PR DESCRIPTION
**Summary**
Fix #328 
There is something wrong with the folder service (version 2.74.2) on Viya 2023.03 LTS. The members query fails because of sortBy parameter 'eq(contentType, 'folder')'. (It works on 2022.09 and 2023.04).

To avoid this failure, remove this sortBy parameter. The side effect is that the folders may not be ordered first.

**Testing**
Test as the reproduce steps.
