### PR TITLE
chore: dependabot for /client /server and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # @types/vscode should match the engine version we're using
+      # should not be upgraded on its own
+      - dependency-name: "@types/vscode"
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    # Don't need to specify `/.github/workflows` for `directory`. Github knows it.
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
**Summary**
Looks like our current dependabot doesn't cover `/client` and `/server`. Guess it's a good idea to also keep them updated.

**Testing**
N/A
