### PR TITLE
fix: trim trailing line separator for SAS log

### DIFF
--- a/client/src/components/logViewer/index.ts
+++ b/client/src/components/logViewer/index.ts
@@ -8,6 +8,7 @@ import {
   window,
 } from "vscode";
 
+import type { OnLogFn } from "../../connection";
 import { useLogStore, useRunStore } from "../../store";
 import { logSelectors, runSelectors } from "../../store/selectors";
 import {
@@ -45,7 +46,7 @@ export const LogTokensProvider: DocumentSemanticTokensProvider = {
  * Handles log lines generated for the SAS session startup.
  * @param logs array of log lines to write.
  */
-export const appendSessionLogFn = (logLines) => {
+export const appendSessionLogFn: OnLogFn = (logLines) => {
   appendLogLines(logLines);
 };
 
@@ -53,7 +54,7 @@ export const appendSessionLogFn = (logLines) => {
  * Handles log lines generated for the SAS session execution.
  * @param logs array of log lines to write.
  */
-export const appendExecutionLogFn = (logLines) => {
+export const appendExecutionLogFn: OnLogFn = (logLines) => {
   appendLogLines(logLines);
 
   if (!useLogStore.getState().producedExecutionOutput) {
@@ -65,13 +66,13 @@ export const appendLogToken = (type: string): void => {
   data.push(type);
 };
 
-const appendLogLines = (logs) => {
+const appendLogLines: OnLogFn = (logs) => {
   if (!outputChannel) {
     outputChannel = window.createOutputChannel(l10n.t("SAS Log"), "sas-log");
   }
   for (const line of logs) {
     appendLogToken(line.type);
-    outputChannel.appendLine(line.line);
+    outputChannel.appendLine(line.line.trimEnd());
   }
 };
 


### PR DESCRIPTION
**Summary**
Fix #886
In most cases, a log line returned from server doesn't contain line separator. It fits the `outputChannel.appendLine` API well.
It appears that in the case of #886, a log line returned from server contains a trailing line separator, which produces an unexpected extra line and messed the log type index.
 
**Testing**
Test case in #886
