### PR TITLE
fix: fix password parsing

### DIFF
--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -29,7 +29,7 @@ import {
 } from "./const";
 import { scriptContent } from "./script";
 import { Config, ITCProtocol, LineCodes } from "./types";
-import { decodeEntities } from "./util";
+import { decodeEntities, escapePowershellString } from "./util";
 
 const LogLineTypes: LogLineTypeEnum[] = [
   "normal",
@@ -124,10 +124,12 @@ export class ITCSession extends Session {
       this._shellProcess.stdin.write(`$profileHost = "${host}"\n`);
       this._shellProcess.stdin.write(`$port = ${port}\n`);
       this._shellProcess.stdin.write(`$protocol = ${protocol}\n`);
-      this._shellProcess.stdin.write(`$username = "${username}"\n`);
+      this._shellProcess.stdin.write(
+        `$username = "${escapePowershellString(username)}"\n`,
+      );
       const password = await this.fetchPassword();
       this._shellProcess.stdin.write(
-        `$password = "${password.replace(/(`|"|'|\$|\(|\)|%|{|}|\[|\])/g, "`$1")}"\n`,
+        `$password = "${escapePowershellString(password)}"\n`,
       );
       this._shellProcess.stdin.write(
         `$serverName = "${

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -126,7 +126,9 @@ export class ITCSession extends Session {
       this._shellProcess.stdin.write(`$protocol = ${protocol}\n`);
       this._shellProcess.stdin.write(`$username = "${username}"\n`);
       const password = await this.fetchPassword();
-      this._shellProcess.stdin.write(`$password = "${password}"\n`);
+      this._shellProcess.stdin.write(
+        `$password = "${password.replace(/(`|"|'|\$|\(|\)|%|{|}|\[|\])/g, "`$1")}"\n`,
+      );
       this._shellProcess.stdin.write(
         `$serverName = "${
           protocol === ITCProtocol.COM ? "ITC Local" : "ITC IOM Bridge"

--- a/client/src/connection/itc/util.ts
+++ b/client/src/connection/itc/util.ts
@@ -1,7 +1,7 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export function decodeEntities(msg: string) {
+export const decodeEntities = (msg: string): string => {
   // Some of our messages from the server contain html encoded
   // characters. This converts them back.
   const specialCharacters = {
@@ -13,4 +13,7 @@ export function decodeEntities(msg: string) {
   });
 
   return msg;
-}
+};
+
+export const escapePowershellString = (unescapedString: string): string =>
+  unescapedString.replace(/(`|"|'|\$|\(|\)|%|{|}|\[|\])/g, "`$1");

--- a/client/test/connection/itc/util.test.ts
+++ b/client/test/connection/itc/util.test.ts
@@ -1,0 +1,12 @@
+import { expect } from "chai";
+
+import { escapePowershellString } from "../../../src/connection/itc/util";
+
+describe("ITC util test", () => {
+  it("escapePowershellString - escapes powershell special characters", () => {
+    const input = "P@$${}[]()\"'%{}rd";
+    const expectedOutput = "P@`$`$`{`}`[`]`(`)`\"`'`%`{`}rd";
+
+    expect(escapePowershellString(input)).to.equal(expectedOutput);
+  });
+});


### PR DESCRIPTION
**Summary**
This fixes an issue where passwords weren't having special characters replaced as expected

**Testing**
- [x] Test signing in to a SAS server with the following password: `P@$${}[]()"'%{}rd`
