### PR TITLE
fix: IOM connection hang when work dir is long

### DIFF
--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -345,7 +345,9 @@ export class ITCSession extends Session {
   private fetchWorkDirectory = (line: string): string | undefined => {
     let foundWorkDirectory = "";
     if (
-      !line.includes(`%put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};`)
+      !line.includes(`%put ${WORK_DIR_START_TAG};`) &&
+      !line.includes(`%put &workDir;`) &&
+      !line.includes(`%put ${WORK_DIR_END_TAG};`)
     ) {
       foundWorkDirectory = this._workDirectoryParser.processLine(line);
     } else {
@@ -422,18 +424,21 @@ export class ITCSession extends Session {
         return;
       }
 
-      const foundWorkDirectory = this.fetchWorkDirectory(line);
-      if (foundWorkDirectory === undefined) {
-        return;
-      }
-
-      if (!this._workDirectory && foundWorkDirectory) {
-        this._workDirectory = foundWorkDirectory;
-        this._runResolve();
-        updateStatusBarItem(true);
-        return;
-      }
       if (!this.processLineCodes(line)) {
+        if (!this._workDirectory) {
+          const foundWorkDirectory = this.fetchWorkDirectory(line);
+          if (foundWorkDirectory === undefined) {
+            return;
+          }
+
+          if (foundWorkDirectory) {
+            this._workDirectory = foundWorkDirectory.trim();
+            this._runResolve();
+            updateStatusBarItem(true);
+            return;
+          }
+        }
+
         this._html5FileName = extractOutputHtmlFileName(
           line,
           this._html5FileName,

--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -16,8 +16,9 @@ class SASRunner{
   $code =
 @'
    %let workDir = %sysfunc(pathname(work));
-   %put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};
-   %put &=workDir;
+   %put ${WORK_DIR_START_TAG};
+   %put &workDir;
+   %put ${WORK_DIR_END_TAG};
    %let rc = %sysfunc(dlgcdir("&workDir"));
    run;
 '@

--- a/client/test/connection/itc/index.test.ts
+++ b/client/test/connection/itc/index.test.ts
@@ -88,13 +88,12 @@ describe("ITC connection", () => {
     it("creates a well-formed local session", async () => {
       const setupPromise = session.setup();
 
-      onDataCallback(Buffer.from(`WORKDIR="/work/dir"\n`));
-      onDataCallback(
-        Buffer.from(`%put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};`),
-      );
-      onDataCallback(
-        Buffer.from(`${WORK_DIR_START_TAG}/work/dir${WORK_DIR_END_TAG}`),
-      );
+      onDataCallback(Buffer.from(`%put ${WORK_DIR_START_TAG};`));
+      onDataCallback(Buffer.from(`%put &workDir;`));
+      onDataCallback(Buffer.from(`%put ${WORK_DIR_END_TAG};`));
+      onDataCallback(Buffer.from(`${WORK_DIR_START_TAG}`));
+      onDataCallback(Buffer.from(`/work/dir`));
+      onDataCallback(Buffer.from(`${WORK_DIR_END_TAG}`));
 
       await setupPromise;
 
@@ -142,13 +141,12 @@ describe("ITC connection", () => {
     beforeEach(async () => {
       writeFileSync(tempHtmlPath, html5);
       const setupPromise = session.setup();
-      onDataCallback(Buffer.from(`WORKDIR=/work/dir`));
-      onDataCallback(
-        Buffer.from(`%put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};`),
-      );
-      onDataCallback(
-        Buffer.from(`${WORK_DIR_START_TAG}/work/dir${WORK_DIR_END_TAG}`),
-      );
+      onDataCallback(Buffer.from(`%put ${WORK_DIR_START_TAG};`));
+      onDataCallback(Buffer.from(`%put &workDir;`));
+      onDataCallback(Buffer.from(`%put ${WORK_DIR_END_TAG};`));
+      onDataCallback(Buffer.from(`${WORK_DIR_START_TAG}`));
+      onDataCallback(Buffer.from(`/work/dir`));
+      onDataCallback(Buffer.from(`${WORK_DIR_END_TAG}`));
       await setupPromise;
     });
     afterEach(() => {
@@ -187,13 +185,12 @@ $runner.FetchResultsFile($filePath, $outputFile)
   describe("close", () => {
     beforeEach(async () => {
       const setupPromise = session.setup();
-      onDataCallback(Buffer.from(`WORKDIR=/work/dir`));
-      onDataCallback(
-        Buffer.from(`%put ${WORK_DIR_START_TAG}&workDir${WORK_DIR_END_TAG};`),
-      );
-      onDataCallback(
-        Buffer.from(`${WORK_DIR_START_TAG}/work/dir${WORK_DIR_END_TAG}`),
-      );
+      onDataCallback(Buffer.from(`%put ${WORK_DIR_START_TAG};`));
+      onDataCallback(Buffer.from(`%put &workDir;`));
+      onDataCallback(Buffer.from(`%put ${WORK_DIR_END_TAG};`));
+      onDataCallback(Buffer.from(`${WORK_DIR_START_TAG}`));
+      onDataCallback(Buffer.from(`/work/dir`));
+      onDataCallback(Buffer.from(`${WORK_DIR_END_TAG}`));
       await setupPromise;
     });
 


### PR DESCRIPTION
**Summary**
Fix #964
When the default working directory name is long, it may wrap into multiple lines in SAS log. The `WORK_DIR_END_TAG` may be break into 2 lines thus not captured.
We're injecting log type between each log line, so when parsing across multiple log lines, it has to process LogLineType first, otherwise the log line type will be captured as part of working directory name, which is wrong.

**Testing**
Make default working directory be a pretty long name and try run code.
