### PR TITLE
feat: add better error reporting for COM/IOM connections

### DIFF
--- a/client/src/connection/itc/LineParser.ts
+++ b/client/src/connection/itc/LineParser.ts
@@ -2,34 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export class LineParser {
-  protected errorLines: string[] = [];
-  protected capturingError: boolean = false;
+  protected processedLines: string[] = [];
+  protected capturingLine: boolean = false;
 
   public constructor(
     protected startTag: string,
     protected endTag: string,
+    protected returnNonProcessedLines: boolean,
   ) {}
 
   public processLine(line: string): string | undefined {
-    if (line.includes(this.startTag) || this.capturingError) {
-      this.errorLines.push(line);
-      this.capturingError = true;
+    if (line.includes(this.startTag) || this.capturingLine) {
+      this.processedLines.push(line);
+      this.capturingLine = true;
       if (line.includes(this.endTag)) {
-        return this.processedError();
+        return this.processedLine();
       }
       return;
     }
 
-    return line;
+    return this.returnNonProcessedLines ? line : undefined;
   }
 
-  protected processedError(): string {
-    this.capturingError = false;
-    const fullError = this.errorLines
+  protected processedLine(): string {
+    this.capturingLine = false;
+    const fullError = this.processedLines
       .join("")
       .replace(this.startTag, "")
       .replace(this.endTag, "");
-    this.errorLines = [];
+    this.processedLines = [];
     return fullError;
+  }
+
+  public isCapturingLine(): boolean {
+    return this.capturingLine;
   }
 }

--- a/client/src/connection/itc/LineParser.ts
+++ b/client/src/connection/itc/LineParser.ts
@@ -1,0 +1,31 @@
+export class LineParser {
+  protected errorLines: string[] = [];
+  protected capturingError: boolean = false;
+  protected startTag: string;
+  protected endTag: string;
+
+  public constructor(startTag: string, endTag: string) {
+    this.startTag = startTag;
+    this.endTag = endTag;
+  }
+
+  public processLine(line: string): string | undefined {
+    if (line.includes(this.startTag) || this.capturingError) {
+      this.errorLines.push(line);
+      this.capturingError = true;
+      if (line.includes(this.endTag)) {
+        return this.processedError();
+      }
+      return;
+    }
+
+    return;
+  }
+
+  protected processedError(): string {
+    this.capturingError = false;
+    const fullError = this.errorLines.join('').replace(this.startTag, '').replace(this.endTag,'');
+    this.errorLines = [];
+    return fullError;
+  }
+}

--- a/client/src/connection/itc/LineParser.ts
+++ b/client/src/connection/itc/LineParser.ts
@@ -4,13 +4,11 @@
 export class LineParser {
   protected errorLines: string[] = [];
   protected capturingError: boolean = false;
-  protected startTag: string;
-  protected endTag: string;
 
-  public constructor(startTag: string, endTag: string) {
-    this.startTag = startTag;
-    this.endTag = endTag;
-  }
+  public constructor(
+    protected startTag: string,
+    protected endTag: string,
+  ) {}
 
   public processLine(line: string): string | undefined {
     if (line.includes(this.startTag) || this.capturingError) {

--- a/client/src/connection/itc/LineParser.ts
+++ b/client/src/connection/itc/LineParser.ts
@@ -1,3 +1,6 @@
+// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 export class LineParser {
   protected errorLines: string[] = [];
   protected capturingError: boolean = false;
@@ -24,7 +27,10 @@ export class LineParser {
 
   protected processedError(): string {
     this.capturingError = false;
-    const fullError = this.errorLines.join('').replace(this.startTag, '').replace(this.endTag,'');
+    const fullError = this.errorLines
+      .join("")
+      .replace(this.startTag, "")
+      .replace(this.endTag, "");
     this.errorLines = [];
     return fullError;
   }

--- a/client/src/connection/itc/LineParser.ts
+++ b/client/src/connection/itc/LineParser.ts
@@ -22,7 +22,7 @@ export class LineParser {
       return;
     }
 
-    return;
+    return line;
   }
 
   protected processedError(): string {

--- a/client/src/connection/itc/const.ts
+++ b/client/src/connection/itc/const.ts
@@ -1,33 +1,5 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { l10n } from "vscode";
 
-export const ERROR_START_TAG = '<ITCError>';
-export const ERROR_END_TAG = '</ITCError>';
-
-export const humanReadableMessages = [
-  {
-    pattern: /Setup error: AuthLockout/,
-    error: l10n.t(
-      "The referenced account is currently locked out and may not be logged on to.",
-    ),
-  },
-  {
-    pattern: /Setup error: AuthError/,
-    error: l10n.t("The user name or password is incorrect."),
-  },
-  {
-    pattern: /Setup error: BadHost/,
-    error: l10n.t("The machine name could not be resolved to an IP address."),
-  },
-  {
-    pattern: /Setup error: ConnectionError/,
-    error: l10n.t(
-      "Could not establish a connection to the server on the requested machine.  Verify that the server has been started and that the host and port of the server match your profile information.",
-    ),
-  },
-  {
-    pattern: /Run error: TranscodingFailed/,
-    error: l10n.t("Run error: Some code points did not transcode."),
-  },
-];
+export const ERROR_START_TAG = "<ITCError>";
+export const ERROR_END_TAG = "</ITCError>";

--- a/client/src/connection/itc/const.ts
+++ b/client/src/connection/itc/const.ts
@@ -21,4 +21,8 @@ export const humanReadableMessages = [
       "Could not establish a connection to the server on the requested machine.  Verify that the server has been started and that the host and port of the server match your profile information.",
     ),
   },
+  {
+    pattern: /Run error: TranscodingFailed/,
+    error: l10n.t("Run error: Some code points did not transcode."),
+  },
 ];

--- a/client/src/connection/itc/const.ts
+++ b/client/src/connection/itc/const.ts
@@ -3,3 +3,6 @@
 
 export const ERROR_START_TAG = "<ITCError>";
 export const ERROR_END_TAG = "</ITCError>";
+
+export const WORK_DIR_START_TAG = "<WorkDirectory>";
+export const WORK_DIR_END_TAG = "</WorkDirectory>";

--- a/client/src/connection/itc/const.ts
+++ b/client/src/connection/itc/const.ts
@@ -1,5 +1,8 @@
 import { l10n } from "vscode";
 
+export const ERROR_START_TAG = '<ITCError>';
+export const ERROR_END_TAG = '</ITCError>';
+
 export const humanReadableMessages = [
   {
     pattern: /Setup error: AuthLockout/,

--- a/client/src/connection/itc/const.ts
+++ b/client/src/connection/itc/const.ts
@@ -1,0 +1,24 @@
+import { l10n } from "vscode";
+
+export const humanReadableMessages = [
+  {
+    pattern: /Setup error: AuthLockout/,
+    error: l10n.t(
+      "The referenced account is currently locked out and may not be logged on to.",
+    ),
+  },
+  {
+    pattern: /Setup error: AuthError/,
+    error: l10n.t("The user name or password is incorrect."),
+  },
+  {
+    pattern: /Setup error: BadHost/,
+    error: l10n.t("The machine name could not be resolved to an IP address."),
+  },
+  {
+    pattern: /Setup error: ConnectionError/,
+    error: l10n.t(
+      "Could not establish a connection to the server on the requested machine.  Verify that the server has been started and that the host and port of the server match your profile information.",
+    ),
+  },
+];

--- a/client/src/connection/itc/const.ts
+++ b/client/src/connection/itc/const.ts
@@ -1,3 +1,5 @@
+// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { l10n } from "vscode";
 
 export const ERROR_START_TAG = '<ITCError>';

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -313,6 +313,7 @@ export class ITCSession extends Session {
    */
   private onShellStdErr = (chunk: Buffer): void => {
     const msg = chunk.toString();
+
     const errorMessage = this._errorParser.processLine(msg);
     if (!errorMessage) {
       return;
@@ -343,6 +344,10 @@ export class ITCSession extends Session {
 
     // Dump error to console
     console.warn("shellProcess stderr: " + errorMessage);
+
+    if (/powershell\.exe: command not found/.test(msg)) {
+      return l10n.t("This platform does not support this connection type.");
+    }
 
     // Do we have SAS messages?
     const sasMessages = errorMessage

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -26,7 +26,7 @@ import { scriptContent } from "./script";
 import { LineCodes } from "./types";
 import { decodeEntities } from "./util";
 
-const SECRET_STORAGE_NAMESPACE = "ITC_SECRET_STORAGE-1";
+const SECRET_STORAGE_NAMESPACE = "ITC_SECRET_STORAGE";
 
 const LogLineTypes: LogLineTypeEnum[] = [
   "normal",

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -20,6 +20,7 @@ import {
 import { updateStatusBarItem } from "../../components/StatusBarItem";
 import { extractOutputHtmlFileName } from "../../components/utils/sasCode";
 import { Session } from "../session";
+import { humanReadableMessages } from "./const";
 import { scriptContent } from "./script";
 import { LineCodes } from "./types";
 
@@ -36,13 +37,6 @@ const LogLineTypes: LogLineTypeEnum[] = [
   "warning",
   "note",
   "message",
-];
-
-const humanReadableMessages = [
-  {
-    pattern: /powershell\.exe: command not found/,
-    error: l10n.t("This platform does not support this connection type."),
-  },
 ];
 
 let sessionInstance: ITCSession;
@@ -330,11 +324,15 @@ export class ITCSession extends Session {
   };
 
   private fetchHumanReadableErrorMessage = (msg: string): string => {
-    const foundMessage = humanReadableMessages.find((message) =>
+    if (/powershell\.exe: command not found/.test(msg)) {
+      return l10n.t("This platform does not support this connection type.");
+    }
+
+    const foundError = humanReadableMessages.find((message) =>
       message.pattern.test(msg),
     );
-    if (foundMessage) {
-      return foundMessage.error;
+    if (foundError) {
+      return foundError.error;
     }
 
     return l10n.t(

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -324,7 +324,7 @@ export class ITCSession extends Session {
     );
 
     // If we encountered an error in setup, we need to go through everything again
-    const fatalErrors = [/Setup error/, /powershell\.exe: command not found/];
+    const fatalErrors = [/Setup error/, /powershell\.exe/];
     if (fatalErrors.find((regex) => regex.test(errorMessage))) {
       // If we can't even run the shell script (i.e. powershell.exe not found),
       // we'll also need to dismiss the password prompt
@@ -345,7 +345,7 @@ export class ITCSession extends Session {
     // Dump error to console
     console.warn("shellProcess stderr: " + errorMessage);
 
-    if (/powershell\.exe: command not found/.test(msg)) {
+    if (/powershell\.exe/.test(msg)) {
       return l10n.t("This platform does not support this connection type.");
     }
 

--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -1,5 +1,6 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ERROR_END_TAG, ERROR_START_TAG } from './const';
 import { LineCodes } from "./types";
 
 export const scriptContent = `
@@ -45,17 +46,7 @@ class SASRunner{
 
         Write-Host "${LineCodes.SessionCreatedCode}"
     } catch {
-      if ($_ -like "*The user name or password is incorrect.*") {
-        throw "Setup error: AuthError"
-      } elseif ($_ -like "*The referenced account is currently locked out and may not be logged on to.*") {
-        throw "Setup error: AuthLockout"
-      } elseif ($_ -like "*The machine name could not be resolved to an IP address.*") {
-        throw "Setup error: HostResolutionError"
-      } elseif ($_ -like "*Could not establish a connection to the server on the requested machine.*") {
-        throw "Setup error: ConnectionError"
-      } else {
-        throw "Setup error: $_"
-      }
+      Write-Error "${ERROR_START_TAG}Setup error: $_${ERROR_END_TAG}"
     }
   }
 
@@ -85,7 +76,7 @@ class SASRunner{
           throw $errVals
       }
     } catch{
-        Write-Error $Error[0].Exception.Message
+        Write-Error "${ERROR_START_TAG}$Error[0].Exception.Message${ERROR_END_TAG}"
     }
   }
 
@@ -95,11 +86,7 @@ class SASRunner{
         $this.objSAS.LanguageService.Async = $true
         $this.objSAS.LanguageService.Submit($code)
     }catch{
-      if ($_ -like "*Some code points did not transcode.*") {
-        throw "Run error: TranscodingFailed"
-      } else {
-        throw "Run error: $_"
-      }
+      Write-Error "${ERROR_START_TAG}Run error: $_${ERROR_END_TAG}"
     }
   }
 
@@ -107,7 +94,7 @@ class SASRunner{
   try{
         $this.objSAS.Close()
     }catch{
-      throw "Close error"
+      Write-Error "${ERROR_START_TAG}Close error: $_${ERROR_END_TAG}"
     }
   }
 
@@ -116,7 +103,7 @@ class SASRunner{
         $this.objSAS.LanguageService.Cancel()
         Write-Host "${LineCodes.RunCancelledCode}"
       }catch{
-        throw "Cancel error"
+        Write-Error "${ERROR_START_TAG}Cancel error: $_${ERROR_END_TAG}"
       }
     }
 
@@ -124,7 +111,7 @@ class SASRunner{
       try{
         return $this.objSAS.LanguageService.FlushLog($chunkSize)
       } catch{
-        throw "FlushLog error"
+        Write-Error "${ERROR_START_TAG}FlushLog error: $_${ERROR_END_TAG}"
       }
       return ""
   }

--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -95,8 +95,11 @@ class SASRunner{
         $this.objSAS.LanguageService.Async = $true
         $this.objSAS.LanguageService.Submit($code)
     }catch{
-      Write-Error $_.ScriptStackTrace
-      throw "Run error"
+      if ($_ -like "*Some code points did not transcode.*") {
+        throw "Run error: TranscodingFailed"
+      } else {
+        throw "Run error: $_"
+      }
     }
   }
 

--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -45,7 +45,17 @@ class SASRunner{
 
         Write-Host "${LineCodes.SessionCreatedCode}"
     } catch {
-      throw "Setup error"
+      if ($_ -like "*The user name or password is incorrect.*") {
+        throw "Setup error: AuthError"
+      } elseif ($_ -like "*The referenced account is currently locked out and may not be logged on to.*") {
+        throw "Setup error: AuthLockout"
+      } elseif ($_ -like "*The machine name could not be resolved to an IP address.*") {
+        throw "Setup error: HostResolutionError"
+      } elseif ($_ -like "*Could not establish a connection to the server on the requested machine.*") {
+        throw "Setup error: ConnectionError"
+      } else {
+        throw "Setup error: $_"
+      }
     }
   }
 

--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -1,6 +1,6 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ERROR_END_TAG, ERROR_START_TAG } from './const';
+import { ERROR_END_TAG, ERROR_START_TAG } from "./const";
 import { LineCodes } from "./types";
 
 export const scriptContent = `

--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -1,6 +1,11 @@
 // Copyright © 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ERROR_END_TAG, ERROR_START_TAG } from "./const";
+import {
+  ERROR_END_TAG,
+  ERROR_START_TAG,
+  WORK_DIR_END_TAG,
+  WORK_DIR_START_TAG,
+} from "./const";
 import { LineCodes } from "./types";
 
 export const scriptContent = `
@@ -11,6 +16,7 @@ class SASRunner{
   $code =
 @'
    %let workDir = %sysfunc(pathname(work));
+   %put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};
    %put &=workDir;
    %let rc = %sysfunc(dlgcdir("&workDir"));
    run;

--- a/client/src/connection/itc/util.ts
+++ b/client/src/connection/itc/util.ts
@@ -1,0 +1,14 @@
+
+export function decodeEntities(msg: string) {
+  // Some of our messages from the server contain html encoded
+  // characters. This converts them back.
+  const specialCharacters = {
+    '&apos;': "'",
+  };
+
+  Object.entries(specialCharacters).map(([encodedHtml, text]) => {
+    msg = msg.replace(encodedHtml, text);
+  });
+  
+  return msg;
+}

--- a/client/src/connection/itc/util.ts
+++ b/client/src/connection/itc/util.ts
@@ -1,14 +1,16 @@
+// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 export function decodeEntities(msg: string) {
   // Some of our messages from the server contain html encoded
   // characters. This converts them back.
   const specialCharacters = {
-    '&apos;': "'",
+    "&apos;": "'",
   };
 
   Object.entries(specialCharacters).map(([encodedHtml, text]) => {
     msg = msg.replace(encodedHtml, text);
   });
-  
+
   return msg;
 }

--- a/client/test/connection/itc/index.test.ts
+++ b/client/test/connection/itc/index.test.ts
@@ -10,6 +10,10 @@ import { v4 } from "uuid";
 
 import { setContext } from "../../../src/components/ExtensionContext";
 import { ITCProtocol, getSession } from "../../../src/connection/itc";
+import {
+  WORK_DIR_END_TAG,
+  WORK_DIR_START_TAG,
+} from "../../../src/connection/itc/const";
 import { scriptContent } from "../../../src/connection/itc/script";
 import { LineCodes } from "../../../src/connection/itc/types";
 import { Session } from "../../../src/connection/session";
@@ -85,6 +89,12 @@ describe("ITC connection", () => {
       const setupPromise = session.setup();
 
       onDataCallback(Buffer.from(`WORKDIR="/work/dir"\n`));
+      onDataCallback(
+        Buffer.from(`%put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};`),
+      );
+      onDataCallback(
+        Buffer.from(`${WORK_DIR_START_TAG}/work/dir${WORK_DIR_END_TAG}`),
+      );
 
       await setupPromise;
 
@@ -133,6 +143,12 @@ describe("ITC connection", () => {
       writeFileSync(tempHtmlPath, html5);
       const setupPromise = session.setup();
       onDataCallback(Buffer.from(`WORKDIR=/work/dir`));
+      onDataCallback(
+        Buffer.from(`%put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};`),
+      );
+      onDataCallback(
+        Buffer.from(`${WORK_DIR_START_TAG}/work/dir${WORK_DIR_END_TAG}`),
+      );
       await setupPromise;
     });
     afterEach(() => {
@@ -172,6 +188,12 @@ $runner.FetchResultsFile($filePath, $outputFile)
     beforeEach(async () => {
       const setupPromise = session.setup();
       onDataCallback(Buffer.from(`WORKDIR=/work/dir`));
+      onDataCallback(
+        Buffer.from(`%put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};`),
+      );
+      onDataCallback(
+        Buffer.from(`${WORK_DIR_START_TAG}/work/dir${WORK_DIR_END_TAG}`),
+      );
       await setupPromise;
     });
 


### PR DESCRIPTION
**Summary**
This adds better error support for IOM & COM connections. Specifically, it provides _better_ errors for:
 - being on the wrong plaform (i.e. Mac)
 - using an incorrect username / password
 - using an incorrect host
 - using an incorrect port (or having a connection where a sas server isn't present)
 - trying to run code that will trigger transcoding errors

**Testing**
 - [x] test being on the wrong plaform (i.e. Mac)
 - [x] test using an incorrect username / password
 - [x] test using an incorrect host
 - [x] test using an incorrect port (or having a connection where a sas server isn't present)
 - [x] test trying to run code that will trigger transcoding errors
