### PR TITLE
fix: add activeProfile check when creating library model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If you introduce breaking changes, please group them together in the "Changed" section using the **BREAKING:** prefix.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue where users were not able to add new profiles if starting with no profiles ([#826](https://github.com/sassoftware/vscode-sas-extension/pull/826))
+
 ## [v1.7.0] - 2024-02-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If you introduce breaking changes, please group them together in the "Changed" section using the **BREAKING:** prefix.
 
-## [Unreleased]
+## [v1.7.1] - 2024-02-15
 
 ### Fixed
 

--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -17,7 +17,7 @@ import {
 const sortById = (a: LibraryItem, b: LibraryItem) => a.id.localeCompare(b.id);
 
 class LibraryModel {
-  public constructor(protected libraryAdapter: LibraryAdapter) {}
+  public constructor(protected libraryAdapter: LibraryAdapter | undefined) {}
 
   public useAdapter(adapter: LibraryAdapter): void {
     this.libraryAdapter = adapter;
@@ -122,6 +122,10 @@ class LibraryModel {
   }
 
   public async getChildren(item?: LibraryItem): Promise<LibraryItem[]> {
+    if (!this.libraryAdapter) {
+      console.log("returning empty things");
+      return [];
+    }
     if (!item) {
       return await this.getLibraries();
     }

--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -123,7 +123,6 @@ class LibraryModel {
 
   public async getChildren(item?: LibraryItem): Promise<LibraryItem[]> {
     if (!this.libraryAdapter) {
-      console.log("returning empty things");
       return [];
     }
     if (!item) {

--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -103,10 +103,14 @@ class LibraryNavigator implements SubscriptionProvider {
     this.libraryDataProvider.useAdapter(this.libraryAdapterForConnectionType());
   }
 
-  private libraryAdapterForConnectionType(): LibraryAdapter {
+  private libraryAdapterForConnectionType(): LibraryAdapter | undefined {
     const activeProfile = profileConfig.getProfileByName(
       profileConfig.getActiveProfile(),
     );
+
+    if (!activeProfile) {
+      return;
+    }
 
     return new LibraryAdapterFactory().create(activeProfile.connectionType);
   }

--- a/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
@@ -34,6 +34,16 @@ const libraryDataProvider = () =>
   new LibraryDataProvider(new MockLibraryModel(), Uri.from({ scheme: "file" }));
 
 describe("LibraryDataProvider", async function () {
+  it("getChildren - returns an empty array when no adapter is specified", async () => {
+    const libraryDataProvider = new LibraryDataProvider(
+      new LibraryModel(undefined),
+      Uri.from({ scheme: "file" }),
+    );
+    const children = await libraryDataProvider.getChildren();
+
+    expect(children.length).to.equal(0);
+  });
+
   it("getChildren - returns tables with a content item", async () => {
     const library: LibraryItem = {
       uid: "lib",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sas-lsp",
   "displayName": "SAS",
   "description": "Official SAS Language Extension for VS Code",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "categories": [
     "Programming Languages",
     "Data Science",


### PR DESCRIPTION
**Summary**
This updates our library model such that it accepts an undefined library adapter. This fixes a login issue where users don't have profiles available.

**Testing**
 - Removed all profiles and added a new one
 - Made sure libraries loaded upon login
