### PR TITLE
fix(core): escape $ symbol in powershell code for local connection

### DIFF
--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -8,8 +8,7 @@ import { BaseConfig, RunResult } from "..";
 import { scriptContent } from "./script";
 import { Session } from "../session";
 
-const beginningCode = `\`'--vscode-sas-extension-submit-begining--\`'`;
-const endCode = `\`'--vscode-sas-extension-submit-end--\`'`;
+const endCode = "--vscode-sas-extension-submit-end--";
 let sessionInstance: COMSession;
 
 /**
@@ -119,8 +118,8 @@ export class COMSession extends Session {
       );
 
       //write an end mnemonic so that the handler knows when execution has finished
-      const codeWithEnd = `%put ${beginningCode};\n${codeWithODSPath}\n%put ${endCode};`;
-      const codeToRun = `$code=@'\n${codeWithEnd}\n'@\n`;
+      const codeWithEnd = `${codeWithODSPath}\n%put ${endCode};`;
+      const codeToRun = `$code=\n@'\n${codeWithEnd}\n'@\n`;
 
       this._shellProcess.stdin.write(codeToRun);
       this._shellProcess.stdin.write(`$runner.Run($code)\n`, async (error) => {

--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -8,7 +8,8 @@ import { BaseConfig, RunResult } from "..";
 import { scriptContent } from "./script";
 import { Session } from "../session";
 
-const endCode = "--vscode-sas-extension-submit-end--";
+const beginningCode = `\`'--vscode-sas-extension-submit-begining--\`'`;
+const endCode = `\`'--vscode-sas-extension-submit-end--\`'`;
 let sessionInstance: COMSession;
 
 /**
@@ -118,8 +119,8 @@ export class COMSession extends Session {
       );
 
       //write an end mnemonic so that the handler knows when execution has finished
-      const codeWithEnd = `${codeWithODSPath}\n%put ${endCode};`;
-      const codeToRun = `$code=@"\n${codeWithEnd}\n"@\n`;
+      const codeWithEnd = `%put ${beginningCode};\n${codeWithODSPath}\n%put ${endCode};`;
+      const codeToRun = `$code=@'\n${codeWithEnd}\n'@\n`;
 
       this._shellProcess.stdin.write(codeToRun);
       this._shellProcess.stdin.write(`$runner.Run($code)\n`, async (error) => {

--- a/client/test/connection/com/index.test.ts
+++ b/client/test/connection/com/index.test.ts
@@ -127,7 +127,7 @@ describe("COM connection", () => {
       expect(runResult.title).to.equal("Results");
 
       expect(stdinStub.args[7][0]).to.deep.equal(
-        `$code=@"\nods html5 path="/work/dir";\nproc print data=sashelp.cars;\nrun;\n%put --vscode-sas-extension-submit-end--;\n"@\n`,
+        `$code=\n@'\nods html5 path="/work/dir";\nproc print data=sashelp.cars;\nrun;\n%put --vscode-sas-extension-submit-end--;\n'@\n`,
       );
 
       expect(stdinStub.args[8][0]).to.deep.equal(`$runner.Run($code)\n`);


### PR DESCRIPTION
Signed-off-by: Shuguang Sun <shuguang79@qq.com>

**Summary**
See https://github.com/sassoftware/vscode-sas-extension/issues/356 . 


**Testing**
Not provide test code. But tested below scenarios:

- `$` symbol
- `%put "ab'c";`

