### PR TITLE
feat: export sasnb to HTML

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,8 @@
         "ag-grid-community": "^33.1.1",
         "ag-grid-react": "^33.1.1",
         "axios": "^1.8.2",
+        "highlight.js": "^11.11.1",
+        "marked": "^15.0.7",
         "media-typer": "^1.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -137,13 +139,11 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -285,6 +285,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
@@ -386,6 +399,20 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -397,6 +424,51 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
       "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
       "dev": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -418,16 +490,124 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -444,12 +624,13 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -569,6 +750,27 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.7.tgz",
+      "integrity": "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/media-typer": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,8 @@
     "ag-grid-community": "^33.1.1",
     "ag-grid-react": "^33.1.1",
     "axios": "^1.8.2",
+    "highlight.js": "^11.11.1",
+    "marked": "^15.0.7",
     "media-typer": "^1.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/client/src/components/notebook/exporters/index.ts
+++ b/client/src/components/notebook/exporters/index.ts
@@ -1,0 +1,32 @@
+// Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { Uri, window, workspace } from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+import path from "path";
+
+import { exportToHTML } from "./toHTML";
+import { exportToSAS } from "./toSAS";
+
+export const exportNotebook = async (client: LanguageClient) => {
+  const notebook = window.activeNotebookEditor?.notebook;
+
+  if (!notebook) {
+    return;
+  }
+
+  const uri = await window.showSaveDialog({
+    filters: { SAS: ["sas"], HTML: ["html"] },
+    defaultUri: Uri.parse(path.basename(notebook.uri.path, ".sasnb")),
+  });
+
+  if (!uri) {
+    return;
+  }
+
+  const content = uri.path.endsWith(".html")
+    ? await exportToHTML(notebook, client)
+    : exportToSAS(notebook);
+
+  workspace.fs.writeFile(uri, Buffer.from(content));
+};

--- a/client/src/components/notebook/exporters/templates/dark.css
+++ b/client/src/components/notebook/exporters/templates/dark.css
@@ -1,0 +1,114 @@
+body {
+  background-color: #03233a;
+  color: #cccccc;
+  --border-color: #b0b7bb;
+  --highlight-background-color: #9fb6c633;
+}
+.markdown-cell a:link {
+  color: #3794ff;
+}
+.hljs {
+  background: #021727;
+  color: #dddfe4;
+}
+
+/* Syntax highlighting */
+.hljs-operator,
+.hljs-punctuation {
+  color: #dddfe4;
+}
+
+.hljs-keyword {
+  color: #4398f9;
+}
+
+.hljs-comment {
+  color: #97c03f;
+}
+
+.hljs-string {
+  color: #f17e70;
+}
+
+.hljs-number {
+  color: #54b6a4;
+}
+
+.hljs-title {
+  color: #92c3fc;
+  font-weight: bold;
+}
+
+.hljs-built_in {
+  color: #faaa6b;
+}
+
+/* SAS Syntax */
+.sas-syntax-sep {
+  color: #dddfe4;
+}
+
+.sas-syntax-keyword,
+.sas-syntax-macro-keyword {
+  color: #4398f9;
+}
+
+.sas-syntax-sec-keyword,
+.sas-syntax-proc-name {
+  color: #92c3fc;
+  font-weight: bold;
+}
+
+.sas-syntax-comment,
+.sas-syntax-macro-comment {
+  color: #97c03f;
+}
+
+.sas-syntax-macro-ref,
+.sas-syntax-macro-sec-keyword {
+  color: #dddfe4;
+  font-weight: bold;
+}
+
+.sas-syntax-cards-data {
+  color: #faaa6b;
+}
+
+.sas-syntax-string {
+  color: #f17e70;
+}
+
+.sas-syntax-date,
+.sas-syntax-time,
+.sas-syntax-dt,
+.sas-syntax-bitmask {
+  color: #54b6a4;
+  font-weight: bold;
+}
+
+.sas-syntax-namelit {
+  color: #f17e70;
+  font-weight: bold;
+}
+
+.sas-syntax-hex,
+.sas-syntax-numeric {
+  color: #54b6a4;
+  font-weight: bold;
+}
+
+.sas-syntax-format {
+  color: #54b6a4;
+}
+
+.log-line.sas-log-error {
+  color: #ff4d4d;
+}
+
+.log-line.sas-log-warning {
+  color: #ffb829;
+}
+
+.log-line.sas-log-note {
+  color: #2fa8fe;
+}

