### PR TITLE
fix: trim prompt line in ssh

### DIFF
--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -192,7 +192,7 @@ export class SSHSession extends Session {
         // run completed
         this.getResult();
       }
-      if (!(line.endsWith("?") || line.endsWith(">"))) {
+      if (!(line.trimEnd().endsWith("?") || line.endsWith(">"))) {
         this.html5FileName = extractOutputHtmlFileName(
           line,
           this.html5FileName,


### PR DESCRIPTION
**Summary**
Fix #1070
In SSH connection, if a data stream line ends with `?`, it's a SAS prompt line and not part of SAS log. It appears that in some rare cases, there'll be trailing white spaces after `?`. I don't know why but let's simply trim it.

**Testing**
Test case in #1070
