### PR TITLE
feat: inherit VS Code file icons in SAS Content and Server

### DIFF
--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -18,7 +18,6 @@ import {
   TabInputText,
   TextDocument,
   TextDocumentContentProvider,
-  ThemeIcon,
   TreeDataProvider,
   TreeDragAndDropController,
   TreeItem,
@@ -230,6 +229,7 @@ class ContentDataProvider
       iconPath: this.iconPathForItem(item),
       id: item.uid,
       label: item.name,
+      resourceUri: uri,
     };
   }
 
@@ -698,7 +698,7 @@ class ContentDataProvider
 
   private iconPathForItem(
     item: ContentItem,
-  ): ThemeIcon | { light: Uri; dark: Uri } {
+  ): undefined | { light: Uri; dark: Uri } {
     const isContainer = getIsContainer(item);
     let icon = "";
     if (isContainer) {
@@ -723,11 +723,6 @@ class ContentDataProvider
           icon = "folder";
           break;
       }
-    } else {
-      const extension = item.name.split(".").pop().toLowerCase();
-      if (extension === "sas") {
-        icon = "sasProgramFile";
-      }
     }
 
     return icon !== ""
@@ -738,7 +733,7 @@ class ContentDataProvider
             `icons/light/${icon}Light.svg`,
           ),
         }
-      : ThemeIcon.File;
+      : undefined;
   }
 }
 

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -3,7 +3,6 @@ import {
   DataTransferItem,
   FileStat,
   FileType,
-  ThemeIcon,
   TreeItem,
   Uri,
   authentication,
@@ -175,7 +174,6 @@ describe("ContentDataProvider", async function () {
     const treeItem = await dataProvider.getTreeItem(contentItem);
     const uri = contentItem.vscUri;
     const expectedTreeItem: TreeItem = {
-      iconPath: ThemeIcon.File,
       id: "unique-id",
       label: "testFile",
       command: {
@@ -183,6 +181,7 @@ describe("ContentDataProvider", async function () {
         arguments: [uri],
         title: "Open SAS File",
       },
+      resourceUri: uri,
     };
 
     expect(treeItem).to.deep.include(expectedTreeItem);


### PR DESCRIPTION
**Summary**
Resolves #1299
We should not explicitly specify a general file icon so that VS Code can go with its default.
It honors user's [File Icon Themes](https://code.visualstudio.com/docs/getstarted/themes#_file-icon-themes)

**Testing**
See file icons in SAS Content and SAS Server same to VS Code Explorer view.
