### PR TITLE
fix: prevent decrease indentation when the word run is used as value

### DIFF
--- a/server/src/sas/CodeZoneManager.ts
+++ b/server/src/sas/CodeZoneManager.ts
@@ -670,7 +670,8 @@ export class CodeZoneManager {
       if (token && token.text) {
         word = token.text.toUpperCase();
         if (_isBlockEnd[word]) {
-          return true;
+          token = this._getPrev(context);
+          return token?.text === ";";
         } else if (word === "CANCEL") {
           token = this._getPrev(context);
           if (token && token.text && _isBlockEnd[token.text.toUpperCase()]) {


### PR DESCRIPTION
**Summary**
Resolve #522 

**Testing**
1 Enter "run" after "=", indentation will not be reduced.
2 Enter "run" instead of after "=", indentation will decrease normally.
