### PR TITLE
fix: document symbol requires non-empty name

### DIFF
--- a/server/src/sas/LanguageServiceProvider.ts
+++ b/server/src/sas/LanguageServiceProvider.ts
@@ -140,7 +140,9 @@ export class LanguageServiceProvider {
       );
       if (rootBlock && rootBlock.startLine === i) {
         const docSymbol: DocumentSymbol = this._buildDocumentSymbol(rootBlock);
-        result.push(docSymbol);
+        if (docSymbol.name) {
+          result.push(docSymbol);
+        }
         i = rootBlock.endFoldingLine;
         continue;
       }
@@ -163,7 +165,7 @@ export class LanguageServiceProvider {
       selectionRange: range,
       children: [],
     };
-    if (parent) {
+    if (parent && docSymbol.name) {
       parent.children!.push(docSymbol);
     }
     for (const innerBlock of block.innerBlocks) {


### PR DESCRIPTION
**Summary**
Fix #715
VS Code now appears to require non-empty name for document symbol. Added guard check.

**Testing**
Test case in #715
