### PR TITLE
doc: update link for SAS Programming documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Ask, Find, and Share on the VS Code SAS Extension on the [SAS Programmers Commun
 
 ### SAS Programming Documentation
 
-[SAS Programming documentation](https://go.documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/lrcon/titlepage.htm)
+[SAS Programming documentation](https://go.documentation.sas.com/doc/en/pgmsascdc/v_048/lepg/titlepage.htm)
 
 ### FAQs
 


### PR DESCRIPTION
**Summary**
The link for SAS Programming documentation has changed, the old one is "Page not found" now.

**Testing**
Click the link for SAS Programming documentation and see correct page.
