### PR TITLE
fix(core): ods html5 output path to work directory

### DIFF
--- a/client/src/components/utils/sasCode.ts
+++ b/client/src/components/utils/sasCode.ts
@@ -53,7 +53,7 @@ export function wrapCodeWithOutputHtml(code: string): string {
   const activeProfile = profileConfig.getActiveProfileDetail();
   const outputDestination =
     activeProfile &&
-      activeProfile.profile.connectionType !== ConnectionType.Rest
+    activeProfile.profile.connectionType !== ConnectionType.Rest
       ? ` body="${v4()}.htm"`
       : "";
 

--- a/client/src/components/utils/sasCode.ts
+++ b/client/src/components/utils/sasCode.ts
@@ -61,9 +61,9 @@ export function wrapCodeWithOutputHtml(code: string): string {
     const htmlStyleOption = generateHtmlStyleOption();
     return `title;footnote;ods _all_ close;
 ods graphics on;
-ods html5${htmlStyleOption} options(bitmap_mode='inline' svg_mode='inline')${outputDestination};
+ods html5(id=_vscode_sas)${htmlStyleOption} options(bitmap_mode='inline' svg_mode='inline')${outputDestination};
 ${code}
-;*';*";*/;run;quit;ods html5 close;`;
+;*';*";*/;run;quit;ods html5(id=_vscode_sas) close;`;
   } else {
     return code;
   }

--- a/client/src/components/utils/sasCode.ts
+++ b/client/src/components/utils/sasCode.ts
@@ -53,7 +53,7 @@ export function wrapCodeWithOutputHtml(code: string): string {
   const activeProfile = profileConfig.getActiveProfileDetail();
   const outputDestination =
     activeProfile &&
-    activeProfile.profile.connectionType !== ConnectionType.Rest
+      activeProfile.profile.connectionType !== ConnectionType.Rest
       ? ` body="${v4()}.htm"`
       : "";
 

--- a/client/src/components/utils/sasCode.ts
+++ b/client/src/components/utils/sasCode.ts
@@ -61,9 +61,9 @@ export function wrapCodeWithOutputHtml(code: string): string {
     const htmlStyleOption = generateHtmlStyleOption();
     return `title;footnote;ods _all_ close;
 ods graphics on;
-ods html5(id=_vscode_sas)${htmlStyleOption} options(bitmap_mode='inline' svg_mode='inline')${outputDestination};
+ods html5(id=vscode) ${htmlStyleOption} options(bitmap_mode='inline' svg_mode='inline')${outputDestination};
 ${code}
-;*';*";*/;run;quit;ods html5(id=_vscode_sas) close;`;
+;*';*";*/;run;quit;ods html5(id=vscode) close;`;
   } else {
     return code;
   }

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -226,8 +226,8 @@ export class ITCSession extends Session {
 
     //write ODS output to work so that the session cleans up after itself
     const codeWithODSPath = code.replace(
-      "ods html5;",
-      `ods html5 path="${this._workDirectory}";`,
+      /\bods html5\(id=vscode\)([^;]*;)/i,
+      `ods html5(id=vscode) path="${this._workDirectory}" $1`,
     );
 
     //write an end mnemonic so that the handler knows when execution has finished

--- a/client/test/connection/itc/index.test.ts
+++ b/client/test/connection/itc/index.test.ts
@@ -160,7 +160,7 @@ describe("ITC connection", () => {
     });
     it("calls run function from script", async () => {
       const runPromise = session.run(
-        `ods html5;\nproc print data=sashelp.cars;\nrun;`,
+        `ods html5(id=vscode);\nproc print data=sashelp.cars;\nrun;`,
       );
 
       //simulate log message for body file
@@ -174,7 +174,7 @@ describe("ITC connection", () => {
       expect(runResult.title).to.equal("Result");
 
       expect(stdinStub.args[13][0]).to.deep.equal(
-        `$code=\n@'\nods html5 path="/work/dir";\nproc print data=sashelp.cars;\nrun;\n%put --vscode-sas-extension-submit-end--;\n'@\n`,
+        `$code=\n@'\nods html5(id=vscode) path="/work/dir" ;\nproc print data=sashelp.cars;\nrun;\n%put --vscode-sas-extension-submit-end--;\n'@\n`,
       );
 
       expect(stdinStub.args[14][0]).to.deep.equal(`$runner.Run($code)\n`);


### PR DESCRIPTION
**Summary**
Add `ods html5;` to function `wrapCodeWithOutputHtml` and make it similar to SAS EG.

The reason to make the change is that the SAS will generate html files in th 'current' diretory instead of 'work' directory. For exampl, I can change the current directory with `%put %sysfunc(dlgcdir("&__prjpath./SAS"));`, and then SAS will generate the html file in the path of '&__prjpath./SAS', however, vscode-sas-extension wants find the file in the work directory.

There is a function in 'client/src/connection/com/index.ts' which try to correct the ods output path and depends on `ods html5;`
```ts
      //write ODS output to work so that the session cleans up after itself
      const codeWithODSPath = code.replace(
        "ods html5;",
        `ods html5 path="${this._workDirectory}";`,
      );
```

**Testing**
Using the COM in main branch or IOM in sas9-itc branch

```sas
%put %sysfunc(dlgcdir("&__prjpath./SAS"));
proc print data=sashelp.cars(obs=10) noobs;
run;
```
