### PR TITLE
feat: allow convert to flow for explorer files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If you introduce breaking changes, please group them together in the "Changed" section using the **BREAKING:** prefix.
 
+## [Unreleased]
+
+### Added
+
+- Added the ability to use `Convert to flow...` for sas notebooks in the local filesystem ([#552](https://github.com/sassoftware/vscode-sas-extension/pull/552))
+
 ## [v1.4.1] - 2023-09-29
 
 ### Fixed

--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -267,15 +267,6 @@ class ContentDataProvider
     return this.model.saveContentToUri(uri, new TextDecoder().decode(content));
   }
 
-  public associateFlow(
-    name: string,
-    uri: Uri,
-    parent: ContentItem,
-    studioSessionId: string,
-  ): Promise<string> {
-    return this.model.associateFlowFile(name, uri, parent, studioSessionId);
-  }
-
   public async deleteResource(item: ContentItem): Promise<boolean> {
     if (!(await closeFileIfOpen(item))) {
       return false;
@@ -414,7 +405,12 @@ class ContentDataProvider
         l10n.t(Messages.NewFileCreationError, { name: inputName }),
       );
       // associate the new .flw file with SAS Studio
-      await this.associateFlow(outputName, newUri, parentItem, studioSessionId);
+      await this.model.associateFlowFile(
+        outputName,
+        newUri,
+        parentItem,
+        studioSessionId,
+      );
     } catch (error) {
       window.showErrorMessage(error);
     }

--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -37,6 +37,7 @@ import { ViyaProfile } from "../profile";
 import { ContentModel } from "./ContentModel";
 import {
   FAVORITES_FOLDER_TYPE,
+  MYFOLDER_TYPE,
   Messages,
   ROOT_FOLDER_TYPE,
   TRASH_FOLDER_TYPE,
@@ -365,43 +366,60 @@ class ContentDataProvider
     this.reveal(resource);
   }
 
-  public async testStudioConnection(): Promise<string> {
-    return await this.model.testStudioConnection();
+  public async acquireStudioSessionId(endpoint: string): Promise<string> {
+    if (endpoint && !this.model.connected()) {
+      await this.connect(endpoint);
+    }
+    return await this.model.acquireStudioSessionId();
   }
 
   public async convertNotebookToFlow(
-    item: ContentItem,
-    name: string,
+    inputName: string,
+    outputName: string,
+    content: string,
     studioSessionId: string,
-  ): Promise<string | undefined> {
-    const parent = await this.getParent(item);
-    const resourceUri = getUri(item);
+    parentItem?: ContentItem,
+  ): Promise<string> {
+    if (!parentItem) {
+      const rootFolders = await this.model.getChildren();
+      const myFolder = rootFolders.find(
+        (rootFolder) => rootFolder.type === MYFOLDER_TYPE,
+      );
+      if (!myFolder) {
+        return "";
+      }
+      parentItem = myFolder;
+    }
+
     try {
-      // get the content of the notebook file
-      const contentString: string =
-        await this.provideTextDocumentContent(resourceUri);
       // convert the notebook file to a .flw file
       const flowDataString = convertNotebookToFlow(
-        contentString,
-        item.name,
-        name,
+        content,
+        inputName,
+        outputName,
       );
       const flowDataUint8Array = new TextEncoder().encode(flowDataString);
       if (flowDataUint8Array.length === 0) {
         window.showErrorMessage(Messages.NoCodeToConvert);
         return;
       }
-      const newUri = await this.createFile(parent, name, flowDataUint8Array);
+      const newUri = await this.createFile(
+        parentItem,
+        outputName,
+        flowDataUint8Array,
+      );
       this.handleCreationResponse(
-        parent,
+        parentItem,
         newUri,
-        l10n.t(Messages.NewFileCreationError, { name: name }),
+        l10n.t(Messages.NewFileCreationError, { name: inputName }),
       );
       // associate the new .flw file with SAS Studio
-      return await this.associateFlow(name, newUri, parent, studioSessionId);
+      await this.associateFlow(outputName, newUri, parentItem, studioSessionId);
     } catch (error) {
       window.showErrorMessage(error);
     }
+
+    return parentItem.name;
   }
 
   public refresh(): void {

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -56,6 +56,10 @@ export class ContentModel {
     this.viyaCadence = "";
   }
 
+  public connected(): boolean {
+    return this.authorized;
+  }
+
   public async connect(baseURL: string): Promise<void> {
     this.connection = axios.create({ baseURL });
     this.connection.interceptors.response.use(
@@ -189,9 +193,15 @@ export class ContentModel {
 
   public async getContentByUri(uri: Uri): Promise<string> {
     const resourceId = getResourceId(uri);
-    const res = await this.connection.get(resourceId + "/content", {
-      transformResponse: (response) => response,
-    });
+    let res;
+    try {
+      res = await this.connection.get(resourceId + "/content", {
+        transformResponse: (response) => response,
+      });
+    } catch (e) {
+      throw new Error(Messages.FileOpenError);
+    }
+
     this.fileTokenMaps[resourceId] = {
       etag: res.headers.etag,
       lastModified: res.headers["last-modified"],
@@ -365,7 +375,7 @@ export class ContentModel {
     }
   }
 
-  public async testStudioConnection(): Promise<string> {
+  public async acquireStudioSessionId(): Promise<string> {
     try {
       const result = await createStudioSession(this.connection);
       return result;

--- a/client/src/components/ContentNavigator/const.ts
+++ b/client/src/components/ContentNavigator/const.ts
@@ -28,7 +28,8 @@ export const ROOT_FOLDER = {
 };
 
 export const FILE_TYPE = "file";
-export const FILE_TYPES = [FILE_TYPE, "dataFlow"];
+export const DATAFLOW_TYPE = "dataFlow";
+export const FILE_TYPES = [FILE_TYPE, DATAFLOW_TYPE];
 export const FOLDER_TYPE = "folder";
 export const MYFOLDER_TYPE = "myFolder";
 export const TRASH_FOLDER_TYPE = "trashFolder";

--- a/client/src/components/ContentNavigator/const.ts
+++ b/client/src/components/ContentNavigator/const.ts
@@ -28,7 +28,7 @@ export const ROOT_FOLDER = {
 };
 
 export const FILE_TYPE = "file";
-export const FILE_TYPES = [FILE_TYPE];
+export const FILE_TYPES = [FILE_TYPE, "dataFlow"];
 export const FOLDER_TYPE = "folder";
 export const MYFOLDER_TYPE = "myFolder";
 export const TRASH_FOLDER_TYPE = "trashFolder";
@@ -85,7 +85,7 @@ export const Messages = {
   ),
   ConvertNotebookToFlowPrompt: l10n.t("Enter a name for the new .flw file"),
   NotebookToFlowConversionSuccess: l10n.t(
-    "The notebook has been successfully converted to a flow. You can now open it in SAS Studio.",
+    "The notebook has been successfully converted to a flow and saved into the following folder: {folderName}. You can now open it in SAS Studio.",
   ),
   NotebookToFlowConversionError: l10n.t(
     "Error converting the notebook file to .flw format.",

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -12,7 +12,6 @@ import {
   workspace,
 } from "vscode";
 
-import { readFileSync } from "fs";
 import { basename } from "path";
 
 import { profileConfig } from "../../commands/profile";
@@ -280,7 +279,7 @@ class ContentNavigator implements SubscriptionProvider {
                 ? await this.contentDataProvider.provideTextDocumentContent(
                     getUri(resource),
                   )
-                : readFileSync(resource.fsPath).toString();
+                : (await workspace.fs.readFile(resource)).toString();
 
               const folderName =
                 await this.contentDataProvider.convertNotebookToFlow(

--- a/client/src/components/ContentNavigator/utils.ts
+++ b/client/src/components/ContentNavigator/utils.ts
@@ -3,7 +3,7 @@
 import { Uri } from "vscode";
 
 import {
-  FILE_TYPE,
+  FILE_TYPES,
   FOLDER_TYPE,
   FOLDER_TYPES,
   TRASH_FOLDER_TYPE,
@@ -70,7 +70,7 @@ export const resourceType = (item: ContentItem): string | undefined => {
     actions.push("removeFromFavorites");
   } else if (
     item.type !== "reference" &&
-    [FOLDER_TYPE, FILE_TYPE].includes(type) &&
+    [FOLDER_TYPE, ...FILE_TYPES].includes(type) &&
     !isRecycled
   ) {
     actions.push("addToFavorites");

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -233,7 +233,7 @@ describe("ContentDataProvider", async function () {
 
     axiosInstance.get
       .withArgs(
-        "uri://myFavorites?limit=1000000&filter=in(contentType,'file','RootFolder','folder','myFolder','favoritesFolder','userFolder','userRoot','trashFolder')&sortBy=eq(contentType,'folder'):descending,name:primary:ascending,type:ascending",
+        "uri://myFavorites?limit=1000000&filter=in(contentType,'file','dataFlow','RootFolder','folder','myFolder','favoritesFolder','userFolder','userRoot','trashFolder')&sortBy=eq(contentType,'folder'):descending,name:primary:ascending,type:ascending",
       )
       .resolves({
         data: {

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -452,10 +452,10 @@ describe("ContentDataProvider", async function () {
       data: origItem,
       headers: { etag: "1234", "last-modified": "5678" },
     });
-    axiosInstance.patch
-      .withArgs("uri://rename", { name: "new-file.sas" })
+    axiosInstance.put
+      .withArgs("uri://rename", { ...origItem, name: "new-file.sas" })
       .resolves({
-        data: newItem,
+        data: { ...origItem, name: "new-file.sas" },
         headers: { etag: "1234", "last-modified": "5678" },
       });
 
@@ -487,10 +487,10 @@ describe("ContentDataProvider", async function () {
       data: item,
       headers: { etag: "1234", "last-modified": "5678" },
     });
-    axiosInstance.patch
-      .withArgs("uri://self", { name: "favorite-link.sas" })
+    axiosInstance.put
+      .withArgs("uri://self", { ...item, name: "favorite-link.sas" })
       .resolves({
-        data: item,
+        data: { ...item, name: "favorite-link.sas" },
         headers: { etag: "1234", "last-modified": "5678" },
       });
     axiosInstance.get.withArgs("uri://rename").resolves({

--- a/package.json
+++ b/package.json
@@ -617,7 +617,7 @@
       "explorer/context": [
         {
           "command": "SAS.convertNotebookToFlow",
-          "when": "resourceExtname == .sasnb && SAS.connectionType == rest",
+          "when": "resourceExtname == .sasnb && SAS.connectionType == rest && !SAS.connection.direct",
           "group": "actionsgroup@0"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -614,6 +614,13 @@
           "group": "navigation@1"
         }
       ],
+      "explorer/context": [
+        {
+          "command": "SAS.convertNotebookToFlow",
+          "when": "resourceExtname == .sasnb && SAS.connectionType == rest",
+          "group": "actionsgroup@0"
+        }
+      ],
       "view/item/context": [
         {
           "command": "SAS.deleteTable",


### PR DESCRIPTION
**Summary**
This does a few things to improve the sasnb -> dataflow experience:
 - Provides visual indication of converting a notebook to dataflow
 - allows converting sasnb files to notebooks from the explorer view (We default to storing notebooks in "My Folder")
 - updates messaging to indicate _where_ a notebook was created (mainly to clear up confusion about where the dataflow went)
 - updates sas content to display created dataflow files, and updates content model to display `FileOpenError` when trying to open files

**Testing**
 - [x] Attempted to "Convert to flow..." from sas content and local filesystem
 - [x] Attempted to open a flow file in vscode
 - [x] Test renaming dataflow
 - [x] Test renaming non-dataflow file
 - [x] Test deleting dataflow
 - [x] Test favoriting dataflow
