### PR TITLE
fix: queue run code

### DIFF
--- a/client/src/connection/itc/CodeRunner.ts
+++ b/client/src/connection/itc/CodeRunner.ts
@@ -6,68 +6,77 @@ import { ITCSession } from ".";
 import { LogLine, getSession } from "..";
 import { useRunStore } from "../../store";
 
-class CodeRunner {
-  public async runCode(
-    code: string,
-    startTag: string = "",
-    endTag: string = "",
-  ): Promise<string> {
-    // If we're already executing code, lets wait for it
-    // to finish up.
-    let unsubscribe;
-    if (useRunStore.getState().isExecutingCode) {
-      await new Promise((resolve) => {
-        unsubscribe = useRunStore.subscribe(
-          (state) => state.isExecutingCode,
-          (isExecutingCode) => !isExecutingCode && resolve(true),
-        );
-      });
-    }
+let wait: Promise<string> | undefined;
 
-    const { setIsExecutingCode } = useRunStore.getState();
-    setIsExecutingCode(true);
-    commands.executeCommand("setContext", "SAS.running", true);
-    const session = getSession();
+export async function runCode(
+  code: string,
+  startTag: string = "",
+  endTag: string = "",
+): Promise<string> {
+  const task = () => _runCode(code, startTag, endTag);
 
-    let logText = "";
-    const onExecutionLogFn = session.onExecutionLogFn;
-    const outputLines = [];
-
-    const addLine = (logLines: LogLine[]) =>
-      outputLines.push(...logLines.map(({ line }) => line));
-
-    try {
-      await session.setup(true);
-
-      // Lets capture output to use it on
-      session.onExecutionLogFn = addLine;
-
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      await (session as ITCSession).run(code, true);
-
-      const logOutput = outputLines.filter((line) => line.trim()).join("");
-
-      logText =
-        startTag && endTag
-          ? logOutput
-              .slice(
-                logOutput.lastIndexOf(startTag),
-                logOutput.lastIndexOf(endTag),
-              )
-              .replace(startTag, "")
-              .replace(endTag, "")
-          : logOutput;
-    } finally {
-      unsubscribe && unsubscribe();
-      // Lets update our session to write to the log
-      session.onExecutionLogFn = onExecutionLogFn;
-
-      setIsExecutingCode(false);
-      commands.executeCommand("setContext", "SAS.running", false);
-    }
-
-    return logText;
-  }
+  wait = wait ? wait.then(task) : task();
+  return wait;
 }
 
-export default CodeRunner;
+async function _runCode(
+  code: string,
+  startTag: string = "",
+  endTag: string = "",
+): Promise<string> {
+  // If we're already executing code, lets wait for it
+  // to finish up.
+  let unsubscribe;
+  if (useRunStore.getState().isExecutingCode) {
+    await new Promise((resolve) => {
+      unsubscribe = useRunStore.subscribe(
+        (state) => state.isExecutingCode,
+        (isExecutingCode) => !isExecutingCode && resolve(true),
+      );
+    });
+  }
+
+  const { setIsExecutingCode } = useRunStore.getState();
+  setIsExecutingCode(true);
+  commands.executeCommand("setContext", "SAS.running", true);
+  const session = getSession();
+
+  let logText = "";
+  const onExecutionLogFn = session.onExecutionLogFn;
+  const outputLines = [];
+
+  const addLine = (logLines: LogLine[]) =>
+    outputLines.push(...logLines.map(({ line }) => line));
+
+  try {
+    await session.setup(true);
+
+    // Lets capture output to use it on
+    session.onExecutionLogFn = addLine;
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    await (session as ITCSession).run(code, true);
+
+    const logOutput = outputLines.filter((line) => line.trim()).join("");
+
+    logText =
+      startTag && endTag
+        ? logOutput
+            .slice(
+              logOutput.lastIndexOf(startTag),
+              logOutput.lastIndexOf(endTag),
+            )
+            .replace(startTag, "")
+            .replace(endTag, "")
+        : logOutput;
+  } finally {
+    unsubscribe && unsubscribe();
+    // Lets update our session to write to the log
+    session.onExecutionLogFn = onExecutionLogFn;
+
+    setIsExecutingCode(false);
+    commands.executeCommand("setContext", "SAS.running", false);
+  }
+
+  return logText;
+}

--- a/client/src/connection/itc/ItcLibraryAdapter.ts
+++ b/client/src/connection/itc/ItcLibraryAdapter.ts
@@ -12,7 +12,7 @@ import {
   TableRow,
 } from "../../components/LibraryNavigator/types";
 import { Column, ColumnCollection } from "../rest/api/compute";
-import CodeRunner from "./CodeRunner";
+import { runCode } from "./CodeRunner";
 import { Config } from "./types";
 
 class ItcLibraryAdapter implements LibraryAdapter {
@@ -23,7 +23,6 @@ class ItcLibraryAdapter implements LibraryAdapter {
   protected endTag: string = "";
   protected outputFinished: boolean = false;
   protected config: Config;
-  protected codeRunner = new CodeRunner();
 
   public async connect(): Promise<void> {
     this.hasEstablishedConnection = true;
@@ -270,7 +269,7 @@ class ItcLibraryAdapter implements LibraryAdapter {
     endTag: string = "",
   ): Promise<string> {
     try {
-      return await this.codeRunner.runCode(code, startTag, endTag);
+      return await runCode(code, startTag, endTag);
     } catch (e) {
       onRunError(e);
       commands.executeCommand("setContext", "SAS.librariesDisplayed", false);

--- a/client/test/connection/itc/Coderunner.test.ts
+++ b/client/test/connection/itc/Coderunner.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 
 import * as connection from "../../../src/connection";
-import CodeRunner from "../../../src/connection/itc/CodeRunner";
+import { runCode } from "../../../src/connection/itc/CodeRunner";
 import { Session } from "../../../src/connection/session";
 
 export class MockSession extends Session {
@@ -70,12 +70,7 @@ describe("CodeRunner tests", () => {
 // postfixed sas code
     `;
 
-    const codeRunner = new CodeRunner();
-    const results = await codeRunner.runCode(
-      codeString,
-      "<CodeTag>",
-      "</CodeTag>",
-    );
+    const results = await runCode(codeString, "<CodeTag>", "</CodeTag>");
 
     expect(results).to.equal("Test Code");
   });
@@ -87,8 +82,7 @@ describe("CodeRunner tests", () => {
 // postfixed sas code
     `;
 
-    const codeRunner = new CodeRunner();
-    const results = await codeRunner.runCode(codeString);
+    const results = await runCode(codeString);
 
     expect(results).to.equal(
       codeString


### PR DESCRIPTION
**Summary**
Fix #1022

During code executing, if 2 or more `runCode` calls happen, they're waiting for a same thing and will execute at same time.

The fix is to queue the `runCode` call, and also refactored the `CodeRunner` class to be a static module, as the execution has to be limited to 1 globally.

Note that the original `runCode` implementation was NOT changed at all except renamed to `_runCode`. It may not be obvious in the diff as the indentation was changed.

**Testing**
Test case in #1022
