### PR TITLE
chore: using pretty for json output to avoid long line

### DIFF
--- a/client/src/connection/itc/ItcLibraryAdapter.ts
+++ b/client/src/connection/itc/ItcLibraryAdapter.ts
@@ -231,7 +231,7 @@ class ItcLibraryAdapter implements LibraryAdapter {
       run;
 
       filename out temp;
-      proc json nokeys out=out; export work.${tempTable}; run;
+      proc json nokeys out=out pretty; export work.${tempTable}; run;
 
       %put <TABLEDATA>;
       %put <Count>&COUNT</Count>;


### PR DESCRIPTION
**Summary**
Now in the library for the ITC session, json is print to log in a long line which might exceed the limit of SAS if the data set is too large. Now we add the `pretty` option to `proc json` which makes each line of the json file short and it help SAS print full json file to log.

**Testing**
Prepare a large dataset, and open it in library.
