### PR TITLE
fix: add formatonpaste configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -425,7 +425,8 @@
     ],
     "configurationDefaults": {
       "[sas]": {
-        "editor.formatOnType": true
+        "editor.formatOnType": true,
+        "editor.formatOnPaste": true
       }
     },
     "commands": [


### PR DESCRIPTION
**Summary**
Resolve #735 

**Testing**
Copy codes with datalines/cards, no redundant whitespace will be inserted in front of each line, and codes will run normally.
