### PR TITLE
fix: reset work dir parser each time

### DIFF
--- a/client/src/connection/itc/LineParser.ts
+++ b/client/src/connection/itc/LineParser.ts
@@ -37,4 +37,9 @@ export class LineParser {
   public isCapturingLine(): boolean {
     return this.capturingLine;
   }
+
+  public reset() {
+    this.capturingLine = false;
+    this.processedLines = [];
+  }
 }

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -141,6 +141,7 @@ export class ITCSession extends Session {
         `$runner.Setup($profileHost,$username,$password,$port,$protocol,$serverName,$displayLang)\n`,
         this.onWriteComplete,
       );
+      this._workDirectoryParser.reset();
       this._shellProcess.stdin.write(
         "$runner.ResolveSystemVars()\n",
         this.onWriteComplete,


### PR DESCRIPTION
**Summary**
Fix #1266
The error happened after the parser had started capturing log lines. In the second time the parser is still in the stale state. We should reset the parser each time before getting the work dir.

**Testing**
Test case in #1266
