### PR TITLE
fix: fix content type when saving files

### DIFF
--- a/client/src/components/ContentNavigator/const.ts
+++ b/client/src/components/ContentNavigator/const.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { l10n } from "vscode";
 
+export const DEFAULT_FILE_CONTENT_TYPE = "text/plain";
+
 const CONTENT_FOLDER_ID = "CONTENT_FOLDER_ID";
 export const ROOT_FOLDER_TYPE = "RootFolder";
 

--- a/client/src/components/ContentNavigator/utils.ts
+++ b/client/src/components/ContentNavigator/utils.ts
@@ -163,11 +163,11 @@ export const getPermission = (item: ContentItem): Permission => {
       };
 };
 
-export const fetchFileContentType = (fileName: string) =>
+export const getFileContentType = (fileName: string) =>
   mimeTypes[fileName.split(".").pop().toLowerCase()] ||
   DEFAULT_FILE_CONTENT_TYPE;
 
-export const fetchItemContentType = (item: ContentItem): string | undefined => {
+export const getItemContentType = (item: ContentItem): string | undefined => {
   const itemIsReference = item.type === "reference";
   if (itemIsReference || isContainer(item)) {
     return undefined;


### PR DESCRIPTION
**Summary**
Previously, saving files would always convert the content type to text/plain. This changes things such that we maintain the content type on save.

Additionally, this makes a few small refactoring changes:
 - This moves a couple of helper functions from ContentModel to utils
 - It removes some unnecessary writes to file metadata

**Testing**
 - [x] Test creating file
 - [x] Test saving file
 - [x] Test renaming file
