### PR TITLE
fix: do not rename when cancel input (#504)

### DIFF
--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -195,8 +195,7 @@ class ContentNavigator implements SubscriptionProvider {
             value: resource.name,
             validateInput: isContainer ? folderValidator : fileValidator,
           });
-
-          if (name === resource.name) {
+          if (name === resource.name || !name) {
             return;
           }
 

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -195,7 +195,7 @@ class ContentNavigator implements SubscriptionProvider {
             value: resource.name,
             validateInput: isContainer ? folderValidator : fileValidator,
           });
-          if (name === resource.name || !name) {
+          if (!name || name === resource.name) {
             return;
           }
 


### PR DESCRIPTION
**Summary**
fix #504 
Do not rename when cancelling the input box

**Testing**
as described in #504.