### PR TITLE
fix: display function autocomplete at some special cases

### DIFF
--- a/server/src/sas/CompletionProvider.ts
+++ b/server/src/sas/CompletionProvider.ts
@@ -1670,7 +1670,7 @@ export class CompletionProvider {
 
   private _notifyOptValue(
     cb: (data?: (string | LibCompleteItem)[]) => void,
-    data: OptionValues,
+    data: OptionValues | undefined,
     optName: string,
   ) {
     if (data) {

--- a/server/src/sas/SyntaxDataProvider.ts
+++ b/server/src/sas/SyntaxDataProvider.ts
@@ -2181,9 +2181,10 @@ export class SyntaxDataProvider {
     procName: string,
     stmtName: string,
     optName: string,
-    cb: (data: OptionValues) => void,
+    cb: (data?: OptionValues) => void,
   ) {
     if (!optName) {
+      cb(undefined);
       return null;
     }
     stmtName = stmtName.toUpperCase();


### PR DESCRIPTION
**Summary**
Fix #905
`getProcedureStatementOptionValues` has to call callback even no data returned, so that function autocomplete can appear.

**Testing**
Test case in #905
