### PR TITLE
chore: restore getFoldingBlock LSP API

### DIFF
--- a/client/src/commands/run.ts
+++ b/client/src/commands/run.ts
@@ -47,7 +47,8 @@ async function getSelectedRegions(
       "sas/getFoldingBlock",
       {
         textDocument: { uri: window.activeTextEditor.document.uri.toString() },
-        position: { line, col },
+        line,
+        col,
       },
     );
     if (block) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -280,22 +280,19 @@ export const runServer = (
   });
 
   connection.onRequest("sas/getFoldingBlock", async (params) => {
-    return await dispatch(params, {
-      async default(languageServices) {
-        const block = languageServices.sasLanguageService.getFoldingBlock(
-          params.position.line,
-          params.position.col,
-          params.strict ?? true,
-          params.ignoreCustomBlock,
-          params.ignoreGlobalBlock,
-        );
-        if (!block) {
-          return undefined;
-        } else {
-          return { ...block, outerBlock: undefined, innerBlocks: undefined };
-        }
-      },
-    });
+    const languageService = getLanguageService(params.textDocument.uri);
+    const block = languageService.getFoldingBlock(
+      params.line,
+      params.col,
+      params.strict ?? true,
+      params.ignoreCustomBlock,
+      params.ignoreGlobalBlock,
+    );
+    if (!block) {
+      return undefined;
+    } else {
+      return { ...block, outerBlock: undefined, innerBlocks: undefined };
+    }
   });
 
   connection.onDocumentOnTypeFormatting(async (params) => {


### PR DESCRIPTION
**Summary**
#991 changed the "sas/getFoldingBlock" LSP API, which broke other clients. The type (line/col) is not really the Position (line, character) type. Restore it.

**Testing**
Run Region works well as before
