### PR TITLE
feat: change output html option to more logical/consistent ID and re-order options

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -116,7 +116,7 @@ async function runCode(selected?: boolean, uri?: Uri) {
 
   const outputHtml = !!workspace
     .getConfiguration("SAS")
-    .get("session.outputHtml");
+    .get("results.html.enabled");
 
   const code = getCode(selected, uri);
 

--- a/client/src/components/utils.ts
+++ b/client/src/components/utils.ts
@@ -6,7 +6,7 @@ import { window, workspace, ColorThemeKind } from "vscode";
 export function wrapCode(code: string): string {
   const outputHtml = !!workspace
     .getConfiguration("SAS")
-    .get("session.outputHtml");
+    .get("results.html.enabled");
   const htmlStyle: string = workspace
     .getConfiguration("SAS")
     .get("results.html.style");

--- a/package.json
+++ b/package.json
@@ -114,53 +114,8 @@
     "configuration": [
       {
         "properties": {
-          "SAS.session.outputHtml": {
-            "order": 0,
-            "type": "boolean",
-            "default": true,
-            "description": "%configuration.SAS.session.outputHtml%"
-          },
-          "SAS.results.html.style": {
-            "order": 1,
-            "type": "string",
-            "default": "(auto)",
-            "enum": [
-              "(auto)",
-              "(server default)",
-              "Aqua",
-              "Daisy",
-              "Dove",
-              "HighContrast",
-              "HighContrastLarge",
-              "HTMLBlue",
-              "HTMLEncore",
-              "Ignite",
-              "Illuminate",
-              "Journal",
-              "Journal2",
-              "Journal3",
-              "Marine",
-              "Midnight",
-              "Moonflower",
-              "Opal",
-              "Pearl",
-              "Sapphire"
-            ],
-            "enumDescriptions": [
-              "%configuration.SAS.results.html.style.(auto)%",
-              "%configuration.SAS.results.html.style.(server default)%"
-            ],
-            "description": "%configuration.SAS.results.html.style%"
-          },
-          "SAS.userProvidedCertificates": {
-            "type": "array",
-            "description": "%configuration.SAS.userProvidedCertificates%",
-            "items": {
-              "type": "string"
-            }
-          },
           "SAS.connectionProfiles": {
-            "order": 2,
+            "order": 0,
             "type": "object",
             "description": "%configuration.SAS.connectionProfiles%",
             "properties": {
@@ -366,6 +321,52 @@
                 }
               }
             }
+          },
+          "SAS.userProvidedCertificates": {
+            "order": 1,
+            "type": "array",
+            "description": "%configuration.SAS.userProvidedCertificates%",
+            "items": {
+              "type": "string"
+            }
+          },
+          "SAS.results.html.enabled": {
+            "order": 2,
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.SAS.results.html.enabled%"
+          },
+          "SAS.results.html.style": {
+            "order": 3,
+            "type": "string",
+            "default": "(auto)",
+            "enum": [
+              "(auto)",
+              "(server default)",
+              "Aqua",
+              "Daisy",
+              "Dove",
+              "HighContrast",
+              "HighContrastLarge",
+              "HTMLBlue",
+              "HTMLEncore",
+              "Ignite",
+              "Illuminate",
+              "Journal",
+              "Journal2",
+              "Journal3",
+              "Marine",
+              "Midnight",
+              "Moonflower",
+              "Opal",
+              "Pearl",
+              "Sapphire"
+            ],
+            "enumDescriptions": [
+              "%configuration.SAS.results.html.style.(auto)%",
+              "%configuration.SAS.results.html.style.(server default)%"
+            ],
+            "description": "%configuration.SAS.results.html.style%"
           }
         }
       }

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -43,7 +43,7 @@
   "configuration.SAS.connectionProfiles.profiles.ssh.username": "SAS SSH Verbindungsbenutzername",
   "configuration.SAS.connectionProfiles.profiles.tokenFile": "SAS Viya Token Datei",
   "configuration.SAS.connectionProfiles.profiles.username": "SAS Viya Benutzer ID",
-  "configuration.SAS.session.outputHtml": "Aktiveren/deaktiveren der ODS HTML5 Ausgabe",
+  "configuration.SAS.results.html.enabled": "Aktiveren/deaktiveren der ODS HTML5 Ausgabe",
   "configuration.SAS.results.html.style": "Lege den Style für ODS HTML5 Ergebnisse fest.",
   "configuration.SAS.results.html.style.(auto)": "Lassen Sie die Erweiterung einen Stil auswählen, der dem Farbschema am ehesten entspricht.",
   "configuration.SAS.results.html.style.(server default)": "Nutze den auf dem SAS Server konfigurierten Standardstyle.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -43,7 +43,7 @@
   "configuration.SAS.connectionProfiles.profiles.ssh.username": "SAS SSH Connection username",
   "configuration.SAS.connectionProfiles.profiles.tokenFile": "SAS Viya Token File",
   "configuration.SAS.connectionProfiles.profiles.username": "SAS Viya User ID",
-  "configuration.SAS.session.outputHtml": "Enable/disable ODS HTML5 output",
+  "configuration.SAS.results.html.enabled": "Enable/disable ODS HTML5 output",
   "configuration.SAS.results.html.style": "Specifies the style for ODS HTML5 results.",
   "configuration.SAS.results.html.style.(auto)": "Let the extension pick a style that most closely matches the color theme.",
   "configuration.SAS.results.html.style.(server default)": "Default to the style configured on the SAS server.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -43,7 +43,7 @@
   "configuration.SAS.connectionProfiles.profiles.ssh.username": "SAS SSH 连接用户名",
   "configuration.SAS.connectionProfiles.profiles.tokenFile": "SAS Viya 令牌文件",
   "configuration.SAS.connectionProfiles.profiles.username": "SAS Viya 用户 ID",
-  "configuration.SAS.session.outputHtml": "启用/禁用 ODS HTML5 输出",
+  "configuration.SAS.results.html.enabled": "启用/禁用 ODS HTML5 输出",
   "configuration.SAS.results.html.style": "指定 ODS HTML5 结果的样式。",
   "configuration.SAS.results.html.style.(auto)": "让扩展程序选择与颜色主题最匹配的样式。",
   "configuration.SAS.results.html.style.(server default)": "默认为 SAS 服务器上配置的样式。",


### PR DESCRIPTION
**Summary**
Enabling HTML output has nothing to do with "session"; so, changed the ID to results.html.enabled which makes more sense, follows pattern with results.html.style, and easier to extend to other results formats in the future. Also, I think it makes more sense for the connection profiles (and related certificates) to appear first, since that is usually the first thing you do when getting going with the extension.

**Testing**
- Ensured the extension settings are now in the desired order. (Note: When you open the extension settings from the extension in the Extensions pane, it looks like the settings are in alphabetical order rather than the specified order. To see the specified order, type "sas" in the search field or select Extensions->SAS in the settings tab.)
- Ensure the "HTML: Enabled" and "HTML: Style" settings still work as desired.