### PR TITLE
fix: workaround compute log display issues

### DIFF
--- a/client/src/components/utils/SASCodeDocument.ts
+++ b/client/src/components/utils/SASCodeDocument.ts
@@ -138,10 +138,8 @@ export class SASCodeDocument {
 ods graphics on;
 ods html5(id=vscode)${htmlStyleOption} options(bitmap_mode='inline' svg_mode='inline')${outputDestination};
 ${code}
-;*';*";*/;run;quit;
-quit;run;
-ods html5(id=vscode) close;
-ods listing close;`;
+;*';*";*/;run;quit;ods html5(id=vscode) close;
+`;
     } else {
       return code;
     }

--- a/client/src/components/utils/SASCodeDocument.ts
+++ b/client/src/components/utils/SASCodeDocument.ts
@@ -138,7 +138,10 @@ export class SASCodeDocument {
 ods graphics on;
 ods html5(id=vscode)${htmlStyleOption} options(bitmap_mode='inline' svg_mode='inline')${outputDestination};
 ${code}
-;*';*";*/;run;quit;ods html5(id=vscode) close;`;
+;*';*";*/;run;quit;
+quit;run;
+ods html5(id=vscode) close;
+ods listing close;`;
     } else {
       return code;
     }

--- a/client/src/connection/rest/job.ts
+++ b/client/src/connection/rest/job.ts
@@ -141,7 +141,7 @@ export class ComputeJob extends Compute {
       timeout: timeout,
     });
 
-    //To clear out the log, we yeild all lines until there is not "next" link
+    //To clear out the log, we yield all lines until there is not "next" link
     do {
       if (resp.status === 200) {
         nextLink = resp.data.links?.find((link) => link.rel === "next");

--- a/client/test/components/util/SASCodeDocument.test.ts
+++ b/client/test/components/util/SASCodeDocument.test.ts
@@ -31,7 +31,8 @@ python code
 selected python code
 endsubmit;
 run;
-;*';*";*/;run;quit;ods html5(id=vscode) close;`;
+;*';*";*/;run;quit;ods html5(id=vscode) close;
+`;
 
     assert.equal(sasCodeDoc.getWrappedCode(), expected);
   });
@@ -55,7 +56,8 @@ ods html5(id=vscode) style=Illuminate options(bitmap_mode='inline' svg_mode='inl
 proc sql;
 SELECT * FROM issues WHERE issue.developer = 'scnjdl'
 ;quit;
-;*';*";*/;run;quit;ods html5(id=vscode) close;`;
+;*';*";*/;run;quit;ods html5(id=vscode) close;
+`;
 
     assert.equal(sasCodeDoc.getWrappedCode(), expected);
   });
@@ -84,7 +86,8 @@ ods html5(id=vscode) style=Illuminate options(bitmap_mode='inline' svg_mode='inl
 proc sgplot data=sashelp.class;
   histogram age;
 run;
-;*';*";*/;run;quit;ods html5(id=vscode) close;`;
+;*';*";*/;run;quit;ods html5(id=vscode) close;
+`;
 
     assert.equal(sasCodeDoc.getWrappedCode(), expected);
   });
@@ -108,7 +111,8 @@ ods graphics on;
 ods html5(id=vscode) style=Illuminate options(bitmap_mode='inline' svg_mode='inline') body="519058ad-d33b-4b5c-9d23-4cc8d6ffb163.htm";
 %let _SASPROGRAMFILE = %nrquote(%nrstr(c:\\temp\\My Test\\R&D\\mean%(95%CI%)\\Parkinson%'s Disease example.sas));
 %put &=_SASPROGRAMFILE;
-;*';*";*/;run;quit;ods html5(id=vscode) close;`;
+;*';*";*/;run;quit;ods html5(id=vscode) close;
+`;
 
     assert.equal(
       sasCodeDoc.getWrappedCode(),
@@ -136,7 +140,8 @@ ods graphics on;
 ods html5(id=vscode) style=Illuminate options(bitmap_mode='inline' svg_mode='inline') body="519058ad-d33b-4b5c-9d23-4cc8d6ffb163.htm";
 %let _SASPROGRAMFILE = %nrquote(%nrstr(/tmp/My Test/R&D/mean%(95%CI%)/Parkinson%'s Disease example.sas));
 %put &=_SASPROGRAMFILE;
-;*';*";*/;run;quit;ods html5(id=vscode) close;`;
+;*';*";*/;run;quit;ods html5(id=vscode) close;
+`;
 
     assert.equal(
       sasCodeDoc.getWrappedCode(),
@@ -171,7 +176,8 @@ cas; caslib _all_ assign;
   data casuser.cascars; set sashelp.cars; run;
 
   proc casutil; load data=SASHELP.BASEBALL outcaslib="CASUSER" casout="CASBALL";run;
-;*';*";*/;run;quit;ods html5(id=vscode) close;`;
+;*';*";*/;run;quit;ods html5(id=vscode) close;
+`;
 
     assert.equal(
       sasCodeDoc.getWrappedCode(),


### PR DESCRIPTION
**Summary**
Simple workaround to introduce a newline at the end of the postamble to ensure that the last bit of log displays properly in the given error scenario. We'll be following up internally with the compute api team to understand why this is required.

**Testing**
Sample program from #963 for 9x and Viya connections.