--- a/client/src/components/notebook/exporters/templates/default.html
+++ b/client/src/components/notebook/exporters/templates/default.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: "Segoe UI", sans-serif;
+      }
+      .markdown-cell table td,
+      .markdown-cell table th {
+        border: 1px solid var(--border-color);
+      }
+      .markdown-cell code {
+        padding: 0 .4em;
+        border-radius: 4px;
+        background-color: var(--highlight-background-color);
+      }
+      .code-cell {
+        position: relative;
+        font-size: 14px;
+      }
+      .code-cell pre code {
+        font-family: Consolas, monospace;
+      }
+      pre code.hljs {
+        display: block;
+        overflow-x: auto;
+        padding: 1em;
+        border: 1px solid var(--border-color);
+      }
+      .code-cell .languageId {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        text-transform: uppercase;
+        padding: .1em .5em;
+        background-color: var(--highlight-background-color);
+      }
+      .log-line {
+        font-family: Consolas, monospace;
+        font-size: 14px;
+        white-space: pre-wrap;
+        margin-inline-start: 1em;
+      }
+      ${theme}
+    </style>
+  </head>
+  <body>
+    ${content}
+  </body>
+</html>

--- a/client/src/components/notebook/exporters/templates/light.css
+++ b/client/src/components/notebook/exporters/templates/light.css
@@ -1,0 +1,109 @@
+body {
+  color: #3b3b3b;
+  --border-color: #b0b7bb;
+  --highlight-background-color: #818b981f;
+}
+.hljs {
+  background: #fff;
+}
+
+/* Syntax highlighting */
+.hljs-operator,
+.hljs-punctuation {
+  color: #1b1d22;
+}
+
+.hljs-keyword {
+  color: #3578c5;
+}
+
+.hljs-comment {
+  color: #647f29;
+}
+
+.hljs-string {
+  color: #8f4238;
+}
+
+.hljs-number {
+  color: #3c8275;
+}
+
+.hljs-title {
+  color: #224c7c;
+  font-weight: bold;
+}
+
+.hljs-built_in {
+  color: #aa0d91;
+}
+
+/* SAS Syntax */
+.sas-syntax-sep {
+  color: #1b1d22;
+}
+
+.sas-syntax-keyword,
+.sas-syntax-macro-keyword {
+  color: #3578c5;
+}
+
+.sas-syntax-sec-keyword,
+.sas-syntax-proc-name {
+  color: #224c7c;
+  font-weight: bold;
+}
+
+.sas-syntax-comment,
+.sas-syntax-macro-comment {
+  color: #647f29;
+}
+
+.sas-syntax-macro-ref,
+.sas-syntax-macro-sec-keyword {
+  color: #1b1d22;
+  font-weight: bold;
+}
+
+.sas-syntax-cards-data {
+  color: #ad6531;
+}
+
+.sas-syntax-string {
+  color: #8f4238;
+}
+
+.sas-syntax-date,
+.sas-syntax-time,
+.sas-syntax-dt,
+.sas-syntax-bitmask {
+  color: #3c8275;
+  font-weight: bold;
+}
+
+.sas-syntax-namelit {
+  color: #8f4238;
+  font-weight: bold;
+}
+
+.sas-syntax-hex,
+.sas-syntax-numeric {
+  color: #3c8275;
+  font-weight: bold;
+}
+
+.sas-syntax-format {
+  color: #3c8275;
+}
+
+.log-line.sas-log-error {
+  color: #ff0000;
+}
+
+.log-line.sas-log-warning {
+  color: #8f5f00;
+}
+
+.log-line.sas-log-note {
+  color: #0000ff;
+}

