### PR TITLE
fix: allow bracket matching in macro quote

### DIFF
--- a/syntaxes/sas.tmLanguage.json
+++ b/syntaxes/sas.tmLanguage.json
@@ -142,9 +142,9 @@
       "end": "'|(?=\\n)"
     },
     "sas-macro-quotes": {
-      "begin": "(?i)%(?:bquote|superq|nrbquote|nrquote|nrstr|str)",
+      "begin": "(?i)%(?:quote|bquote|superq|nrbquote|nrquote|nrstr|str)",
       "end": "\\)|(?=\\n)",
-      "name": "sas.string.quoted.macro",
+      "name": "sas.quoted.macro",
       "patterns": [
         {
           "include": "#sas-macro-quotes"

--- a/syntaxes/sassql.tmLanguage.json
+++ b/syntaxes/sassql.tmLanguage.json
@@ -659,9 +659,9 @@
       ]
     },
     "sas-macro-quotes": {
-      "begin": "(?i)%(?:bquote|superq|nrbquote|nrquote|nrstr|str)",
+      "begin": "(?i)%(?:quote|bquote|superq|nrbquote|nrquote|nrstr|str)",
       "end": "\\)|(?=\\n)",
-      "name": "sas.string.quoted.macro",
+      "name": "sas.quoted.macro",
       "patterns": [
         {
           "include": "#sas-macro-quotes"


### PR DESCRIPTION
**Summary**
Fix #1213
VS Code will NOT match brackets in strings. Macro quote doesn't need to be treated as string.

**Testing**
Test case in #1213
