### PR TITLE
fix: externalized error message and toggle developer tools (#734)

### DIFF
--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -284,7 +284,9 @@ export class ITCSession extends Session {
     this.clearPassword();
     this._runReject(
       new Error(
-        "There was an error executing the SAS Program.\nSee console log for more details.",
+        l10n.t(
+          "There was an error executing the SAS Program. See [console log](command:workbench.action.toggleDevTools) for more details.",
+        ),
       ),
     );
     // If we encountered an error in setup, we need to go through everything again

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -103,6 +103,7 @@
   "The notebook has been successfully converted to a flow and saved into the following folder: {folderName}. You can now open it in SAS Studio.": "笔记本已成功转换为流并保存到以下文件夹中：{folderName}。 您现在可以在 SAS Studio 中打开它。",
   "The output file name must end with the .flw extension.": "输出文件名必须以 .flw 扩展名结尾。",
   "The {selected} SAS connection profile has been deleted from the settings.json file.": "已从settings.json文件中删除{selected} SAS连接配置文件。",
+  "There was an error executing the SAS Program. See [console log](command:workbench.action.toggleDevTools) for more details.": "SAS程序执行出错。请参见[开发控制台日志](command:workbench.action.toggleDevTools)获取更多信息。",
   "Unable to add file to my folder.": "无法将文件添加到我的文件夹。",
   "Unable to create file \"{name}\".": "无法创建文件\"{name}\"。",
   "Unable to create folder \"{name}\".": "无法创建文件夹\"{name}\"。",


### PR DESCRIPTION
Fix https://github.com/sassoftware/vscode-sas-extension/issues/734

Suggestion from [jbodart-argenx](https://github.com/jbodart-argenx): https://github.com/sassoftware/vscode-sas-extension/issues/685#issuecomment-1849425397

1. Externalized error message 'There was an error executing the SAS Program. See [console log] for more details.'

2. The 'console log' in the show error message dialog should be a link to open the developer tools.

Testing

1. Change the language to zh-cn to check if the error message is change to Chinese.

2. Click the hyper link [console log] to see if the developer tools is opened.
