### PR TITLE
fix: remove sign in from command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Removed `SAS: Sign in` from the command palette. Users will have the option of clicking "Sign in" on the library/content pane, or by clicking the running man icon to execute sas code ([#862](https://github.com/sassoftware/vscode-sas-extension/pull/862))
+- Update command palette entry `SAS: Sign in` so that it's only visible for Viya profiles. Non-viya users will still be able to connect and execute code by using the running man icon ([#862](https://github.com/sassoftware/vscode-sas-extension/pull/862))
 
 ## [v1.7.1] - 2024-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If you introduce breaking changes, please group them together in the "Changed" section using the **BREAKING:** prefix.
 
+## [Unreleased]
+
+### Changed
+
+- Removed `SAS: Sign in` from the command palette. Users will have the option of clicking "Sign in" on the library/content pane, or by clicking the running man icon to execute sas code ([#862](https://github.com/sassoftware/vscode-sas-extension/pull/862))
+
 ## [v1.7.1] - 2024-02-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -818,7 +818,7 @@
         },
         {
           "command": "SAS.authorize",
-          "when": "false"
+          "when": "(!SAS.authorized && SAS.connectionType == rest) && !SAS.connection.direct"
         },
         {
           "when": "false",

--- a/package.json
+++ b/package.json
@@ -817,6 +817,10 @@
           "command": "SAS.runRegion"
         },
         {
+          "command": "SAS.authorize",
+          "when": "false"
+        },
+        {
           "when": "false",
           "command": "SAS.restoreResource"
         },


### PR DESCRIPTION
**Summary**
This removes `SAS: Sign in` from the command palette in an attempt to prevent errors related to trying to use this with non-viya profiles.

**Testing**
- [x] Made sure sign in no longer shows up for non-viya connections
- [x] Made sure sign in _only_  shows up for viya connections (if we choose to implement the suggestion)
