### PR TITLE
fix: update high contrast data viewer theming

### DIFF
--- a/client/src/webview/DataViewer.css
+++ b/client/src/webview/DataViewer.css
@@ -50,23 +50,27 @@ body,
 
 /* DARK MODE ICONS */
 
-.vscode-dark .header-icon.float {
+.vscode-dark .header-icon.float,
+.vscode-high-contrast .header-icon.float {
   background: url(../../../icons/dark/tableHeaderNumericTypeDark.svg) center
     no-repeat;
 }
 
 .header-icon.time,
 .header-icon.date-time,
-.vscode-dark .header-icon.date {
+.vscode-dark .header-icon.date,
+.vscode-high-contrast .header-icon.date {
   background: url(../../../icons/dark/tableHeaderDateDark.svg) center no-repeat;
 }
 
-.vscode-dark .header-icon.currency {
+.vscode-dark .header-icon.currency,
+.vscode-high-contrast .header-icon.currency {
   background: url(../../../icons/dark/tableHeaderCurrencyDark.svg) center
     no-repeat;
 }
 
-.vscode-dark .header-icon.char {
+.vscode-dark .header-icon.char,
+.vscode-high-contrast .header-icon.char {
   background: url(../../../icons/dark/tableHeaderCharacterTypeDark.svg) center
     no-repeat;
 }

--- a/client/src/webview/DataViewer.tsx
+++ b/client/src/webview/DataViewer.tsx
@@ -1,6 +1,6 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { createElement, useState } from "react";
+import { createElement, useMemo } from "react";
 import { createRoot } from "react-dom/client";
 
 import { AgGridReact } from "ag-grid-react";
@@ -21,11 +21,20 @@ const gridStyles = {
 
 const DataViewer = () => {
   const { columns, onGridReady } = useDataViewer();
-  const [theme] = useState(
-    document.querySelector(".vscode-dark")
-      ? "ag-theme-alpine-dark"
-      : "ag-theme-alpine",
-  );
+  const theme = useMemo(() => {
+    const themeKind = document
+      .querySelector("[data-vscode-theme-kind]")
+      .getAttribute("data-vscode-theme-kind");
+
+    switch (themeKind) {
+      case "vscode-high-contrast-light":
+      case "vscode-light":
+        return "ag-theme-alpine";
+      case "vscode-high-contrast":
+      case "vscode-dark":
+        return "ag-theme-alpine-dark";
+    }
+  }, []);
 
   if (columns.length === 0) {
     return null;


### PR DESCRIPTION
**Summary**
Prior to this change, we checked to see if we were using a dark theme and applied the `ag-alpine-theme-dark` theme. This changes makes it such that we target `ag-alpine-theme-dark` for both dark and high contrast dark themes, and default to the light theme `ag-alpine-theme` in other cases

**Testing**
 - [x] Test locally using light/dark theme
 - [x] Test via vsix install for high contrast
