### PR TITLE
fix: prevent decrease indentation when the word run is used as value

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -29,7 +29,7 @@
       "flags": "i"
     },
     "decreaseIndentPattern": {
-      "pattern": "(run|quit|%mend)(\\s|/\\*.*\\*/|\\*[^;]*;)*;$",
+      "pattern": "(;|^\\s*)(\\s|/\\*.*\\*/|\\*[^;]*;)*(run|quit|%mend)(\\s|/\\*.*\\*/|\\*[^;]*;)*;$",
       "flags": "i"
     }
   },

--- a/server/src/sas/CodeZoneManager.ts
+++ b/server/src/sas/CodeZoneManager.ts
@@ -670,7 +670,8 @@ export class CodeZoneManager {
       if (token && token.text) {
         word = token.text.toUpperCase();
         if (_isBlockEnd[word]) {
-          return true;
+          token = this._getPrev(context);
+          return token?.text === ";";
         } else if (word === "CANCEL") {
           token = this._getPrev(context);
           if (token && token.text && _isBlockEnd[token.text.toUpperCase()]) {
@@ -704,15 +705,6 @@ export class CodeZoneManager {
       context.col = 0;
       context.syntaxIdx = -1;
       context.lastStmtEnd = null;
-    } else if (
-      token.line === initLine &&
-      token.col <= initCol &&
-      token.col + token.text.length >= initCol
-    ) {
-      context.line = token.line;
-      context.col = token.col;
-      context.syntaxIdx = -1;
-      context.lastStmtEnd = { line: token.line, col: token.col };
     } else {
       context.line = token.line;
       context.col = token.col + token.text.length;


### PR DESCRIPTION
Summary
Resolve https://github.com/sassoftware/vscode-sas-extension/issues/522

Testing
1 Enter "run" after "=", indentation will not be reduced.
2 Enter "run" instead of after "=", indentation will decrease normally.