### PR TITLE
fix: Fileref OUTFILE should be allowed for COM/IOM

### DIFF
--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -152,7 +152,7 @@ class SASRunner{
 
   [void]FetchResultsFile([string]$filePath, [string]$outputFile) {
     $fileRef = ""
-    $objFile = $this.objSAS.FileService.AssignFileref("outfile", "DISK", $filePath, "", [ref] $fileRef)
+    $objFile = $this.objSAS.FileService.AssignFileref("", "DISK", $filePath, "", [ref] $fileRef)
     $objStream = $objFile.OpenBinaryStream(1);
     [Byte[]] $bytes = 0x0
 


### PR DESCRIPTION
**Summary**
Fix #868
Pass an empty string to the `AssignFileref` call and it will create a temporary fileref that will never conflict with user code.

**Testing**
Test case in #868
