### PR TITLE
feat: option to control the default placement of Result panel

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -6,7 +6,6 @@ import {
   ProgressLocation,
   Selection,
   Uri,
-  ViewColumn,
   commands,
   l10n,
   window,
@@ -16,6 +15,7 @@ import type { BaseLanguageClient } from "vscode-languageclient";
 import { wrapCodeWithOutputHtml } from "../components/Helper/SasCodeHelper";
 import { isOutputHtmlEnabled } from "../components/Helper/SettingHelper";
 import { LogFn as LogChannelFn } from "../components/LogChannel";
+import { showResult } from "../components/ResultPanel";
 import { OnLogFn, RunResult, getSession } from "../connection";
 import { profileConfig, switchProfile } from "./profile";
 
@@ -139,13 +139,7 @@ async function runCode(selected?: boolean, uri?: Uri) {
       });
       return session.run(code).then((results) => {
         if (outputHtml && results.html5) {
-          const odsResult = window.createWebviewPanel(
-            "SASSession", // Identifies the type of the webview. Used internally
-            l10n.t("Result"), // Title of the panel displayed to the user
-            { preserveFocus: true, viewColumn: ViewColumn.Beside }, // Editor column to show the new webview panel in.
-            {}, // Webview options. More on these later.
-          );
-          odsResult.webview.html = results.html5;
+          showResult(results.html5, uri);
         }
       });
     },

--- a/client/src/components/Helper/SettingHelper.ts
+++ b/client/src/components/Helper/SettingHelper.ts
@@ -9,3 +9,11 @@ export function isOutputHtmlEnabled(): boolean {
 export function getHtmlStyle(): string {
   return workspace.getConfiguration("SAS").get("results.html.style");
 }
+
+export function isSideResultEnabled(): string {
+  return workspace.getConfiguration("SAS").get("results.sideBySide");
+}
+
+export function isSinglePanelEnabled(): string {
+  return workspace.getConfiguration("SAS").get("results.singlePanel");
+}

--- a/client/src/components/ResultPanel.ts
+++ b/client/src/components/ResultPanel.ts
@@ -34,7 +34,7 @@ export const showResult = (html: string, uri?: Uri, title?: string) => {
       resultPanel.title = title;
     }
     resultPanel.reveal(
-      sideResult ? ViewColumn.Beside : editor.viewColumn,
+      sideResult ? ViewColumn.Beside : editor?.viewColumn,
       true,
     );
   }

