### PR TITLE
fix: ssh setup resolve

### DIFF
--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -179,7 +179,7 @@ export class SSHSession extends Session {
     const output = data.toString().trimEnd();
 
     this.logs.push(output);
-    if (output.endsWith("?")) {
+    if (this.timer && output.endsWith("?")) {
       this.clearTimer();
       this.resolve?.();
       return;

--- a/client/test/connection/ssh/index.test.ts
+++ b/client/test/connection/ssh/index.test.ts
@@ -217,8 +217,8 @@ describe("ssh connection", () => {
           }
 
           if (onDataListener) {
-            //need to pass a "?" to the callback to resolve the promise here
-            onDataListener("?");
+            // send back end code to finish running
+            onDataListener("--vscode-sas-extension-submit-end--\n");
           }
         }
         return true;
@@ -260,8 +260,8 @@ describe("ssh connection", () => {
           if (onDataListener) {
             //here we define long running as a value that exceeds the timeout values set in the provider
             sandbox.clock.tick(50 * seconds);
-            //need to pass a "?" to the callback to resolve the promise here
-            onDataListener("?");
+            // send back end code to finish running
+            onDataListener("--vscode-sas-extension-submit-end--\n");
           }
         }
         return true;


### PR DESCRIPTION
**Summary**
Fix #458

This is a regression introduced by
https://github.com/sassoftware/vscode-sas-extension/pull/355/files#diff-93c2ba90afbd1237f6041f9b12f380c455911f4275dc33ea8ebde51ce1031f75L197
It should only resolve for setup, not for running.
Prevously it relied on if _onLogFn was passed in. Now we can rely on the setup timer existence.

**Testing**
Test case in #458
