### PR TITLE
fix: correct default value for last found index in ProblemProcessor (#1475)

### DIFF
--- a/client/src/components/logViewer/ProblemProcessor.ts
+++ b/client/src/components/logViewer/ProblemProcessor.ts
@@ -317,7 +317,7 @@ export class ProblemProcessor {
     const unclaimedLocations = [];
     locations.forEach((location) => {
       const problemNumber = location.problemNumber;
-      const lastFoundIndex = lastIndexMap.get(problemNumber) ?? 0;
+      const lastFoundIndex = lastIndexMap.get(problemNumber) ?? -1;
       let currentIndex = (lastFoundIndex + 1) % rawProblems.length;
       let foundIndex = undefined;
       let count = 0;


### PR DESCRIPTION
**Summary**

If there is first matching locations and problems, the initial beginning index should be 0, which is 1 before this fix.
fix #1475 

**Testing**

