### PR TITLE
chore: create library adapter, make library model api agnostic

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -234,7 +234,7 @@ export async function runTask(
   session.onSessionLogFn = onSessionLog ?? appendSessionLogFn;
 
   messageEmitter.fire(`${l10n.t("Connecting to SAS session...")}\r\n`);
-  !cancelled && (await session.setup());
+  !cancelled && (await session.setup(true));
 
   messageEmitter.fire(`${l10n.t("SAS code running...")}\r\n`);
   return cancelled ? undefined : session.run(code);

--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -144,13 +144,7 @@ async function runCode(selected?: boolean, uri?: Uri) {
   session.onExecutionLogFn = appendExecutionLogFn;
   session.onSessionLogFn = appendSessionLogFn;
 
-  await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title: l10n.t("Connecting to SAS session..."),
-    },
-    session.setup,
-  );
+  await session.setup();
 
   await window.withProgress(
     {

--- a/client/src/components/LibraryNavigator/LibraryAdapterFactory.ts
+++ b/client/src/components/LibraryNavigator/LibraryAdapterFactory.ts
@@ -1,5 +1,7 @@
-// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ProgressLocation, l10n, window } from "vscode";
+
 import RestLibraryAdapter from "../../connection/rest/RestLibraryAdapter";
 import { ConnectionType } from "../profile";
 import { LibraryAdapter } from "./types";
@@ -9,8 +11,20 @@ class LibraryAdapterFactory {
     switch (connectionType) {
       case ConnectionType.Rest:
       default:
-        return new RestLibraryAdapter();
+        return new RestLibraryAdapter(this.emitConnectionNotification);
     }
+  }
+
+  private async emitConnectionNotification(
+    callback: () => Promise<void>,
+  ): Promise<void> {
+    await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: l10n.t("Connecting to SAS session..."),
+      },
+      callback,
+    );
   }
 }
 

--- a/client/src/components/LibraryNavigator/LibraryAdapterFactory.ts
+++ b/client/src/components/LibraryNavigator/LibraryAdapterFactory.ts
@@ -1,7 +1,5 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ProgressLocation, l10n, window } from "vscode";
-
 import RestLibraryAdapter from "../../connection/rest/RestLibraryAdapter";
 import { ConnectionType } from "../profile";
 import { LibraryAdapter } from "./types";
@@ -11,20 +9,8 @@ class LibraryAdapterFactory {
     switch (connectionType) {
       case ConnectionType.Rest:
       default:
-        return new RestLibraryAdapter(this.emitConnectionNotification);
+        return new RestLibraryAdapter();
     }
-  }
-
-  private async emitConnectionNotification(
-    callback: () => Promise<void>,
-  ): Promise<void> {
-    await window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title: l10n.t("Connecting to SAS session..."),
-      },
-      callback,
-    );
   }
 }
 

--- a/client/src/components/LibraryNavigator/LibraryAdapterFactory.ts
+++ b/client/src/components/LibraryNavigator/LibraryAdapterFactory.ts
@@ -1,0 +1,17 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import RestLibraryAdapter from "../../connection/rest/RestLibraryAdapter";
+import { ConnectionType } from "../profile";
+import { LibraryAdapter } from "./types";
+
+class LibraryAdapterFactory {
+  public create(connectionType: ConnectionType): LibraryAdapter {
+    switch (connectionType) {
+      case ConnectionType.Rest:
+      default:
+        return new RestLibraryAdapter();
+    }
+  }
+}
+
+export default LibraryAdapterFactory;

--- a/client/src/components/LibraryNavigator/LibraryDataProvider.ts
+++ b/client/src/components/LibraryNavigator/LibraryDataProvider.ts
@@ -25,10 +25,9 @@ import {
 import { Writable } from "stream";
 
 import { SubscriptionProvider } from "../SubscriptionProvider";
-import { ConnectionType } from "../profile";
 import LibraryModel from "./LibraryModel";
 import { Icons, Messages, WorkLibraryId } from "./const";
-import { LibraryItem, LibraryType, TableType } from "./types";
+import { LibraryAdapter, LibraryItem, LibraryType, TableType } from "./types";
 
 export const libraryItemMimeType =
   "application/vnd.code.tree.librarydataprovider";
@@ -172,8 +171,8 @@ class LibraryDataProvider
     return new Disposable(() => {});
   }
 
-  public refresh(connectionType: ConnectionType): void {
-    this.model.reset(connectionType);
+  public useAdapter(libraryAdapter: LibraryAdapter): void {
+    this.model.useAdapter(libraryAdapter);
     this._onDidChangeTreeData.fire(undefined);
   }
 }

