### PR TITLE
fix: check for failed state during session log stream to prevent unbounded loop

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -19,7 +19,12 @@ import {
   wrapCodeWithOutputHtml,
 } from "../components/utils/sasCode";
 import { isOutputHtmlEnabled } from "../components/utils/settings";
-import { OnLogFn, RunResult, getSession } from "../connection";
+import {
+  ErrorRepresentation,
+  OnLogFn,
+  RunResult,
+  getSession,
+} from "../connection";
 import { profileConfig, switchProfile } from "./profile";
 
 interface FoldingBlock {
@@ -233,7 +238,7 @@ export async function runTask(
   return cancelled ? undefined : session.run(code);
 }
 
-const isErrorRep = (err: unknown): err is SessionError => {
+const isErrorRep = (err: unknown): err is ErrorRepresentation => {
   if (
     err &&
     typeof err === "object" &&

--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -244,6 +244,7 @@ const isErrorRep = (err: unknown): err is ErrorRepresentation => {
     typeof err === "object" &&
     "message" in err &&
     "details" in err &&
+    Array.isArray(err.details) &&
     "errorCode" in err
   ) {
     return true;

--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -170,10 +170,7 @@ const _run = async (selected = false, uri?: Uri) => {
 
   await runCode(selected, uri)
     .catch((err) => {
-      console.dir(err);
-      window.showErrorMessage(
-        err.response?.data ? JSON.stringify(err.response.data) : err.message,
-      );
+      onRunError(err);
     })
     .finally(() => {
       running = false;
@@ -235,3 +232,41 @@ export async function runTask(
   messageEmitter.fire(`${l10n.t("SAS code running...")}\r\n`);
   return cancelled ? undefined : session.run(code);
 }
+
+const isErrorRep = (err: unknown): err is SessionError => {
+  if (
+    err &&
+    typeof err === "object" &&
+    "message" in err &&
+    "details" in err &&
+    "errorCode" in err
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const onRunError = (err) => {
+  console.dir(err);
+
+  if (err.response) {
+    // The request was made and we got a status code that falls out side of the 2xx range
+    const errorData = err.response.data;
+
+    if (isErrorRep(errorData)) {
+      //errorData is an error representation, extract out the details to show a better message
+      const details = errorData.details;
+      const options = {
+        modal: true,
+        detail: details.join("\n"),
+      };
+      window.showErrorMessage(errorData.message, options);
+    } else {
+      window.showErrorMessage(err.message);
+    }
+  } else {
+    // Either the request was made but no response was received, or
+    // there was an issue in the request setup itself, just show the message
+    window.showErrorMessage(err.message);
+  }
+};

--- a/client/src/connection/index.ts
+++ b/client/src/connection/index.ts
@@ -12,6 +12,7 @@ import {
 import { getSession as getCOMSession } from "./com";
 import { Config as RestConfig, getSession as getRestSession } from "./rest";
 import {
+  Error2 as ComputeError,
   LogLine as ComputeLogLine,
   LogLineTypeEnum as ComputeLogLineTypeEnum,
 } from "./rest/api/compute";
@@ -20,6 +21,7 @@ import { getSession as getSSHSession } from "./ssh";
 
 let profileConfig: ProfileConfig;
 
+export type ErrorRepresentation = ComputeError;
 export type LogLine = ComputeLogLine;
 export type LogLineTypeEnum = ComputeLogLineTypeEnum;
 export type OnLogFn = (logs: LogLine[]) => void;

--- a/client/src/connection/rest/session.ts
+++ b/client/src/connection/rest/session.ts
@@ -204,6 +204,7 @@ export class ComputeSession extends Compute {
       "warning",
       "completed",
       "idle",
+      "failed",
     ];
 
     while (states.indexOf(state) === -1) {


### PR DESCRIPTION
**Summary**
Check for failed state when streaming the session log to avoid attempting to check for logs in an unbounded loop.

**Testing**
Steps in #562 
