### PR TITLE
feat: close session on status bar

### DIFF
--- a/client/src/components/StatusBarItem.ts
+++ b/client/src/components/StatusBarItem.ts
@@ -1,0 +1,41 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { MarkdownString, StatusBarAlignment, Uri, l10n, window } from "vscode";
+
+import { profileConfig } from "../commands/profile";
+
+const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
+statusBarItem.command = "SAS.switchProfile";
+
+export const getStatusBarItem = () => statusBarItem;
+
+export async function updateStatusBarItem(connected?: boolean) {
+  const activeProfileName = profileConfig.getActiveProfile();
+  const activeProfile = profileConfig.getProfileByName(activeProfileName);
+  if (!activeProfile) {
+    resetStatusBarItem();
+  } else {
+    const targetURL = profileConfig.remoteTarget(activeProfileName);
+    const closeSessionUri = Uri.parse("command:SAS.close");
+    const tooltip = new MarkdownString(
+      `#### ${l10n.t("SAS Profile")}\n\n${activeProfileName}\n\n${targetURL}${
+        connected
+          ? `\n\n---\n\n[${l10n.t("Close Session")}](${closeSessionUri})`
+          : ""
+      }`,
+    );
+    tooltip.isTrusted = true;
+
+    statusBarItem.text = `${
+      connected ? "$(vm-active)" : "$(account)"
+    } ${activeProfileName}`;
+    statusBarItem.tooltip = tooltip;
+    statusBarItem.show();
+  }
+}
+
+export function resetStatusBarItem(): void {
+  statusBarItem.text = `$(debug-disconnect) ${l10n.t("No Profile")}`;
+  statusBarItem.tooltip = l10n.t("No SAS Connection Profile");
+  statusBarItem.show();
+}

--- a/client/src/connection/com/index.ts
+++ b/client/src/connection/com/index.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 
 import { BaseConfig, RunResult } from "..";
+import { updateStatusBarItem } from "../../components/StatusBarItem";
 import { Session } from "../session";
 import { scriptContent } from "./script";
 
@@ -151,6 +152,7 @@ export class COMSession extends Session {
         this._runResolve = undefined;
       }
       resolve();
+      updateStatusBarItem(false);
     });
   };
 
@@ -212,6 +214,7 @@ do {
         const parts = line.split("WORKDIR=");
         this._workDirectory = parts[1].trim();
         this._runResolve();
+        updateStatusBarItem(true);
         return;
       }
       if (line.endsWith(endCode)) {

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -8,6 +8,7 @@ import {
   getContextValue,
   setContextValue,
 } from "../../components/ExtensionContext";
+import { updateStatusBarItem } from "../../components/StatusBarItem";
 import { Session } from "../session";
 import { ContextsApi, SessionsApi } from "./api/compute";
 import { ComputeState, getApiConfig } from "./common";
@@ -85,6 +86,7 @@ class RestSession extends Session {
     if (this._computeSession) {
       //reconnected to a running session, so just return
       await this.printSessionLog(this._computeSession);
+      updateStatusBarItem(true);
       return;
     }
 
@@ -133,6 +135,7 @@ class RestSession extends Session {
 
     //Save the current sessionId
     setContextValue("SAS.sessionId", this._computeSession.sessionId);
+    updateStatusBarItem(true);
   };
 
   public run = async (code: string) => {
@@ -193,6 +196,7 @@ class RestSession extends Session {
 
       //Since the session is being closed, remove the cached session id
       setContextValue("SAS.sessionId", undefined);
+      updateStatusBarItem(false);
     }
   };
 

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -5,6 +5,7 @@ import { l10n } from "vscode";
 import { Client, ClientChannel, ConnectConfig } from "ssh2";
 
 import { BaseConfig, RunResult } from "..";
+import { updateStatusBarItem } from "../../components/StatusBarItem";
 import { Session } from "../session";
 
 const endCode = "--vscode-sas-extension-submit-end--";
@@ -168,6 +169,7 @@ export class SSHSession extends Session {
     this.html5FileName = "";
     this.timer = undefined;
     this.conn.end();
+    updateStatusBarItem(false);
   };
 
   private onStreamData = (data: Buffer): void => {
@@ -176,6 +178,7 @@ export class SSHSession extends Session {
     if (this.timer && output.endsWith("?")) {
       this.clearTimer();
       this.resolve?.();
+      updateStatusBarItem(true);
       return;
     }
 

--- a/connect-and-run.md
+++ b/connect-and-run.md
@@ -254,7 +254,7 @@ To run a piece of SAS code:
 - A new session must be created the first time you run SAS code. Connection time will vary depending on the server connection.
 - Currently, only HTML output is supported. By default, the ODS HTML5 statement is added to the submitted code. Clear the `Enable/disable ODS HTML5 output` option in the Settings editor for the SAS extension to disable this output.
 - When you click `Run`, the code in the active tab in the editor is submitted. Make sure that the correct tab is active when you run your program.
-- To reset your connection to SAS, run the `Close Current Session` command in VS Code or click the `Close Current Session` button next to the `Run` button.
+- To reset your connection to SAS, run the `Close Current Session` command in VS Code or click the `Close Session` button from the tooltip of the active profile status bar item.
 
 ## Run SAS Code by Task
 

--- a/package.json
+++ b/package.json
@@ -752,13 +752,6 @@
           "group": "navigation@3"
         }
       ],
-      "editor/title": [
-        {
-          "when": "editorLangId == sas",
-          "command": "SAS.close",
-          "group": "navigation"
-        }
-      ],
       "commandPalette": [
         {
           "when": "editorLangId == sas && !SAS.hideRunMenuItem",


### PR DESCRIPTION
**Summary**
Resolve #119

- Remove the disconnect button from the editor toolbar (next to the run button), as it's not specific to a file.
- Change the icon of the active profile status bar item when a compute session established to provide visual indication.
- Add `Close Session` button on the tooltip of the active profile status bar item when a compute session established.
- Add `SAS Profile` title to the tooltip of the active profile status bar item
- (Engineering) Extract status bar related code to a separate file

**Testing**
Create and close sessions to see the changes.
