### PR TITLE
chore: minor cleanup

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,6 @@
         "media-typer": "^1.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-infinite-scroller": "^1.2.6",
         "ssh2": "^1.11.0",
         "uuid": "^9.0.0",
         "vscode-languageclient": "^8.0.1"
@@ -491,17 +490,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-infinite-scroller": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
-      "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {
@@ -1024,14 +1012,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
-      }
-    },
-    "react-infinite-scroller": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
-      "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
-      "requires": {
-        "prop-types": "^15.5.8"
       }
     },
     "react-is": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,6 @@
     "media-typer": "^1.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-infinite-scroller": "^1.2.6",
     "ssh2": "^1.11.0",
     "uuid": "^9.0.0",
     "vscode-languageclient": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -161,8 +161,11 @@
                     },
                     "sasOptions": {
                       "type": "array",
-                      "default": null,
-                      "description": "%configuration.SAS.connectionProfiles.profiles.sasOptions%"
+                      "default": [],
+                      "description": "%configuration.SAS.connectionProfiles.profiles.sasOptions%",
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "autoExec": {
                       "type": "array",
@@ -302,11 +305,6 @@
                             "description": "%configuration.SAS.connectionProfiles.profiles.ssh.port%",
                             "exclusiveMinimum": 1,
                             "exclusiveMaximum": 65535
-                          },
-                          "sasOptions": {
-                            "type": "array",
-                            "default": [],
-                            "description": "%configuration.SAS.connectionProfiles.profiles.sasOptions%"
                           }
                         }
                       }


### PR DESCRIPTION
- Remove redundant `sasOptions` definition in configuration
- "react-infinite-scroller" is not used anymore with ag grid now