### PR TITLE
fix: associate sas-notebook with sasnb only

### DIFF
--- a/client/src/components/ContentNavigator/convert.ts
+++ b/client/src/components/ContentNavigator/convert.ts
@@ -309,26 +309,6 @@ QUIT;`;
   return codeList;
 }
 
-function generateCodeListFromPythonNotebook(content: string): Entry[] {
-  const codeList = [];
-  try {
-    const notebookContent = JSON.parse(content);
-    const language = notebookContent.metadata.kernelspec.language;
-    if (["python", "sas"].includes(language)) {
-      for (const cell of notebookContent.cells) {
-        const code = cell.source.join("");
-        const cellType = cell.cell_type;
-        if (code !== "" && cellType === "code") {
-          codeList.push({ code, language });
-        }
-      }
-    }
-  } catch (error) {
-    console.error("Error reading or parsing the .ipynb file:", error);
-  }
-  return codeList;
-}
-
 export function convertNotebookToFlow(
   content: string,
   inputName: string,
@@ -337,8 +317,6 @@ export function convertNotebookToFlow(
   let codeList = [];
   if (inputName.endsWith(".sasnb")) {
     codeList = generateCodeListFromSASNotebook(content);
-  } else if (inputName.endsWith(".ipynb")) {
-    codeList = generateCodeListFromPythonNotebook(content);
   } else {
     console.error("Unsupported file type");
   }

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -240,9 +240,7 @@ class ContentNavigator implements SubscriptionProvider {
           // Open window to chose the name and location of the new .flw file
           const name = await window.showInputBox({
             prompt: Messages.ConvertNotebookToFlowPrompt,
-            value: resource.name
-              .replace(".sasnb", ".flw")
-              .replace(".ipynb", ".flw"),
+            value: resource.name.replace(".sasnb", ".flw"),
             validateInput: flowFileValidator,
           });
 

--- a/client/src/components/ContentNavigator/utils.ts
+++ b/client/src/components/ContentNavigator/utils.ts
@@ -77,7 +77,7 @@ export const resourceType = (item: ContentItem): string | undefined => {
   }
 
   // if item is a notebook file add action
-  if (item?.name?.endsWith(".sasnb") || item?.name?.endsWith(".ipynb")) {
+  if (item?.name?.endsWith(".sasnb")) {
     actions.push("convertNotebookToFlow");
   }
 

--- a/client/test/components/ContentNavigator/convert.test.ts
+++ b/client/test/components/ContentNavigator/convert.test.ts
@@ -185,19 +185,4 @@ describe("Notebook Conversion", async () => {
     );
     deepEqual(flowDataActual, flowDataExpected, "The flow data is not correct");
   });
-
-  it("convert the python notebook to node flow", async () => {
-    await updateWorkspaceSettings("Node");
-    const contentPythonNotebook =
-      getTestFixtureContent("test.ipynb").toString();
-    const flowDataPythonNotebook =
-      getTestFixtureContent("test_ipynb.flw").toString();
-    const [flowDataActual, flowDataExpected] = convertAndRemoveIds(
-      contentPythonNotebook,
-      "test.ipynb",
-      flowDataPythonNotebook,
-      workspace.getConfiguration().get("SAS.flowConversionMode"),
-    );
-    deepEqual(flowDataActual, flowDataExpected, "The flow data is not correct");
-  });
 });

--- a/package.json
+++ b/package.json
@@ -876,7 +876,7 @@
         "displayName": "%notebooks.SAS.sasNotebook%",
         "selector": [
           {
-            "filenamePattern": "*.{sasnb,ipynb}"
+            "filenamePattern": "*.{sasnb}"
           }
         ]
       }


### PR DESCRIPTION
**Summary**
Removes conversion of .ipynb to flow. We only want to support converting .sasnb files to flow.
Removes default association of .ipynb to the sas-notebook component since this causes .ipynb files to no longer render when opened.

**Testing**
Steps in #537 