--- a/client/src/components/notebook/exporters/toHTML.ts
+++ b/client/src/components/notebook/exporters/toHTML.ts
@@ -1,0 +1,189 @@
+// Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import {
+  ColorThemeKind,
+  NotebookCell,
+  NotebookCellKind,
+  NotebookCellOutput,
+  NotebookDocument,
+  TextDocument,
+  window,
+} from "vscode";
+import {
+  LanguageClient,
+  SemanticTokensRequest,
+} from "vscode-languageclient/node";
+
+import { readFileSync } from "fs";
+import hljs from "highlight.js/lib/core";
+import python from "highlight.js/lib/languages/python";
+import sql from "highlight.js/lib/languages/sql";
+import { marked } from "marked";
+import path from "path";
+
+import type { LogLine } from "../../../connection";
+import { includeLogInNotebookExport } from "../../utils/settings";
+
+const templatesDir = path.resolve(__dirname, "../notebook/exporters/templates");
+
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("sql", sql);
+
+export const exportToHTML = async (
+  notebook: NotebookDocument,
+  client: LanguageClient,
+) => {
+  const cells = notebook.getCells();
+
+  let template = readFileSync(`${templatesDir}/default.html`).toString();
+
+  const isDark =
+    window.activeColorTheme.kind === ColorThemeKind.Dark ||
+    window.activeColorTheme.kind === ColorThemeKind.HighContrast;
+  const theme = readFileSync(
+    `${templatesDir}/${isDark ? "dark" : "light"}.css`,
+  ).toString();
+
+  template = template.replace("${theme}", theme);
+  template = template.replace("${content}", await exportCells(cells, client));
+
+  return template;
+};
+
+const exportCells = async (cells: NotebookCell[], client: LanguageClient) => {
+  let result = "";
+
+  for (const cell of cells) {
+    if (cell.kind === NotebookCellKind.Markup) {
+      result += markdownToHTML(cell.document) + "\n";
+    } else {
+      result += (await codeToHTML(cell.document, client)) + "\n";
+      if (cell.outputs.length > 0) {
+        for (const output of cell.outputs) {
+          if (includeLogInNotebookExport()) {
+            result += logToHTML(output) + "\n";
+          }
+          result += odsToHTML(output) + "\n";
+        }
+      }
+    }
+  }
+
+  return result;
+};
+
+const markdownToHTML = (doc: TextDocument) => {
+  return `<div class="markdown-cell">
+${marked.parse(doc.getText())}
+</div>`;
+};
+
+const codeToHTML = async (doc: TextDocument, client: LanguageClient) => {
+  let result = "";
+  if (doc.languageId === "sas") {
+    result = await SASToHTML(doc, client);
+  } else {
+    result = hljs.highlight(doc.getText(), {
+      language: doc.languageId,
+    }).value;
+  }
+  return `<div class="code-cell">
+<pre><code class="hljs">${result}</code></pre>
+<div class="languageId">${doc.languageId}</div>
+</div>`;
+};
+
+const SASToHTML = async (doc: TextDocument, client: LanguageClient) => {
+  const result = [];
+  const tokens = (
+    await client.sendRequest(SemanticTokensRequest.type, {
+      textDocument: {
+        uri: doc.uri.toString(),
+      },
+    })
+  ).data;
+  const legend =
+    client.initializeResult.capabilities.semanticTokensProvider.legend
+      .tokenTypes;
+  let tokenIndex = 0;
+  let token =
+    tokenIndex + 4 < tokens.length
+      ? {
+          line: tokens[tokenIndex],
+          startChar: tokens[tokenIndex + 1],
+          length: tokens[tokenIndex + 2],
+          tokenType: tokens[tokenIndex + 3],
+        }
+      : null;
+
+  for (let line = 0; line < doc.lineCount; line++) {
+    const lineText = doc.lineAt(line).text;
+    const parts = [];
+    let end = 0;
+
+    while (token && token.line === line) {
+      parts.push(lineText.slice(end, token.startChar));
+      end = token.startChar + token.length;
+      parts.push(
+        `<span class="sas-syntax-${legend[token.tokenType]}">${lineText.slice(
+          token.startChar,
+          end,
+        )}</span>`,
+      );
+      tokenIndex += 5;
+      token =
+        tokenIndex + 4 < tokens.length
+          ? {
+              line: tokens[tokenIndex] + token.line,
+              startChar:
+                tokens[tokenIndex + 1] +
+                (tokens[tokenIndex] > 0 ? 0 : token.startChar),
+              length: tokens[tokenIndex + 2],
+              tokenType: tokens[tokenIndex + 3],
+            }
+          : null;
+    }
+    parts.push(lineText.slice(end));
+    result.push(parts.join(""));
+  }
+  return result.join("\n");
+};
+
+const odsToHTML = (output: NotebookCellOutput) => {
+  const ods = output.items.find(
+    (item) => item.mime === "application/vnd.sas.ods.html5",
+  );
+  if (ods) {
+    const html = ods.data.toString();
+    const style = html.slice(
+      html.indexOf("<style>"),
+      html.indexOf("</style>") + 8,
+    );
+    const content = html.slice(
+      html.indexOf("<body ") + 6,
+      html.lastIndexOf("</body>"),
+    );
+    return `<div class="cell-output">
+${style}
+<div ${content}</div>
+</div>`;
+  }
+  return "";
+};
+
+const logToHTML = (output: NotebookCellOutput) => {
+  const logItem = output.items.find(
+    (item) => item.mime === "application/vnd.sas.compute.log.lines",
+  );
+  if (logItem) {
+    const logs: LogLine[] = JSON.parse(logItem.data.toString());
+    return `<div class="cell-output">
+${logs
+  .map(
+    (line) => `<div class="log-line sas-log-${line.type}">${line.line}</div>`,
+  )
+  .join("\n")}
+</div>`;
+  }
+  return "";
+};

