### PR TITLE
fix: problems are not clear when there is no problem in log (#1017)

### DIFF
--- a/client/src/components/logViewer/sasDiagnostics.ts
+++ b/client/src/components/logViewer/sasDiagnostics.ts
@@ -77,10 +77,6 @@ async function updateDiagnostics(
 
   const problems = parseLog(logs, codeDoc.wrappedCodeLineAt(0));
 
-  if (!problems || problems.length === 0) {
-    return;
-  }
-
   updateProblemLocation(problems, codeDoc);
 
   const problemsWithValidLocation = problems.filter((problem) => {
@@ -90,7 +86,10 @@ async function updateDiagnostics(
 
   const diagnostics = constructDiagnostics(problemsWithValidLocation);
 
-  getSasDiagnosticCollection().set(Uri.parse(codeDoc.getUri()), diagnostics);
+  getSasDiagnosticCollection().set(
+    Uri.parse(codeDoc.getUri()),
+    diagnostics.length > 0 ? diagnostics : undefined,
+  );
 }
 
 function updateProblemLocation(problems: Problem[], codeDoc: SASCodeDocument) {


### PR DESCRIPTION
**Summary**
The problem related with a sas file should be clear if there is no problem in its log.

**Testing**
see issue #1017 description.
