### PR TITLE
fix: library pane crash with option symbolgen

### DIFF
--- a/client/src/connection/itc/ItcLibraryAdapter.ts
+++ b/client/src/connection/itc/ItcLibraryAdapter.ts
@@ -54,7 +54,7 @@ class ItcLibraryAdapter implements LibraryAdapter {
         where libname='${item.library}' and memname='${item.name}'
         order by varnum;
       quit;
-      %put <COLOUTPUT>; %put &OUTPUT; %put </COLOUTPUT>;
+      %put <COLOUTPUT> &OUTPUT; %put </COLOUTPUT>;
     `;
 
     const columnLines = processQueryRows(
@@ -87,7 +87,7 @@ class ItcLibraryAdapter implements LibraryAdapter {
         select catx(',', libname, readonly) as libname_target into: OUTPUT separated by '~'
         from sashelp.vlibnam order by libname asc;
       quit;
-      %put <LIBOUTPUT>; %put &OUTPUT; %put </LIBOUTPUT>;
+      %put <LIBOUTPUT> &OUTPUT; %put </LIBOUTPUT>;
     `;
 
     const libNames = processQueryRows(
@@ -186,7 +186,7 @@ class ItcLibraryAdapter implements LibraryAdapter {
         where libname='${item.name!}'
         order by memname asc;
       quit;
-      %put <TABLEOUTPUT>; %put &OUTPUT; %put </TABLEOUTPUT>;
+      %put <TABLEOUTPUT> &OUTPUT; %put </TABLEOUTPUT>;
     `;
 
     const tableNames = processQueryRows(
@@ -249,7 +249,7 @@ class ItcLibraryAdapter implements LibraryAdapter {
     const count = parseInt(countMatches[1].replace(/\s|\n/gm, ""), 10);
     output = output.replace(countRegex, "");
 
-    const rows = output.replace(/\n|\t/gm, "");
+    const rows = output.replace(/\n|\t/gm, "").slice(output.indexOf("{"));
     try {
       const tableData = JSON.parse(rows);
       return { rows: tableData[`SASTableData+${tempTable}`], count };

--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -131,7 +131,7 @@ class SASRunner{
     try{
       $this.objSAS.LanguageService.FlushLogLines($chunkSize,$carriageControls,$lineTypes,$logLines)
     } catch{
-      throw "FlushLog error"
+      Write-Error "${ERROR_START_TAG}FlushLog error: $_${ERROR_END_TAG}"
     }
     for ($i = 0; $i -lt $logLines.Value.Length; $i++) {
       if (($carriageControls.Value[$i] -eq 1) -and $skipPageHeader) {


### PR DESCRIPTION
**Summary**
Fix #1012
Put the start tag in the same statement with macro resolution so that it will be after the extra log produced by `options symbolgen` 

**Testing**
Test case in #1012