--- a/client/src/components/ResultPanel.ts
+++ b/client/src/components/ResultPanel.ts
@@ -12,11 +12,14 @@ let resultPanel: WebviewPanel | undefined;
 export const showResult = (html: string, uri?: Uri, title?: string) => {
   const sideResult = isSideResultEnabled();
   const singlePanel = isSinglePanelEnabled();
+  if (!title) {
+    title = l10n.t("Result");
+  }
 
   if (!singlePanel || !resultPanel) {
     resultPanel = window.createWebviewPanel(
       "SASSession", // Identifies the type of the webview. Used internally
-      title ?? l10n.t("Result"), // Title of the panel displayed to the user
+      title, // Title of the panel displayed to the user
       {
         preserveFocus: true,
         viewColumn: sideResult ? ViewColumn.Beside : ViewColumn.Active,
@@ -30,7 +33,7 @@ export const showResult = (html: string, uri?: Uri, title?: string) => {
           (editor) => editor.document.uri.toString() === uri.toString(),
         )
       : window.activeTextEditor;
-    if (title) {
+    if (resultPanel.title !== title) {
       resultPanel.title = title;
     }
     resultPanel.reveal(

--- a/client/src/components/ResultPanel.ts
+++ b/client/src/components/ResultPanel.ts
@@ -1,0 +1,42 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { Uri, ViewColumn, WebviewPanel, l10n, window } from "vscode";
+
+import {
+  isSideResultEnabled,
+  isSinglePanelEnabled,
+} from "./Helper/SettingHelper";
+
+let resultPanel: WebviewPanel | undefined;
+
+export const showResult = (html: string, uri?: Uri, title?: string) => {
+  const sideResult = isSideResultEnabled();
+  const singlePanel = isSinglePanelEnabled();
+
+  if (!singlePanel || !resultPanel) {
+    resultPanel = window.createWebviewPanel(
+      "SASSession", // Identifies the type of the webview. Used internally
+      title ?? l10n.t("Result"), // Title of the panel displayed to the user
+      {
+        preserveFocus: true,
+        viewColumn: sideResult ? ViewColumn.Beside : ViewColumn.Active,
+      }, // Editor column to show the new webview panel in.
+      {}, // Webview options. More on these later.
+    );
+    resultPanel.onDidDispose(() => (resultPanel = undefined));
+  } else {
+    const editor = uri
+      ? window.visibleTextEditors.find(
+          (editor) => editor.document.uri.toString() === uri.toString(),
+        )
+      : window.activeTextEditor;
+    if (title) {
+      resultPanel.title = title;
+    }
+    resultPanel.reveal(
+      sideResult ? ViewColumn.Beside : editor.viewColumn,
+      true,
+    );
+  }
+  resultPanel.webview.html = html;
+};

--- a/client/src/components/tasks/SasTasks.ts
+++ b/client/src/components/tasks/SasTasks.ts
@@ -1,6 +1,6 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { EventEmitter, TaskDefinition, ViewColumn, l10n, window } from "vscode";
+import { EventEmitter, TaskDefinition, l10n } from "vscode";
 
 import { runTask } from "../../commands/run";
 import { RunResult } from "../../connection";
@@ -10,6 +10,7 @@ import {
   wrapCode,
 } from "../Helper/SasCodeHelper";
 import { isOutputHtmlEnabled } from "../Helper/SettingHelper";
+import { showResult } from "../ResultPanel";
 
 export const SAS_TASK_TYPE = "sas";
 
@@ -71,12 +72,10 @@ function showRunResult(
 
   if (outputHtml && results.html5) {
     messageEmitter.fire(l10n.t("Show results...") + "\r\n");
-    const odsResult = window.createWebviewPanel(
-      "SASSession", // Identifies the type of the webview. Used internally
-      l10n.t("Result: {result}", { result: taskName }), // Title of the panel displayed to the user
-      { preserveFocus: true, viewColumn: ViewColumn.Beside }, // Editor column to show the new webview panel in.
-      {}, // Webview options. More on these later.
+    showResult(
+      results.html5,
+      undefined,
+      l10n.t("Result: {result}", { result: taskName }),
     );
-    odsResult.webview.html = results.html5;
   }
 }

--- a/package.json
+++ b/package.json
@@ -357,14 +357,26 @@
               "type": "string"
             }
           },
-          "SAS.results.html.enabled": {
+          "SAS.results.sideBySide": {
             "order": 2,
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.SAS.results.sideBySide%"
+          },
+          "SAS.results.singlePanel": {
+            "order": 3,
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.SAS.results.singlePanel%"
+          },
+          "SAS.results.html.enabled": {
+            "order": 4,
             "type": "boolean",
             "default": true,
             "description": "%configuration.SAS.results.html.enabled%"
           },
           "SAS.results.html.style": {
-            "order": 3,
+            "order": 5,
             "type": "string",
             "default": "(auto)",
             "enum": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -47,6 +47,8 @@
   "configuration.SAS.results.html.style": "Specifies the style for ODS HTML5 results.",
   "configuration.SAS.results.html.style.(auto)": "Let the extension pick a style that most closely matches the color theme.",
   "configuration.SAS.results.html.style.(server default)": "Default to the style configured on the SAS server.",
+  "configuration.SAS.results.sideBySide": "Display results to the side of the code",
+  "configuration.SAS.results.singlePanel": "Reuse single panel to display results",
   "configuration.SAS.userProvidedCertificates": "Provide trusted CA certificate files",
   "notebooks.SAS.htmlRenderer": "SAS HTML Renderer",
   "notebooks.SAS.logRenderer": "SAS Log Renderer",


### PR DESCRIPTION
**Summary**
Resolve #62
Added `Display results to the side of the code` setting. If uncheck, it will display Result in the same tab group to the submitted code.
Added `Reuse single panel to display results` setting. If uncheck, it will display new Result panel each time.

**Testing**
By default the behavior is same to current version. Tested combinations of different settings.