### PR TITLE
fix: reject run promise when close session

### DIFF
--- a/client/src/components/notebook/Controller.ts
+++ b/client/src/components/notebook/Controller.ts
@@ -98,10 +98,12 @@ export class NotebookController {
         ]),
       ]);
       execution.end(false, Date.now());
+      if (!this._interrupted) {
+        this._interrupted = deferred();
+      }
     }
     if (this._interrupted) {
       this._interrupted.resolve();
-      this._interrupted = undefined;
     }
   }
 

--- a/client/src/connection/itc/index.ts
+++ b/client/src/connection/itc/index.ts
@@ -208,7 +208,7 @@ export class ITCSession extends Session {
    * @param onLog A callback handler responsible for marshalling log lines back to the higher level extension API.
    * @returns A promise that eventually resolves to contain the given {@link RunResult} for the input code execution.
    */
-  public run = async (
+  protected _run = async (
     code: string,
     skipPageHeaders?: boolean,
   ): Promise<RunResult> => {
@@ -249,7 +249,7 @@ export class ITCSession extends Session {
    * Cleans up resources for the given SAS session.
    * @returns void promise.
    */
-  public close = async (): Promise<void> => {
+  protected _close = async (): Promise<void> => {
     return new Promise((resolve) => {
       if (this._shellProcess) {
         this._shellProcess.stdin.write(

--- a/client/src/connection/rest/index.ts
+++ b/client/src/connection/rest/index.ts
@@ -138,7 +138,7 @@ class RestSession extends Session {
     updateStatusBarItem(true);
   };
 
-  public run = async (code: string) => {
+  protected _run = async (code: string) => {
     if (!this._computeSession?.sessionId) {
       throw new Error();
     }
@@ -189,7 +189,7 @@ class RestSession extends Session {
     return res;
   };
 
-  public close = async () => {
+  protected _close = async () => {
     if (this.sessionId()) {
       this._computeSession.delete();
       this._computeSession = undefined;

--- a/client/src/connection/ssh/index.ts
+++ b/client/src/connection/ssh/index.ts
@@ -112,7 +112,7 @@ export class SSHSession extends Session {
     });
   };
 
-  public run = (code: string): Promise<RunResult> => {
+  protected _run = (code: string): Promise<RunResult> => {
     this._html5FileName = "";
 
     return new Promise((_resolve, _reject) => {
@@ -124,7 +124,7 @@ export class SSHSession extends Session {
     });
   };
 
-  public close = (): void | Promise<void> => {
+  protected _close = (): void | Promise<void> => {
     if (!this._stream) {
       this.disposeResources();
       return;

--- a/client/test/connection/itc/Coderunner.test.ts
+++ b/client/test/connection/itc/Coderunner.test.ts
@@ -26,7 +26,7 @@ export class MockSession extends Session {
     return;
   }
 
-  public async run(codeString: string): Promise<connection.RunResult> {
+  protected async _run(codeString: string): Promise<connection.RunResult> {
     if (this._runMap) {
       const [, result] = Object.entries(this._runMap).find(([code]) =>
         codeString.includes(code),
@@ -45,7 +45,7 @@ export class MockSession extends Session {
     return {};
   }
 
-  public close(): void | Promise<void> {}
+  protected _close(): void | Promise<void> {}
 
   public sessionId?(): string {
     return "";


### PR DESCRIPTION
**Summary**
Fix the problem described [here](https://github.com/sassoftware/vscode-sas-extension/issues/1212#issuecomment-2360386822)
Need to reject the current run promise when close session, otherwise it will never resolve or reject and user can't run again.

**Testing**
Close session in a long running, user can run again.
