### PR TITLE
fix: do not add empty line before the first section inside a region

### DIFF
--- a/client/testFixture/formatter/expected.sas
+++ b/client/testFixture/formatter/expected.sas
@@ -88,13 +88,11 @@ quit;
 
 %macro reportit(request);
   %if %upcase(&request)=STAT %then %do;
-
     proc means;
       title "Summary of All Numeric Variables";
     run;
   %end;
   %else %if %upcase(&request)=PRINTIT %then %do;
-
     proc print;
       title "Listing of Data";
     run;
@@ -105,7 +103,6 @@ quit;
 
 *region;
 %macro;
-
   *region;
   data _null_;
     *region;

--- a/server/src/sas/formatter/printer.ts
+++ b/server/src/sas/formatter/printer.ts
@@ -45,7 +45,12 @@ export const print: Printer<SASAST>["print"] = (path, options, print) => {
     );
     if (node.type === "region") {
       const region = printRegion(children);
-      return !path.isFirst && node.block ? [hardline, ...region] : region;
+      return !(
+        path.isFirst ||
+        (path.index === 1 && path.parent?.type === "region")
+      ) && node.block
+        ? [hardline, ...region]
+        : region;
     }
     return [...join(line, children), literalline];
   }


### PR DESCRIPTION
**Summary**
Fix #1288
When inside a region, it's not the first node but the second. The first node is the region start statement (e.g. `%macro;`)

**Testing**
Test case in #1288
