### PR TITLE
Assign _SASPROGRAMFILE macro-variable to full path and filename of submitted SAS program (Local SAS 9.4)

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -29,8 +29,8 @@ interface FoldingBlock {
 let running = false;
 
 function getCode(selected = false, uri?: Uri): string {
-  if(uri){
-    console.log('run.ts::getCode() - uri.fsPath:', uri.fsPath && uri.fsPath );
+  if (uri) {
+    console.log("run.ts::getCode() - uri.fsPath:", uri.fsPath && uri.fsPath);
   }
   const editor = uri
     ? window.visibleTextEditors.find(
@@ -41,13 +41,17 @@ function getCode(selected = false, uri?: Uri): string {
   let code = "";
   let setCodeFile = "";
   if (uri && uri.fsPath) {
-    setCodeFile = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + uri.fsPath + '));\n';
+    setCodeFile =
+      "option set=SAS_EXECFILEPATH=%sysfunc(quote(" + uri.fsPath + "));\n";
   } else if (doc) {
     if (doc.fileName) {
-      setCodeFile = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + doc.fileName + '));\n';
-    }
-    else if (doc.uri && doc.uri.fsPath) {
-      setCodeFile = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + doc.uri.fsPath + '));\n';
+      setCodeFile =
+        "option set=SAS_EXECFILEPATH=%sysfunc(quote(" + doc.fileName + "));\n";
+    } else if (doc.uri && doc.uri.fsPath) {
+      setCodeFile =
+        "option set=SAS_EXECFILEPATH=%sysfunc(quote(" +
+        doc.uri.fsPath +
+        "));\n";
     }
   }
   if (selected) {

--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -13,7 +13,10 @@ import {
 } from "vscode";
 import type { BaseLanguageClient } from "vscode-languageclient";
 
-import { wrapCodeWithOutputHtml } from "../components/Helper/SasCodeHelper";
+import {
+  assign_SASProgramFile,
+  wrapCodeWithOutputHtml,
+} from "../components/Helper/SasCodeHelper";
 import { isOutputHtmlEnabled } from "../components/Helper/SettingHelper";
 import { LogFn as LogChannelFn } from "../components/LogChannel";
 import { OnLogFn, RunResult, getSession } from "../connection";
@@ -63,11 +66,7 @@ function getCode(selected = false, uri?: Uri): string {
     code = doc?.getText();
   }
   if (codeFile) {
-    // Environment Variable SAS_EXECFILEPATH is set by SAS Enhanced Editor
-    // code = "option set=SAS_EXECFILEPATH=%sysfunc(quote(" + codeFile + "));\n" + code;
-
-    // Macro-variable &_SASPROGRAMFILE is set in SAS Studio and SAS Enterprise Guide
-    code = "%let _SASPROGRAMFILE = %bquote(" + codeFile + ");\n" + code;
+    code = assign_SASProgramFile(code, codeFile);
   }
   return wrapCodeWithOutputHtml(code);
 }

--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -29,6 +29,9 @@ interface FoldingBlock {
 let running = false;
 
 function getCode(selected = false, uri?: Uri): string {
+  if(uri){
+    console.log('run.ts::getCode() - uri.fsPath:', uri.fsPath && uri.fsPath );
+  }
   const editor = uri
     ? window.visibleTextEditors.find(
         (editor) => editor.document.uri.toString() === uri.toString(),
@@ -36,6 +39,17 @@ function getCode(selected = false, uri?: Uri): string {
     : window.activeTextEditor;
   const doc = editor?.document;
   let code = "";
+  let setCodeFile = "";
+  if (uri && uri.fsPath) {
+    setCodeFile = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + uri.fsPath + '));\n';
+  } else if (doc) {
+    if (doc.fileName) {
+      setCodeFile = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + doc.fileName + '));\n';
+    }
+    else if (doc.uri && doc.uri.fsPath) {
+      setCodeFile = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + doc.uri.fsPath + '));\n';
+    }
+  }
   if (selected) {
     // run selected code if there is one or more non-empty selections, otherwise run all code
 
@@ -52,7 +66,8 @@ function getCode(selected = false, uri?: Uri): string {
   } else {
     code = doc?.getText();
   }
-
+  code = setCodeFile + code;
+  // console.log('code:', code);
   return wrapCodeWithOutputHtml(code);
 }
 

--- a/client/src/components/Helper/SasCodeHelper.ts
+++ b/client/src/components/Helper/SasCodeHelper.ts
@@ -94,10 +94,18 @@ export async function getSASCodeFromActiveEditor() {
 
   checkCodeIsNotEmpty(sasCode);
   if (activeEditor.document.fileName) {
+    // Environment Variable SAS_EXECFILEPATH is set by SAS Enhanced Editor
+    // sasCode =
+    //   "option set=SAS_EXECFILEPATH=%sysfunc(quote(" +
+    //   activeEditor.document.fileName +
+    //   "));\n" +
+    //   sasCode;
+
+    // Macro-variable &_SASPROGRAMFILE is set in SAS Studio and SAS Enterprise Guide
     sasCode =
-      "option set=SAS_EXECFILEPATH=%sysfunc(quote(" +
+      "%let _SASPROGRAMFILE = %bquote(" +
       activeEditor.document.fileName +
-      "));\n" +
+      ");\n" +
       sasCode;
   }
 
@@ -126,8 +134,12 @@ export async function getSASCodeFromFile(file: string) {
 
   checkCodeIsNotEmpty(sasCode);
 
-  sasCode =
-    "option set=SAS_EXECFILEPATH=%sysfunc(quote(" + fileUri + "));\n" + sasCode;
+  // Environment Variable SAS_EXECFILEPATH is set by SAS Enhanced Editor
+  // sasCode =
+  //   "option set=SAS_EXECFILEPATH=%sysfunc(quote(" + fileUri + "));\n" + sasCode;
+
+  // Macro-variable &_SASPROGRAMFILE is set in SAS Studio and SAS Enterprise Guide
+  sasCode = "%let _SASPROGRAMFILE = %bquote(" + fileUri + ");\n" + sasCode;
 
   return sasCode;
 }

--- a/client/src/components/Helper/SasCodeHelper.ts
+++ b/client/src/components/Helper/SasCodeHelper.ts
@@ -92,7 +92,10 @@ export async function getSASCodeFromActiveEditor() {
   }
 
   checkCodeIsNotEmpty(sasCode);
-
+  if (activeEditor.document.fileName) {
+    sasCode = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + activeEditor.document.fileName + '));\n' + sasCode;
+  }
+  
   return sasCode;
 }
 
@@ -103,6 +106,7 @@ export async function getSASCodeFromFile(file: string) {
   if (isAbsolute(file)) {
     const textDocument = await workspace.openTextDocument(file);
     if (textDocument.languageId === "sas") {
+      fileUri = file ;
       sasCode = textDocument.getText();
     } else {
       throw new Error(l10n.t("Not a valid sas file: {file}", { file }));
@@ -116,6 +120,8 @@ export async function getSASCodeFromFile(file: string) {
   }
 
   checkCodeIsNotEmpty(sasCode);
+
+  sasCode = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + fileUri + '));\n' + sasCode;
 
   return sasCode;
 }

--- a/client/src/components/Helper/SasCodeHelper.ts
+++ b/client/src/components/Helper/SasCodeHelper.ts
@@ -94,9 +94,13 @@ export async function getSASCodeFromActiveEditor() {
 
   checkCodeIsNotEmpty(sasCode);
   if (activeEditor.document.fileName) {
-    sasCode = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + activeEditor.document.fileName + '));\n' + sasCode;
+    sasCode =
+      "option set=SAS_EXECFILEPATH=%sysfunc(quote(" +
+      activeEditor.document.fileName +
+      "));\n" +
+      sasCode;
   }
-  
+
   return sasCode;
 }
 
@@ -107,7 +111,7 @@ export async function getSASCodeFromFile(file: string) {
   if (isAbsolute(file)) {
     const textDocument = await workspace.openTextDocument(file);
     if (textDocument.languageId === "sas") {
-      fileUri = file ;
+      fileUri = file;
       sasCode = textDocument.getText();
     } else {
       throw new Error(l10n.t("Not a valid sas file: {file}", { file }));
@@ -122,7 +126,8 @@ export async function getSASCodeFromFile(file: string) {
 
   checkCodeIsNotEmpty(sasCode);
 
-  sasCode = 'option set=SAS_EXECFILEPATH=%sysfunc(quote(' + fileUri + '));\n' + sasCode;
+  sasCode =
+    "option set=SAS_EXECFILEPATH=%sysfunc(quote(" + fileUri + "));\n" + sasCode;
 
   return sasCode;
 }

--- a/client/src/components/Helper/SasCodeHelper.ts
+++ b/client/src/components/Helper/SasCodeHelper.ts
@@ -94,21 +94,16 @@ export async function getSASCodeFromActiveEditor() {
 
   checkCodeIsNotEmpty(sasCode);
   if (activeEditor.document.fileName) {
-    // Environment Variable SAS_EXECFILEPATH is set by SAS Enhanced Editor
-    // sasCode =
-    //   "option set=SAS_EXECFILEPATH=%sysfunc(quote(" +
-    //   activeEditor.document.fileName +
-    //   "));\n" +
-    //   sasCode;
-
-    // Macro-variable &_SASPROGRAMFILE is set in SAS Studio and SAS Enterprise Guide
-    sasCode =
-      "%let _SASPROGRAMFILE = %bquote(" +
-      activeEditor.document.fileName +
-      ");\n" +
-      sasCode;
+    sasCode = assign_SASProgramFile(sasCode, activeEditor.document.fileName);
   }
 
+  return sasCode;
+}
+
+export function assign_SASProgramFile(code: string, codeFile: string) {
+  codeFile = codeFile.replace(/[('")]/g, "%$&");
+  const sasCode =
+    "%let _SASPROGRAMFILE = %nrquote(%nrstr(" + codeFile + "));\n" + code;
   return sasCode;
 }
 
@@ -134,12 +129,7 @@ export async function getSASCodeFromFile(file: string) {
 
   checkCodeIsNotEmpty(sasCode);
 
-  // Environment Variable SAS_EXECFILEPATH is set by SAS Enhanced Editor
-  // sasCode =
-  //   "option set=SAS_EXECFILEPATH=%sysfunc(quote(" + fileUri + "));\n" + sasCode;
-
-  // Macro-variable &_SASPROGRAMFILE is set in SAS Studio and SAS Enterprise Guide
-  sasCode = "%let _SASPROGRAMFILE = %bquote(" + fileUri + ");\n" + sasCode;
+  sasCode = assign_SASProgramFile(sasCode, fileUri);
 
   return sasCode;
 }

--- a/client/test/components/Helper/SasCodeHelper.test.ts
+++ b/client/test/components/Helper/SasCodeHelper.test.ts
@@ -12,9 +12,7 @@ describe("assign_SASProgramFile", () => {
       "assign_SASProgramFile returned unexpected string",
     );
   });
-});
 
-describe("assign_SASProgramFile", () => {
   it("correctly assigns unix style file path to &_SASPROGRAMFILE", () => {
     const code = "%put &=_SASPROGRAMFILE;";
     const fileName = `/tmp/My Test/R&D/mean(95%CI)/Parkinson's Disease example.sas`;

--- a/client/test/components/Helper/SasCodeHelper.test.ts
+++ b/client/test/components/Helper/SasCodeHelper.test.ts
@@ -1,0 +1,27 @@
+import * as assert from "assert";
+
+import { assign_SASProgramFile } from "../../../src/components/Helper/SasCodeHelper";
+
+describe("assign_SASProgramFile", () => {
+  it("correctly assigns windows style file path to &_SASPROGRAMFILE", () => {
+    const code = "%put &=_SASPROGRAMFILE;";
+    const fileName = `c:\\temp\\My Test\\R&D\\mean(95%CI)\\Parkinson's Disease example.sas`;
+    assert.equal(
+      assign_SASProgramFile(code, fileName),
+      `%let _SASPROGRAMFILE = %nrquote(%nrstr(c:\\temp\\My Test\\R&D\\mean%(95%CI%)\\Parkinson%'s Disease example.sas));\n%put &=_SASPROGRAMFILE;`,
+      "assign_SASProgramFile returned unexpected string",
+    );
+  });
+});
+
+describe("assign_SASProgramFile", () => {
+  it("correctly assigns unix style file path to &_SASPROGRAMFILE", () => {
+    const code = "%put &=_SASPROGRAMFILE;";
+    const fileName = `/tmp/My Test/R&D/mean(95%CI)/Parkinson's Disease example.sas`;
+    assert.equal(
+      assign_SASProgramFile(code, fileName),
+      `%let _SASPROGRAMFILE = %nrquote(%nrstr(/tmp/My Test/R&D/mean%(95%CI%)/Parkinson%'s Disease example.sas));\n%put &=_SASPROGRAMFILE;`,
+      "assign_SASProgramFile returned unexpected string",
+    );
+  });
+});


### PR DESCRIPTION
implements #521 

**Summary**
Add code to set environment variable SAS_EXECFILEPATH to the full path and filename of the SAS program code is being submitted from

**Testing**
manually tested against local SAS 9.4 profile
