### PR TITLE
fix: check job results for success or error

### DIFF
--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -155,7 +155,7 @@ class RestSession extends Session {
     await retLog;
 
     //Now get the results
-    const results = state === ComputeState.Error ? [] : await job.results();
+    const results = await job.results();
 
     const res: RunResult = {
       html5: "",


### PR DESCRIPTION
**Summary**
Relaxes the check on compute job state to check for results even if the job errors out. This has the added benefit of showing results that are valid, in scenarios where part of the code produced results, but a subsequent part of code resulted in a compute job error state.

**Testing**
Test case in #467 
