### PR TITLE
chore: remove default assignees from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Create a report to help us improve
 title: ""
 labels: bug
-assignees: clangsmith, 2TomLi
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature request
 about: Suggest an idea for this project
 title: ""
 labels: enhancement
-assignees: clangsmith, 2TomLi
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
**Summary**
This removes Casey & Tom as the default assignees for new bugs/issues

**Testing**
👀 
