### PR TITLE
Revert "fix: pin node version to avoid compatibility issues"

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.16.0"
+          node-version-file: ".nvmrc"
           cache: "npm"
       - run: npm ci
       - run: npm run locale --update-locales


### PR DESCRIPTION
Reverts sassoftware/vscode-sas-extension#786

Looks like the issue was resolved now