### PR TITLE
fix: add proper content-type for rename (#507)

### DIFF
--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -300,6 +300,7 @@ export class ContentModel {
           headers: {
             "If-Unmodified-Since": fileTokenMap.lastModified,
             "If-Match": fileTokenMap.etag,
+            "Content-Type": "application/vnd.sas.file+json",
           },
         },
       );


### PR DESCRIPTION
**Summary**
Fix #507. Add Content-Type: "application/vnd.sas.file+json" in the header when renaming an item

**Testing**
As described in #507.