--- a/client/src/components/LibraryNavigator/LibraryDataProvider.ts
+++ b/client/src/components/LibraryNavigator/LibraryDataProvider.ts
@@ -25,6 +25,7 @@ import {
 import { Writable } from "stream";
 
 import { SubscriptionProvider } from "../SubscriptionProvider";
+import { ConnectionType } from "../profile";
 import LibraryModel from "./LibraryModel";
 import { Icons, Messages, WorkLibraryId } from "./const";
 import { LibraryItem, LibraryType, TableType } from "./types";
@@ -162,7 +163,7 @@ class LibraryDataProvider
 
   public async deleteTable(item: LibraryItem): Promise<void> {
     await this.model.deleteTable(item);
-    this.refresh();
+    this._onDidChangeTreeData.fire(undefined);
   }
 
   public watch(): Disposable {
@@ -171,8 +172,8 @@ class LibraryDataProvider
     return new Disposable(() => {});
   }
 
-  public refresh(): void {
-    this.model.reset();
+  public refresh(connectionType: ConnectionType): void {
+    this.model.reset(connectionType);
     this._onDidChangeTreeData.fire(undefined);
   }
 }

--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -1,4 +1,4 @@
-// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ProgressLocation, l10n, window } from "vscode";
 

--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -1,82 +1,35 @@
-// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ProgressLocation, l10n, window } from "vscode";
 
-import { AxiosResponse } from "axios";
 import { Writable } from "stream";
 
-import { appendSessionLogFn } from "../../components/logViewer";
-import { getSession } from "../../connection";
-import { DataAccessApi } from "../../connection/rest/api/compute";
-import { getApiConfig } from "../../connection/rest/common";
 import PaginatedResultSet from "./PaginatedResultSet";
 import { DefaultRecordLimit, Messages } from "./const";
-import { LibraryItem, LibraryItemType, TableData, TableRow } from "./types";
+import {
+  LibraryAdapter,
+  LibraryItem,
+  LibraryItemType,
+  TableData,
+  TableRow,
+} from "./types";
 
 const sortById = (a: LibraryItem, b: LibraryItem) => a.id.localeCompare(b.id);
 
-const requestOptions = {
-  headers: { Accept: "application/vnd.sas.collection+json" },
-};
-
 class LibraryModel {
-  protected dataAccessApi: ReturnType<typeof DataAccessApi>;
-  protected sessionId: string;
+  public constructor(protected libraryAdapter: LibraryAdapter) {}
 
-  public async connect(): Promise<void> {
-    const session = getSession();
-    session.onSessionLogFn = appendSessionLogFn;
-
-    await window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title: l10n.t("Connecting to SAS session..."),
-      },
-      async () => {
-        await session.setup();
-      },
-    );
-
-    this.sessionId = session?.sessionId();
-    this.dataAccessApi = DataAccessApi(getApiConfig());
-  }
-
-  public async setup(): Promise<void> {
-    if (this.sessionId && this.dataAccessApi) {
-      return;
-    }
-
-    await this.connect();
-  }
-
-  public reset(): void {
-    this.sessionId = undefined;
+  public useAdapter(adapter: LibraryAdapter): void {
+    this.libraryAdapter = adapter;
   }
 
   public getTableResultSet(item: LibraryItem): PaginatedResultSet<TableData> {
     return new PaginatedResultSet<TableData>(
       async (start: number, end: number) => {
-        await this.setup();
+        await this.libraryAdapter.setup();
         const limit = end - start + 1;
-        return await this.retryOnFail(
-          async () =>
-            await this.dataAccessApi.getRows(
-              {
-                sessionId: this.sessionId,
-                libref: item.library || "",
-                tableName: item.name,
-                includeIndex: true,
-                start,
-                limit,
-              },
-              requestOptions,
-            ),
-        );
+        return await this.libraryAdapter.getRows(item, start, limit);
       },
-      (response) => ({
-        rows: response.data.items,
-        count: response.data.count,
-      }),
     );
   }
 
@@ -84,7 +37,7 @@ class LibraryModel {
     fileStream: Writable,
     item: LibraryItem,
   ) {
-    await this.setup();
+    await this.libraryAdapter.setup();
     let offset = 0;
     const limit = 1000;
     const { rowCount: totalItemCount } = await this.getTable(item);
@@ -110,31 +63,19 @@ class LibraryModel {
           return;
         });
         do {
-          const { data } = await this.retryOnFail(
-            async () =>
-              await this.dataAccessApi.getRowsAsCSV(
-                {
-                  includeColumnNames: true,
-                  includeIndex: true,
-                  libref: item.library || "",
-                  // Since we're including column names, we need to grab one more row
-                  limit: limit + 1,
-                  sessionId: this.sessionId,
-                  start: offset,
-                  tableName: item.name,
-                },
-                requestOptions,
-              ),
+          const data = await this.libraryAdapter.getRowsAsCSV(
+            item,
+            offset,
+            limit,
           );
 
-          // return { headers: data.items.shift(), rows: data.items };
-          const headers = data.items.shift();
+          const headers = data.rows.shift();
           if (!hasWrittenHeader) {
             fileStream.write(stringArrayToCsvString(headers.columns));
             hasWrittenHeader = true;
           }
 
-          data.items.forEach((item: TableRow) =>
+          data.rows.forEach((item: TableRow) =>
             fileStream.write("\n" + stringArrayToCsvString(item.cells)),
           );
 
@@ -147,23 +88,15 @@ class LibraryModel {
   }
 
   public async fetchColumns(item: LibraryItem) {
-    await this.setup();
+    await this.libraryAdapter.setup();
     let offset = 0;
     let items = [];
     let totalItemCount = Infinity;
     do {
-      const { data } = await this.retryOnFail(
-        async () =>
-          await this.dataAccessApi.getColumns(
-            {
-              sessionId: this.sessionId,
-              limit: DefaultRecordLimit,
-              start: offset,
-              libref: item.library || "",
-              tableName: item.name,
-            },
-            { headers: { Accept: "application/json" } },
-          ),
+      const data = await this.libraryAdapter.getColumns(
+        item,
+        offset,
+        DefaultRecordLimit,
       );
 
       items = [...items, ...data.items];
@@ -175,33 +108,12 @@ class LibraryModel {
   }
 
   public async getTable(item: LibraryItem) {
-    await this.setup();
-    const response = await this.retryOnFail(
-      async () =>
-        await this.dataAccessApi.getTable(
-          {
-            sessionId: this.sessionId,
-            libref: item.library || "",
-            tableName: item.name,
-          },
-          { headers: { Accept: "application/json" } },
-        ),
-    );
-
-    return response.data;
+    return this.libraryAdapter.getTable(item);
   }
 
   public async deleteTable(item: LibraryItem) {
-    await this.setup();
     try {
-      await this.retryOnFail(
-        async () =>
-          await this.dataAccessApi.deleteTable({
-            sessionId: this.sessionId,
-            libref: item.library,
-            tableName: item.name,
-          }),
-      );
+      this.libraryAdapter.deleteTable(item);
     } catch (error) {
       throw new Error(
         l10n.t(Messages.TableDeletionError, { tableName: item.uid }),
@@ -218,22 +130,15 @@ class LibraryModel {
   }
 
   private async getLibraries(): Promise<LibraryItem[]> {
-    await this.setup();
+    await this.libraryAdapter.setup();
 
     let offset = 0;
     let items = [];
     let totalItemCount = Infinity;
     do {
-      const { data } = await this.retryOnFail(
-        async () =>
-          await this.dataAccessApi.getLibraries(
-            {
-              sessionId: this.sessionId,
-              limit: DefaultRecordLimit,
-              start: offset,
-            },
-            requestOptions,
-          ),
+      const data = await this.libraryAdapter.getLibraries(
+        offset,
+        DefaultRecordLimit,
       );
 
       items = [...items, ...data.items];
@@ -243,48 +148,20 @@ class LibraryModel {
 
     items.sort(sortById);
 
-    const libraryItems: LibraryItem[] = await Promise.all(
-      items.map(async (item: LibraryItem): Promise<LibraryItem> => {
-        const { data } = await this.retryOnFail(
-          async () =>
-            await this.dataAccessApi.getLibrarySummary(
-              {
-                sessionId: this.sessionId,
-                libref: item.id,
-              },
-              {
-                headers: {
-                  Accept: "application/json",
-                },
-              },
-            ),
-        );
-
-        return { ...item, readOnly: data.readOnly };
-      }),
-    );
-
-    return this.processItems(libraryItems, "library", undefined);
+    return this.processItems(items, "library", undefined);
   }
 
-  private async getTables(item?: LibraryItem): Promise<LibraryItem[]> {
-    await this.setup();
+  private async getTables(item: LibraryItem): Promise<LibraryItem[]> {
+    await this.libraryAdapter.setup();
 
     let offset = 0;
     let items = [];
     let totalItemCount = Infinity;
     do {
-      const { data } = await this.retryOnFail(
-        async () =>
-          await this.dataAccessApi.getTables(
-            {
-              sessionId: this.sessionId,
-              libref: item.id,
-              limit: DefaultRecordLimit,
-              start: offset,
-            },
-            requestOptions,
-          ),
+      const data = await this.libraryAdapter.getTables(
+        item,
+        offset,
+        DefaultRecordLimit,
       );
       items = [...items, ...data.items];
       totalItemCount = data.count;
@@ -313,24 +190,6 @@ class LibraryModel {
         }),
       )
       .sort(sortById);
-  }
-
-  private async retryOnFail(
-    callbackFn: () => Promise<AxiosResponse>,
-  ): Promise<AxiosResponse> {
-    try {
-      return await callbackFn();
-    } catch (error) {
-      // If it's not a 404, we can't retry it
-      if (error.response?.status !== 404) {
-        throw error;
-      }
-
-      await this.connect();
-
-      // If it fails a second time, we give up
-      return await callbackFn();
-    }
   }
 }
 

--- a/client/src/components/LibraryNavigator/PaginatedResultSet.ts
+++ b/client/src/components/LibraryNavigator/PaginatedResultSet.ts
@@ -1,26 +1,15 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { AxiosResponse } from "axios";
 
 class PaginatedResultSet<T> {
-  private queryForData: (start: number, end: number) => Promise<AxiosResponse>;
-  private transformData: (response: AxiosResponse) => T;
+  private queryForData: (start: number, end: number) => Promise<T>;
 
-  constructor(
-    queryForData: (start: number, end: number) => Promise<AxiosResponse>,
-    transformData: (response: AxiosResponse) => T,
-  ) {
+  constructor(queryForData: (start: number, end: number) => Promise<T>) {
     this.queryForData = queryForData;
-    this.transformData = transformData;
   }
 
   public async getData(start: number, end: number): Promise<T> {
-    const response = await this.queryForData(start, end);
-    return this.prepareResponse(response);
-  }
-
-  private prepareResponse(response: AxiosResponse): T {
-    return this.transformData(response);
+    return await this.queryForData(start, end);
   }
 }
 

--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -12,10 +12,12 @@ import {
 
 import { createWriteStream } from "fs";
 
+import { profileConfig } from "../../commands/profile";
 import { Column } from "../../connection/rest/api/compute";
 import DataViewer from "../../panels/DataViewer";
 import { WebViewManager } from "../../panels/WebviewManager";
 import { SubscriptionProvider } from "../SubscriptionProvider";
+import { ConnectionType } from "../profile";
 import LibraryDataProvider from "./LibraryDataProvider";
 import LibraryModel from "./LibraryModel";
 import PaginatedResultSet from "./PaginatedResultSet";
@@ -29,7 +31,7 @@ class LibraryNavigator implements SubscriptionProvider {
   constructor(context: ExtensionContext) {
     this.extensionUri = context.extensionUri;
     this.libraryDataProvider = new LibraryDataProvider(
-      new LibraryModel(),
+      new LibraryModel(this.activeProfileConnectionType()),
       context.extensionUri,
     );
     this.webviewManager = new WebViewManager();
@@ -98,7 +100,15 @@ class LibraryNavigator implements SubscriptionProvider {
   }
 
   public async refresh(): Promise<void> {
-    this.libraryDataProvider.refresh();
+    this.libraryDataProvider.refresh(this.activeProfileConnectionType());
+  }
+
+  private activeProfileConnectionType(): ConnectionType {
+    const activeProfile = profileConfig.getProfileByName(
+      profileConfig.getActiveProfile(),
+    );
+
+    return activeProfile && activeProfile.connectionType;
   }
 }
 

--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -17,11 +17,11 @@ import { Column } from "../../connection/rest/api/compute";
 import DataViewer from "../../panels/DataViewer";
 import { WebViewManager } from "../../panels/WebviewManager";
 import { SubscriptionProvider } from "../SubscriptionProvider";
-import { ConnectionType } from "../profile";
+import LibraryAdapterFactory from "./LibraryAdapterFactory";
 import LibraryDataProvider from "./LibraryDataProvider";
 import LibraryModel from "./LibraryModel";
 import PaginatedResultSet from "./PaginatedResultSet";
-import { LibraryItem, TableData } from "./types";
+import { LibraryAdapter, LibraryItem, TableData } from "./types";
 
 class LibraryNavigator implements SubscriptionProvider {
   private libraryDataProvider: LibraryDataProvider;
@@ -31,7 +31,7 @@ class LibraryNavigator implements SubscriptionProvider {
   constructor(context: ExtensionContext) {
     this.extensionUri = context.extensionUri;
     this.libraryDataProvider = new LibraryDataProvider(
-      new LibraryModel(this.activeProfileConnectionType()),
+      new LibraryModel(this.libraryAdapterForConnectionType()),
       context.extensionUri,
     );
     this.webviewManager = new WebViewManager();
@@ -100,15 +100,15 @@ class LibraryNavigator implements SubscriptionProvider {
   }
 
   public async refresh(): Promise<void> {
-    this.libraryDataProvider.refresh(this.activeProfileConnectionType());
+    this.libraryDataProvider.useAdapter(this.libraryAdapterForConnectionType());
   }
 
-  private activeProfileConnectionType(): ConnectionType {
+  private libraryAdapterForConnectionType(): LibraryAdapter {
     const activeProfile = profileConfig.getProfileByName(
       profileConfig.getActiveProfile(),
     );
 
-    return activeProfile && activeProfile.connectionType;
+    return new LibraryAdapterFactory().create(activeProfile.connectionType);
   }
 }
 

--- a/client/src/components/LibraryNavigator/types.ts
+++ b/client/src/components/LibraryNavigator/types.ts
@@ -1,5 +1,6 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ColumnCollection, TableInfo } from "../../connection/rest/api/compute";
 
 export const LibraryType = "library";
 export const TableType = "table";
@@ -14,10 +15,38 @@ export interface LibraryItem {
 }
 
 export interface TableRow {
-  cells: string[];
+  cells?: string[];
+  columns?: string[];
 }
 
 export interface TableData {
   rows: TableRow[];
   count: number;
+}
+
+export interface LibraryAdapter {
+  connect(): Promise<void>;
+  deleteTable(item: LibraryItem): Promise<void>;
+  getColumns(
+    item: LibraryItem,
+    start: number,
+    limit: number,
+  ): Promise<ColumnCollection>;
+  getLibraries(
+    start: number,
+    limit: number,
+  ): Promise<{ items: LibraryItem[]; count: number }>;
+  getRows(item: LibraryItem, start: number, limit: number): Promise<TableData>;
+  getRowsAsCSV(
+    item: LibraryItem,
+    start: number,
+    limit: number,
+  ): Promise<TableData>;
+  getTable(item: LibraryItem): Promise<TableInfo>;
+  getTables(
+    item: LibraryItem,
+    start: number,
+    limit: number,
+  ): Promise<{ items: LibraryItem[]; count: number }>;
+  setup(): Promise<void>;
 }

--- a/client/src/components/notebook/Controller.ts
+++ b/client/src/components/notebook/Controller.ts
@@ -41,13 +41,7 @@ export class NotebookController {
 
     try {
       const session = getSession();
-      await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: vscode.l10n.t("Connecting to SAS session..."),
-        },
-        session.setup,
-      );
+      await session.setup();
     } catch (err) {
       vscode.window.showErrorMessage(
         err.response?.data ? JSON.stringify(err.response.data) : err.message,

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -63,7 +63,7 @@ export class ITCSession extends Session {
    * Initialization logic that should be performed prior to execution.
    * @returns void promise.
    */
-  public setup = async (): Promise<void> => {
+  public establishConnection = async (): Promise<void> => {
     const setupPromise = new Promise<void>((resolve, reject) => {
       this._runResolve = resolve;
       this._runReject = reject;

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -63,7 +63,7 @@ export class ITCSession extends Session {
    * Initialization logic that should be performed prior to execution.
    * @returns void promise.
    */
-  public establishConnection = async (): Promise<void> => {
+  protected establishConnection = async (): Promise<void> => {
     const setupPromise = new Promise<void>((resolve, reject) => {
       this._runResolve = resolve;
       this._runReject = reject;

--- a/client/src/connection/rest/RestLibraryAdapter.ts
+++ b/client/src/connection/rest/RestLibraryAdapter.ts
@@ -1,7 +1,5 @@
-// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ProgressLocation, l10n, window } from "vscode";
-
 import { AxiosResponse } from "axios";
 
 import { getSession } from "..";
@@ -27,19 +25,17 @@ class RestLibraryAdapter implements LibraryAdapter {
   protected dataAccessApi: ReturnType<typeof DataAccessApi>;
   protected sessionId: string;
 
+  public constructor(
+    private readonly emitConnectionNotification: (
+      callback: () => Promise<void>,
+    ) => Promise<void>,
+  ) {}
+
   public async connect(): Promise<void> {
     const session = getSession();
     session.onLogFn = LogChannelFn;
 
-    await window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title: l10n.t("Connecting to SAS session..."),
-      },
-      async () => {
-        await session.setup();
-      },
-    );
+    await this.emitConnectionNotification(async () => await session.setup());
 
     this.sessionId = session?.sessionId();
     this.dataAccessApi = DataAccessApi(getApiConfig());

--- a/client/src/connection/rest/RestLibraryAdapter.ts
+++ b/client/src/connection/rest/RestLibraryAdapter.ts
@@ -26,7 +26,7 @@ class RestLibraryAdapter implements LibraryAdapter {
   protected sessionId: string;
 
   public constructor(
-    private readonly emitConnectionNotification: (
+    protected readonly emitConnectionNotification: (
       callback: () => Promise<void>,
     ) => Promise<void>,
   ) {}

--- a/client/src/connection/rest/RestLibraryAdapter.ts
+++ b/client/src/connection/rest/RestLibraryAdapter.ts
@@ -25,17 +25,13 @@ class RestLibraryAdapter implements LibraryAdapter {
   protected dataAccessApi: ReturnType<typeof DataAccessApi>;
   protected sessionId: string;
 
-  public constructor(
-    protected readonly emitConnectionNotification: (
-      callback: () => Promise<void>,
-    ) => Promise<void>,
-  ) {}
+  public constructor() {}
 
   public async connect(): Promise<void> {
     const session = getSession();
     session.onLogFn = LogChannelFn;
 
-    await this.emitConnectionNotification(async () => await session.setup());
+    await session.setup();
 
     this.sessionId = session?.sessionId();
     this.dataAccessApi = DataAccessApi(getApiConfig());

--- a/client/src/connection/rest/RestLibraryAdapter.ts
+++ b/client/src/connection/rest/RestLibraryAdapter.ts
@@ -1,0 +1,252 @@
+// Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ProgressLocation, l10n, window } from "vscode";
+
+import { AxiosResponse } from "axios";
+
+import { getSession } from "..";
+import {
+  LibraryAdapter,
+  LibraryItem,
+  TableData,
+} from "../../components/LibraryNavigator/types";
+import { LogFn as LogChannelFn } from "../../components/LogChannel";
+import {
+  ColumnCollection,
+  DataAccessApi,
+  RowCollection,
+  TableInfo,
+} from "./api/compute";
+import { getApiConfig } from "./common";
+
+const requestOptions = {
+  headers: { Accept: "application/vnd.sas.collection+json" },
+};
+
+class RestLibraryAdapter implements LibraryAdapter {
+  protected dataAccessApi: ReturnType<typeof DataAccessApi>;
+  protected sessionId: string;
+
+  public async connect(): Promise<void> {
+    const session = getSession();
+    session.onLogFn = LogChannelFn;
+
+    await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: l10n.t("Connecting to SAS session..."),
+      },
+      async () => {
+        await session.setup();
+      },
+    );
+
+    this.sessionId = session?.sessionId();
+    this.dataAccessApi = DataAccessApi(getApiConfig());
+  }
+
+  public async setup(): Promise<void> {
+    if (this.sessionId && this.dataAccessApi) {
+      return;
+    }
+
+    await this.connect();
+  }
+
+  public async getRows(
+    item: LibraryItem,
+    start: number,
+    limit: number,
+  ): Promise<TableData> {
+    const { data } = await this.retryOnFail<RowCollection>(
+      async () =>
+        await this.dataAccessApi.getRows(
+          {
+            sessionId: this.sessionId,
+            libref: item.library || "",
+            tableName: item.name,
+            includeIndex: true,
+            start,
+            limit,
+          },
+          requestOptions,
+        ),
+    );
+
+    return {
+      rows: data.items,
+      count: data.count,
+    };
+  }
+
+  public async getRowsAsCSV(
+    item: LibraryItem,
+    start: number,
+    limit: number,
+  ): Promise<TableData> {
+    const response = await this.retryOnFail(
+      async () =>
+        await this.dataAccessApi.getRowsAsCSV(
+          {
+            includeColumnNames: true,
+            includeIndex: true,
+            libref: item.library || "",
+            // Since we're including column names, we need to grab one more row
+            limit: limit + 1,
+            sessionId: this.sessionId,
+            start,
+            tableName: item.name,
+          },
+          requestOptions,
+        ),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const data = response.data as unknown as RowCollection;
+    return {
+      rows: data.items,
+      count: data.count,
+    };
+  }
+
+  public async getColumns(
+    item: LibraryItem,
+    start: number,
+    limit: number,
+  ): Promise<ColumnCollection> {
+    const { data } = await this.retryOnFail(
+      async () =>
+        await this.dataAccessApi.getColumns(
+          {
+            sessionId: this.sessionId,
+            limit,
+            start,
+            libref: item.library || "",
+            tableName: item.name,
+          },
+          { headers: { Accept: "application/json" } },
+        ),
+    );
+
+    return data;
+  }
+
+  public async getTable(item: LibraryItem): Promise<TableInfo> {
+    await this.setup();
+    const response = await this.retryOnFail(
+      async () =>
+        await this.dataAccessApi.getTable(
+          {
+            sessionId: this.sessionId,
+            libref: item.library || "",
+            tableName: item.name,
+          },
+          { headers: { Accept: "application/json" } },
+        ),
+    );
+
+    return response.data;
+  }
+
+  private async retryOnFail<T>(
+    callbackFn: () => Promise<AxiosResponse<T>>,
+  ): Promise<AxiosResponse<T>> {
+    try {
+      return await callbackFn();
+    } catch (error) {
+      // If it's not a 404, we can't retry it
+      if (error.response?.status !== 404) {
+        throw error;
+      }
+
+      await this.connect();
+
+      // If it fails a second time, we give up
+      return await callbackFn();
+    }
+  }
+
+  public async deleteTable(item: LibraryItem): Promise<void> {
+    await this.setup();
+    try {
+      await this.retryOnFail(
+        async () =>
+          await this.dataAccessApi.deleteTable({
+            sessionId: this.sessionId,
+            libref: item.library,
+            tableName: item.name,
+          }),
+      );
+    } catch (error) {
+      throw new Error("Cannot delete table");
+    }
+  }
+
+  public async getLibraries(
+    start: number,
+    limit: number,
+  ): Promise<{ items: LibraryItem[]; count: number }> {
+    const { data } = await this.retryOnFail(
+      async () =>
+        await this.dataAccessApi.getLibraries(
+          {
+            sessionId: this.sessionId,
+            limit,
+            start,
+          },
+          requestOptions,
+        ),
+    );
+
+    const libraryItems: LibraryItem[] = await Promise.all(
+      data.items.map(async (item: LibraryItem): Promise<LibraryItem> => {
+        const { data: responseData } = await this.retryOnFail(
+          async () =>
+            await this.dataAccessApi.getLibrarySummary(
+              {
+                sessionId: this.sessionId,
+                libref: item.id,
+              },
+              {
+                headers: {
+                  Accept: "application/json",
+                },
+              },
+            ),
+        );
+
+        return {
+          ...item,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          readOnly: (responseData as { readOnly: boolean }).readOnly,
+        };
+      }),
+    );
+
+    return { items: libraryItems, count: data.count };
+  }
+
+  public async getTables(
+    item: LibraryItem,
+    start: number,
+    limit: number,
+  ): Promise<{ items: LibraryItem[]; count: number }> {
+    const { data } = await this.retryOnFail(
+      async () =>
+        await this.dataAccessApi.getTables(
+          {
+            sessionId: this.sessionId,
+            libref: item.id,
+            limit,
+            start,
+          },
+          requestOptions,
+        ),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return { items: data.items as LibraryItem[], count: data.count };
+  }
+}
+
+export default RestLibraryAdapter;

--- a/client/src/connection/rest/RestLibraryAdapter.ts
+++ b/client/src/connection/rest/RestLibraryAdapter.ts
@@ -8,7 +8,7 @@ import {
   LibraryItem,
   TableData,
 } from "../../components/LibraryNavigator/types";
-import { LogFn as LogChannelFn } from "../../components/LogChannel";
+import { appendSessionLogFn } from "../../components/logViewer";
 import {
   ColumnCollection,
   DataAccessApi,
@@ -29,7 +29,7 @@ class RestLibraryAdapter implements LibraryAdapter {
 
   public async connect(): Promise<void> {
     const session = getSession();
-    session.onLogFn = LogChannelFn;
+    session.onSessionLogFn = appendSessionLogFn;
 
     await session.setup();
 

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -39,7 +39,7 @@ class RestSession extends Session {
     this._config = value;
   }
 
-  public establishConnection = async (): Promise<void> => {
+  protected establishConnection = async (): Promise<void> => {
     const apiConfig = getApiConfig();
     let formattedOpts: string[] = [];
     const autoExecLines = this._config.autoExecLines || [];

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -39,7 +39,7 @@ class RestSession extends Session {
     this._config = value;
   }
 
-  public setup = async (): Promise<void> => {
+  public establishConnection = async (): Promise<void> => {
     const apiConfig = getApiConfig();
     let formattedOpts: string[] = [];
     const autoExecLines = this._config.autoExecLines || [];

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -15,7 +15,11 @@ export abstract class Session {
     this._onExecutionLogFn = value;
   }
 
-  async setup(): Promise<void> {
+  async setup(silent?: boolean): Promise<void> {
+    if (silent) {
+      return await this.establishConnection();
+    }
+
     await window.withProgress(
       {
         location: ProgressLocation.Notification,

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -29,7 +29,7 @@ export abstract class Session {
     );
   }
 
-  abstract establishConnection(): Promise<void>;
+  protected abstract establishConnection(): Promise<void>;
   abstract run(code: string): Promise<RunResult>;
   cancel?(): Promise<void>;
   abstract close(): Promise<void> | void;

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -21,7 +21,7 @@ export abstract class Session {
         location: ProgressLocation.Notification,
         title: l10n.t("Connecting to SAS session..."),
       },
-      async () => await this.establishConnection(),
+      this.establishConnection,
     );
   }
 

--- a/client/src/connection/session.ts
+++ b/client/src/connection/session.ts
@@ -1,5 +1,7 @@
 // Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ProgressLocation, l10n, window } from "vscode";
+
 import { OnLogFn, RunResult } from ".";
 
 export abstract class Session {
@@ -13,7 +15,17 @@ export abstract class Session {
     this._onExecutionLogFn = value;
   }
 
-  abstract setup(): Promise<void>;
+  async setup(): Promise<void> {
+    await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: l10n.t("Connecting to SAS session..."),
+      },
+      async () => await this.establishConnection(),
+    );
+  }
+
+  abstract establishConnection(): Promise<void>;
   abstract run(code: string): Promise<RunResult>;
   cancel?(): Promise<void>;
   abstract close(): Promise<void> | void;

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -57,7 +57,7 @@ export class SSHSession extends Session {
     this._config = newValue;
   }
 
-  public setup = (): Promise<void> => {
+  public establishConnection = (): Promise<void> => {
     return new Promise((pResolve, pReject) => {
       this.resolve = pResolve;
       this.reject = pReject;

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -57,7 +57,7 @@ export class SSHSession extends Session {
     this._config = newValue;
   }
 
-  public establishConnection = (): Promise<void> => {
+  protected establishConnection = (): Promise<void> => {
     return new Promise((pResolve, pReject) => {
       this.resolve = pResolve;
       this.reject = pReject;

--- a/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
@@ -10,6 +10,7 @@ import {
   Messages,
 } from "../../../src/components/LibraryNavigator/const";
 import { LibraryItem } from "../../../src/components/LibraryNavigator/types";
+import { ConnectionType } from "../../../src/components/profile";
 import RestLibraryAdapter from "../../../src/connection/rest/RestLibraryAdapter";
 import { DataAccessApi } from "../../../src/connection/rest/api/compute";
 import { getApiConfig } from "../../../src/connection/rest/common";
@@ -26,7 +27,7 @@ class MockRestLibraryAdapter extends RestLibraryAdapter {
 
 class MockLibraryModel extends LibraryModel {
   constructor() {
-    super();
+    super(ConnectionType.Rest);
     this.libraryAdapter = new MockRestLibraryAdapter();
   }
 }

--- a/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
@@ -10,16 +10,24 @@ import {
   Messages,
 } from "../../../src/components/LibraryNavigator/const";
 import { LibraryItem } from "../../../src/components/LibraryNavigator/types";
+import RestLibraryAdapter from "../../../src/connection/rest/RestLibraryAdapter";
 import { DataAccessApi } from "../../../src/connection/rest/api/compute";
 import { getApiConfig } from "../../../src/connection/rest/common";
 
-class MockLibraryModel extends LibraryModel {
+class MockRestLibraryAdapter extends RestLibraryAdapter {
   constructor() {
     super();
     const apiConfig = getApiConfig();
     apiConfig.baseOptions.baseURL = "http://test.local";
     this.dataAccessApi = DataAccessApi(apiConfig);
     this.sessionId = "1234";
+  }
+}
+
+class MockLibraryModel extends LibraryModel {
+  constructor() {
+    super();
+    this.libraryAdapter = new MockRestLibraryAdapter();
   }
 }
 

--- a/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
@@ -10,7 +10,6 @@ import {
   Messages,
 } from "../../../src/components/LibraryNavigator/const";
 import { LibraryItem } from "../../../src/components/LibraryNavigator/types";
-import { ConnectionType } from "../../../src/components/profile";
 import RestLibraryAdapter from "../../../src/connection/rest/RestLibraryAdapter";
 import { DataAccessApi } from "../../../src/connection/rest/api/compute";
 import { getApiConfig } from "../../../src/connection/rest/common";
@@ -27,8 +26,7 @@ class MockRestLibraryAdapter extends RestLibraryAdapter {
 
 class MockLibraryModel extends LibraryModel {
   constructor() {
-    super(ConnectionType.Rest);
-    this.libraryAdapter = new MockRestLibraryAdapter();
+    super(new MockRestLibraryAdapter());
   }
 }
 

--- a/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
@@ -17,7 +17,7 @@ import { getApiConfig } from "../../../src/connection/rest/common";
 
 class MockRestLibraryAdapter extends RestLibraryAdapter {
   constructor() {
-    super();
+    super(async (callback) => await callback());
     const apiConfig = getApiConfig();
     apiConfig.baseOptions.baseURL = "http://test.local";
     this.dataAccessApi = DataAccessApi(apiConfig);

--- a/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
@@ -16,7 +16,7 @@ import { getApiConfig } from "../../../src/connection/rest/common";
 
 class MockRestLibraryAdapter extends RestLibraryAdapter {
   constructor() {
-    super(async (callback) => await callback());
+    super();
     const apiConfig = getApiConfig();
     apiConfig.baseOptions.baseURL = "http://test.local";
     this.dataAccessApi = DataAccessApi(apiConfig);

--- a/client/test/components/LibraryNavigator/PaginatedResultSet.test.ts
+++ b/client/test/components/LibraryNavigator/PaginatedResultSet.test.ts
@@ -23,17 +23,12 @@ describe("PaginatedResultSet", async function () {
       },
     };
 
-    const transformData = (response: AxiosResponse) => ({
-      test: response.data.test,
-    });
-
     const paginatedResultSet = new PaginatedResultSet(
       async () => mockAxiosResponse,
-      transformData,
     );
 
-    expect(await paginatedResultSet.getData(0, 100)).to.deep.equal({
-      test: "yes",
-    });
+    expect(await paginatedResultSet.getData(0, 100)).to.deep.equal(
+      mockAxiosResponse,
+    );
   });
 });


### PR DESCRIPTION
**Summary**
This refactors LibraryDataProvider in preparation for getting things working with iom/com connections. Here's the general architecture changes made as part of this pr:
 - The concept of a `LibraryAdapter` has been introduced along with `RestLibraryAdapter`. `LibraryAdapter` is an interface that is used by LibraryModel to manage library/table data
 - `LibraryAdapterFactory` has been added to create `LibraryAdapter`s. At the moment, this always creates a `RestLibraryAdapter`, but will eventually create a `ItcLibraryAdapter`
 - `LibraryModel`s functionality has been limited to: working with the file system, paginating api requests, and further processing library adapter results for easier consumption by `LibraryDataProvider`

**Testing**
 - [x] Tested deleting a library
 - [x] Tested refreshing libraries
 - [x] Tested viewing multiple tables
 - [x] Tested drag and drop with table
 - [x] Tested exporting table as CSV
