### PR TITLE
fix: rename folder failed (#533)

### DIFF
--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -301,7 +301,10 @@ export class ContentModel {
           headers: {
             "If-Unmodified-Since": fileTokenMap.lastModified,
             "If-Match": fileTokenMap.etag,
-            "Content-Type": !isContainer(item) && !itemIsReference ? "application/vnd.sas.file+json" : undefined,
+            "Content-Type":
+              !isContainer(item) && !itemIsReference
+                ? "application/vnd.sas.file+json"
+                : undefined,
           },
         },
       );

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -301,7 +301,7 @@ export class ContentModel {
           headers: {
             "If-Unmodified-Since": fileTokenMap.lastModified,
             "If-Match": fileTokenMap.etag,
-            "Content-Type": "application/vnd.sas.file+json",
+            "Content-Type": !isContainer(item) && !itemIsReference ? "application/vnd.sas.file+json" : undefined,
           },
         },
       );


### PR DESCRIPTION
**Summary**
Fix #533
The content-type is invalid when the renaming item is a folder or favorite.

**Testing**
As described in #533 
