### PR TITLE
fix: should not trim HTML buffer

### DIFF
--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -147,7 +147,7 @@ export class SSHSession extends Session {
         }
 
         s.on("data", (data) => {
-          fileContents += data.toString().trimEnd();
+          fileContents += data.toString();
         }).on("close", (code) => {
           const rc: number = code;
 


### PR DESCRIPTION
**Summary**
Fix #483
The data callback will be called multiple times, each time with a piece of the file content. The splitting can happen at any places.
For example, `<td class="r">12</td>` can be split into `<td ` (with trailing whitespace) and the rest part. If trimmed, it will become `<tdclass="r">12</td>` after combination which is not a valid HTML.
It is critical and a data integrity issue.

**Testing**
Test case in #483
