### PR TITLE
fix: use vscode.open to open file

### DIFF
--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -301,18 +301,14 @@ class ContentDataProvider
     const oldUriToNewUriMap = [[item.vscUri, newUri]];
     const newItemIsContainer = getIsContainer(newItem);
     if (closing !== true && !newItemIsContainer) {
-      await commands.executeCommand("vscode.openWith", newUri, "default", {
-        preview: false,
-      });
+      await commands.executeCommand("vscode.open", newUri);
     }
     if (closing !== true && newItemIsContainer) {
       const urisToOpen = getPreviouslyOpenedChildItems(
         await this.getChildren(newItem),
       );
       for (const [, newUri] of urisToOpen) {
-        await commands.executeCommand("vscode.openWith", newUri, "default", {
-          preview: false,
-        });
+        await commands.executeCommand("vscode.open", newUri);
       }
       oldUriToNewUriMap.push(...urisToOpen);
     }


### PR DESCRIPTION
**Summary**
Fix #1289
Need to use `vscode.open` to open file with correct UI instead of always opening with the default code editor.
It looks like the reason using `vscode.openWith` was to set `preview` to `false`. In my opinion we should not always set `preview` to `false`. It's possible that the file was in preview mode before closing, in which case it doesn't make sense to re-open with `preview: false`. The tab closing is noticeable to end user. We even ask user to save or not save the file before closing. So I think it's OK to re-open with preview mode, same as if user close and re-open.

**Testing**
Test case in #1289
