### PR TITLE
fix: should not clear log for non-user running

### DIFF
--- a/client/src/components/logViewer/index.ts
+++ b/client/src/components/logViewer/index.ts
@@ -110,7 +110,11 @@ useRunStore.subscribe(
     } else if (isExecuting && !prevIsExecuting) {
       setProducedExecutionLogOutput(false);
 
-      if (clearLogOnExecutionStart() && outputChannel) {
+      if (
+        clearLogOnExecutionStart() &&
+        outputChannel &&
+        useRunStore.getState().isUserExecuting
+      ) {
         outputChannel.dispose();
         outputChannel = undefined;
         data = [];

--- a/client/src/connection/itc/CodeRunner.ts
+++ b/client/src/connection/itc/CodeRunner.ts
@@ -37,7 +37,7 @@ async function _runCode(
   }
 
   const { setIsExecutingCode } = useRunStore.getState();
-  setIsExecutingCode(true);
+  setIsExecutingCode(true, false);
   commands.executeCommand("setContext", "SAS.running", true);
   const session = getSession();
 

--- a/client/src/store/run/actions.ts
+++ b/client/src/store/run/actions.ts
@@ -5,15 +5,16 @@ import { StateCreator } from "zustand/vanilla";
 import { type Store } from "./store";
 
 export interface RunActions {
-  setIsExecutingCode: (isExecuting: boolean) => void;
+  setIsExecutingCode: (isExecuting: boolean, isUserExecuting?: boolean) => void;
 }
 
 export const createRunActions: StateCreator<Store, [], [], RunActions> = (
   set,
 ) => ({
-  setIsExecutingCode: (isExecutingCode) => {
+  setIsExecutingCode: (isExecutingCode, isUserExecuting = true) => {
     set({
       isExecutingCode,
+      isUserExecuting,
     });
   },
 });

--- a/client/src/store/run/initialState.ts
+++ b/client/src/store/run/initialState.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 export interface RunState {
   isExecutingCode: boolean;
+  isUserExecuting: boolean;
 }
 
 export const initialState: RunState = {
   isExecutingCode: false,
+  isUserExecuting: false,
 };

--- a/client/test/store/run/actions.test.ts
+++ b/client/test/store/run/actions.test.ts
@@ -12,6 +12,7 @@ describe("run actions", () => {
     const { setIsExecutingCode } = useRunStore.getState();
     const expectedState: RunState = {
       isExecutingCode: true,
+      isUserExecuting: true,
     };
 
     setIsExecutingCode(true);


### PR DESCRIPTION
**Summary**
Fix #1243
ITCLibraryAdapter internally runs SAS code. We should not clear log in this case.

**Testing**
Test case in #1243
