### PR TITLE
chore: ability to debug single test file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,6 +48,7 @@
         "${workspaceRoot}/client/testFixture",
         "--disable-extensions"
       ],
+      "env": { "testFile": "${relativeFile}" },
       "outFiles": ["${workspaceRoot}/client/out/test/**/*.js"],
       "preLaunchTask": {
         "type": "npm",

--- a/client/test/index.ts
+++ b/client/test/index.ts
@@ -11,9 +11,13 @@ export function run(): Promise<void> {
   mocha.timeout(100000);
 
   const testsRoot = __dirname;
+  const testFile = process.env.testFile;
+  const pattern = testFile
+    ? path.join(...testFile.replace(/\.ts$/, ".js").split(path.sep).slice(2))
+    : "**/**.test.js";
 
   return new Promise((resolve, reject) => {
-    glob("**/**.test.js", { cwd: testsRoot }, (err, files) => {
+    glob(pattern, { cwd: testsRoot }, (err, files) => {
       if (err) {
         return reject(err);
       }


### PR DESCRIPTION
**Summary**
Currently it always run all tests. As a developer, I'd like to only debug my test.

**Testing**

1. Open my test file in VS Code, say `client/test/connection/ssh/index.test.ts`
2. In the `Run and Debug` panel, select `Language Server E2E Test` and start debugging.
3. Notice that only the tests in current file is run.

Also verified that `npm run test` still run all tests