### PR TITLE
doc: update VS Code requirement to 1.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Required VS Code version 1.82 at minimum
 - Removed the disconnect button from the editor toolbar (next to the run button), Please use the `Close Session` button on the tooltip of the active profile status bar item instead. ([#573](https://github.com/sassoftware/vscode-sas-extension/pull/573))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Welcome to the SAS Extension for Visual Studio Code! This extension provides sup
 
 ## Installation
 
-To install the SAS extension, open the Extensions view by clicking the Extensions icon in the Activity Bar on the left side of the Visual Studio Code window. Search for the 'Official' SAS extension, and click the Install button. Once the installation is complete, the Install button changes to the Manage button.
+Install latest VS Code (version 1.82 at minimum). To install the SAS extension, open the Extensions view by clicking the Extensions icon in the Activity Bar on the left side of the Visual Studio Code window. Search for the 'Official' SAS extension, and click the Install button. Once the installation is complete, the Install button changes to the Manage button.
 
 ## Features
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,12 +23,12 @@
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@types/ssh2": "^1.11.19",
-        "@types/vscode": "^1.73.0",
+        "@types/vscode": "1.82.0",
         "@types/vscode-notebook-renderer": "^1.72.3",
         "@vscode/test-electron": "^2.3.8"
       },
       "engines": {
-        "vscode": "^1.73.0"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.76.0.tgz",
-      "integrity": "sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true
     },
     "node_modules/@types/vscode-notebook-renderer": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
   "version": "0.0.1",
   "publisher": "SAS",
   "engines": {
-    "vscode": "^1.73.0"
+    "vscode": "^1.82.0"
   },
   "dependencies": {
     "ag-grid-community": "^31.0.2",
@@ -23,7 +23,7 @@
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@types/ssh2": "^1.11.19",
-    "@types/vscode": "^1.73.0",
+    "@types/vscode": "1.82.0",
     "@types/vscode-notebook-renderer": "^1.72.3",
     "@vscode/test-electron": "^2.3.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "vscode": "^1.73.0"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "icon": "icons/sas.png",
   "engines": {
-    "vscode": "^1.73.0"
+    "vscode": "^1.82.0"
   },
   "activationEvents": [
     "onLanguage:sas",


### PR DESCRIPTION
**Summary**
Fix #764
One of our auto-updated dependency required VS Code 1.82
https://github.com/sassoftware/vscode-sas-extension/pull/644/files#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dR621

**Testing**
N/A
