### PR TITLE
build: move notebook renderer build to esbuild

### DIFF
--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -45,8 +45,13 @@ const nodeBuildOptions = {
 
 const browserBuildOptions = {
   ...commonBuildOptions,
+  format: "esm",
   entryPoints: {
     "./client/dist/webview/DataViewer": "./client/src/webview/DataViewer.tsx",
+    "./client/dist/notebook/LogRenderer":
+      "./client/src/components/notebook/renderers/LogRenderer.ts",
+    "./client/dist/notebook/HTMLRenderer":
+      "./client/src/components/notebook/renderers/HTMLRenderer.ts",
   },
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,43 +101,4 @@ const browserServerConfig = {
   devtool: "source-map",
 };
 
-/** @type WebpackConfig */
-const notebookRendererConfig = {
-  context: path.join(__dirname, "client"),
-  mode: "none",
-  entry: {
-    LogRenderer: "./src/components/notebook/renderers/LogRenderer.ts",
-    HTMLRenderer: "./src/components/notebook/renderers/HTMLRenderer.ts",
-  },
-  output: {
-    filename: "[name].js",
-    path: path.join(__dirname, "client", "dist", "notebook"),
-    libraryTarget: "module",
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: "ts-loader",
-          },
-        ],
-      },
-    ],
-  },
-  experiments: {
-    outputModule: true,
-  },
-  performance: {
-    hints: false,
-  },
-  devtool: "source-map",
-};
-
-module.exports = [
-  browserClientConfig,
-  browserServerConfig,
-  notebookRendererConfig,
-];
+module.exports = [browserClientConfig, browserServerConfig];


### PR DESCRIPTION
**Summary**
From #482
Move notebook renderer build from webpack to esbuild, so that the `watch` script can build everything needed for Launch Client.
Added `format: "esm"` which is required for the notebook renderer to be invoked by VS Code engine. It looks also makes sense to DataViewer as it is currently imported as a [module](https://github.com/sassoftware/vscode-sas-extension/blob/main/client/src/panels/DataViewer.ts#L54).

**Testing**

1. Clean up `client/dist` directory.
2. Click `Launch Client` in VS Code.
3. Verify that notebook result and data viewer works well.