### PR TITLE
feat: ods graphics on; in wrapper

### DIFF
--- a/client/src/components/utils/sasCode.ts
+++ b/client/src/components/utils/sasCode.ts
@@ -47,7 +47,7 @@ export function wrapCodeWithOutputHtml(code: string): string {
   if (outputHtml) {
     const htmlStyleOption = generateHtmlStyleOption();
     return `title;footnote;ods _all_ close;
-ods graphics / imagemap;
+ods graphics on;
 ods html5${htmlStyleOption} options(bitmap_mode='inline' svg_mode='inline');
 ${code}
 ;*';*";*/;run;quit;ods html5 close;`;

--- a/client/src/components/utils/sasCode.ts
+++ b/client/src/components/utils/sasCode.ts
@@ -47,6 +47,7 @@ export function wrapCodeWithOutputHtml(code: string): string {
   if (outputHtml) {
     const htmlStyleOption = generateHtmlStyleOption();
     return `title;footnote;ods _all_ close;
+ods graphics / imagemap;
 ods html5${htmlStyleOption} options(bitmap_mode='inline' svg_mode='inline');
 ${code}
 ;*';*";*/;run;quit;ods html5 close;`;


### PR DESCRIPTION
**Summary**
Adds ods graphics on; to ods wrapper code to better align with SAS Studio

**Testing**

1. Run a program  (example below).
```
title 'Shoe Sales Over $500,000';
data work.shoes;
   set sashelp.shoes;
   where sales>500000;
run;
```
2. Check the Output Log. Verify that ods graphics on; appears in the output log as a line.


