### PR TITLE
fix: remote unix machine x window issue when running specific sas cod…

### DIFF
--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -219,7 +219,11 @@ export class SSHSession extends Session {
     const resolvedEnv: string[] = ['_JAVA_OPTIONS="-Djava.awt.headless=true"'];
     const execArgs: string = resolvedEnv.join(" ");
 
-    const resolvedSasOpts: string[] = ["-nodms", "-terminal", "-nosyntaxcheck"];
+    const resolvedSasOpts: string[] = [
+      "-nodms",
+      "-noterminal",
+      "-nosyntaxcheck",
+    ];
 
     if (this._config.sasOptions?.length > 0) {
       resolvedSasOpts.push(...this._config.sasOptions);


### PR DESCRIPTION
Cannot run PROC IMPORT on remote Unix machine (#699)

**Summary**
When using the SSH to login the Unix machine, we supplied a wrong SAS options to connect the session. 
The "-terminal" should be changed to "-noterminal".
(https://go.documentation.sas.com/doc/en/pgmsascdc/v_045/lesysoptsref/p1db6atd7mw5fnn1lvcra2s1i7tq.htm)

**Testing**
1. Add a new connection profile which support the SAS9.4 (remote -SSH); 
2. Try to run the line
proc import datafile=x out=_csv dbms=csv replace; run;
3. The output should *not* be:
ERROR: The connection to the X display server could not be made. Verify that
the X display name is correct, and that you have access authorization.
See the online Help for more information about connecting to an X
display server.
ERROR: Device does not support full-screen.

It should be: ERROR: Physical file does not exist.....
 
