### PR TITLE
fix: pin node version to avoid compatibility issues

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version: "18.16.0"
           cache: "npm"
       - run: npm ci
       - run: npm run locale --update-locales


### PR DESCRIPTION
**Summary**
@vscode/l10n-dev is not compatible with current lts node. This PR pins the version to a known version that works.

**Testing**
Run action locally. L10n files needing localization are now properly identified. Those keys will get updated using our normal L10 process.
