### PR TITLE
fix: always show running man icon

### DIFF
--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -10,6 +10,7 @@ import {
   NotebookData,
   StatusBarAlignment,
   StatusBarItem,
+  Uri,
   authentication,
   commands,
   l10n,
@@ -101,8 +102,8 @@ export function activate(context: ExtensionContext): void {
       await run();
       await libraryNavigator.refresh();
     }),
-    commands.registerCommand("SAS.runSelected", async () => {
-      await runSelected();
+    commands.registerCommand("SAS.runSelected", async (uri: Uri) => {
+      await runSelected(uri);
       await libraryNavigator.refresh();
     }),
     commands.registerCommand("SAS.runRegion", async () => {

--- a/package.json
+++ b/package.json
@@ -346,6 +346,7 @@
           "light": "icons/light/submitSASCode.svg",
           "dark": "icons/dark/submitSASCode.svg"
         },
+        "enablement": "!SAS.running",
         "category": "SAS"
       },
       {
@@ -355,6 +356,7 @@
           "light": "icons/light/submitSASCode.svg",
           "dark": "icons/dark/submitSASCode.svg"
         },
+        "enablement": "!SAS.running",
         "category": "SAS"
       },
       {
@@ -364,6 +366,7 @@
           "light": "icons/light/submitSASCode.svg",
           "dark": "icons/dark/submitSASCode.svg"
         },
+        "enablement": "!SAS.running",
         "category": "SAS"
       },
       {
@@ -570,13 +573,13 @@
       ],
       "editor/title/run": [
         {
-          "when": "editorFocus && editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
           "command": "SAS.runSelected"
         }
       ],
       "editor/context": [
         {
-          "when": "editorFocus && editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
           "command": "SAS.run",
           "group": "navigation@2"
         },


### PR DESCRIPTION
**Summary**
Fix #433

When a command is invoked from a menu, VS Code will pass the URI of the triggered resource as the first parameter.
We should utilize it over `vscode.window.activeTextEditor` (which is the editor with focus, thus could be SAS log).

**Testing**

- Be able to directly click the running man icon when focus is not in the SAS code. The code submitted is correct.
- Not be able to run when it's already running (running man icon disabled)