--- a/client/src/components/notebook/exporters/toSAS.ts
+++ b/client/src/components/notebook/exporters/toSAS.ts
@@ -1,29 +1,12 @@
-// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// Copyright © 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { NotebookCell, window, workspace } from "vscode";
+import { NotebookCell, NotebookDocument } from "vscode";
 
-export const exportNotebook = async () => {
-  const notebook = window.activeNotebookEditor?.notebook;
-
-  if (!notebook) {
-    return;
-  }
-
-  const uri = await window.showSaveDialog({
-    filters: { SAS: ["sas"] },
-  });
-
-  if (!uri) {
-    return;
-  }
-
-  const content = notebook
+export const exportToSAS = (notebook: NotebookDocument) =>
+  notebook
     .getCells()
     .map((cell) => exportCell(cell) + "\n")
     .join("\n");
-
-  workspace.fs.writeFile(uri, Buffer.from(content));
-};
 
 const exportCell = (cell: NotebookCell) => {
   const text = cell.document.getText();
@@ -48,10 +31,8 @@ ${code}
 quit;`;
 };
 
-const wrapPython = (code: string) => {
-  return `proc python;
+const wrapPython = (code: string) => `proc python;
 submit;
 ${code}
 endsubmit;
 run;`;
-};

--- a/client/src/components/utils/settings.ts
+++ b/client/src/components/utils/settings.ts
@@ -33,3 +33,7 @@ export function clearLogOnExecutionStart(): boolean {
 export function isShowProblemsFromSASLogEnabled(): boolean {
   return workspace.getConfiguration("SAS").get("problems.log.enabled");
 }
+
+export function includeLogInNotebookExport(): boolean {
+  return workspace.getConfiguration("SAS").get("notebook.export.includeLog");
+}

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -51,8 +51,8 @@ import {
 import { LogTokensProvider, legend } from "../components/logViewer";
 import { sasDiagnostic } from "../components/logViewer/sasDiagnostics";
 import { NotebookController } from "../components/notebook/Controller";
-import { exportNotebook } from "../components/notebook/Exporter";
 import { NotebookSerializer } from "../components/notebook/Serializer";
+import { exportNotebook } from "../components/notebook/exporters";
 import { ConnectionType } from "../components/profile";
 import { SasTaskProvider } from "../components/tasks/SasTaskProvider";
 import { SAS_TASK_TYPE } from "../components/tasks/SasTasks";
@@ -197,7 +197,9 @@ export function activate(context: ExtensionContext): void {
     new NotebookController(),
     commands.registerCommand("SAS.notebook.new", newSASNotebook),
     commands.registerCommand("SAS.file.new", newSASFile),
-    commands.registerCommand("SAS.notebook.export", exportNotebook),
+    commands.registerCommand("SAS.notebook.export", () =>
+      exportNotebook(client),
+    ),
     tasks.registerTaskProvider(SAS_TASK_TYPE, new SasTaskProvider()),
     ...sasDiagnostic.getSubscriptions(),
   );

--- a/package.json
+++ b/package.json
@@ -491,6 +491,12 @@
             "type": "boolean",
             "default": true,
             "description": "%configuration.SAS.log.clearOnExecutionStart%"
+          },
+          "SAS.notebook.export.includeLog": {
+            "order": 10,
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.SAS.notebook.export.includeLog%"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -58,6 +58,7 @@
   "configuration.SAS.log.clearOnExecutionStart": "Clear SAS Log when code execution starts",
   "configuration.SAS.log.showOnExecutionFinish": "Show SAS Log when code execution is finished",
   "configuration.SAS.log.showOnExecutionStart": "Show SAS Log when code execution starts",
+  "configuration.SAS.notebook.export.includeLog": "Include SAS log in exported notebook",
   "configuration.SAS.problems.log.enabled": "Show problems from SAS log",
   "configuration.SAS.results.html.enabled": "Enable/disable ODS HTML5 output",
   "configuration.SAS.results.html.style": "Specifies the style for ODS HTML5 results.",

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -95,6 +95,10 @@ if (process.env.npm_config_webviews || process.env.npm_config_client) {
           src: "./server/src/python/sas",
           dest: "./server/dist/node/typeshed-fallback/stubs/sas",
         },
+        {
+          src: "./client/src/components/notebook/exporters/templates",
+          dest: "./client/dist/notebook/exporters/templates",
+        },
       ];
       for (const item of foldersToCopy) {
         fs.cpSync(item.src, item.dest, { recursive: true });

--- a/website/docs/Features/sasNotebook.md
+++ b/website/docs/Features/sasNotebook.md
@@ -12,3 +12,17 @@ SAS Notebook is an interactive notebook file that includes markdown code, execut
 - You can use the `File` menu to save your SAS Notebook to a `.sasnb` file, share the notebook with others, and open the notebook in another VS Code window.
 
 ![SAS Notebook](/images/sasNotebook.png)
+
+## Export
+
+To export your SAS Notebook to other formats, click the **More Actions** (`...`) button on the notebook toolbar at top, and select `Export`. The following formats are supported.
+
+### SAS
+
+PYTHON and SQL code cells will be wrapped with PROC PYTHON/SQL respectively to be executed on SAS. Markdown cells will be converted to block comments.
+
+### HTML
+
+The exported HTML will be in Light or Dark theme depending on your VS Code theme kind.
+
+By default it doesn't include SAS log into the exported HTML file. To include log, check the `SAS.notebook.export.includeLog` setting.


### PR DESCRIPTION
**Summary**
Provide the ability to export SAS Notebook to HTML file.

_Notes_
- Extensions do not have access to the VS Code DOM, we're not able to get what rendered in VS Code. Therefore the exported HTML may not look same to what you see in VS Code. Same thing happens for Jupyter extension.
- The exported HTML will be in Light or Dark theme depending on your current VS Code theme kind.
- By default it doesn't include SAS log into the exported HTML file. To include log, check the `SAS.notebook.export.includeLog` setting.

**Testing**
Open a `.sasnb` file, click `...` from the top toolbar and select `Export`, specify an HTML file name.
