### PR TITLE
Added single-line comment mode, consistent with the official SAS editor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.node
 *.qps-ploc.json
 l10n/bundle.l10n.json
+.history

--- a/client/src/commands/wrapLinesWithComment.ts
+++ b/client/src/commands/wrapLinesWithComment.ts
@@ -1,0 +1,80 @@
+import { Range, commands, window } from "vscode";
+
+/**
+ * Registers a command to wrap the non-blank content of the selected line or multiple lines with SAS block comments (/* ... *\/).
+ * If the selection spans multiple lines, each line will be commented individually.
+ */
+export function registerAddCommentCommand() {
+  return commands.registerCommand("SAS.addBlockComment", async () => {
+    const editor = window.activeTextEditor;
+    if (!editor) {
+      window.showInformationMessage("No active editor");
+      return;
+    }
+    const { selections, document } = editor;
+    await editor.edit((editBuilder) => {
+      for (const selection of selections) {
+        const start = selection.start.line;
+        const end = selection.end.line;
+        for (let i = start; i <= end; i++) {
+          const line = document.lineAt(i);
+          const lineText = line.text.substring(
+            line.firstNonWhitespaceCharacterIndex,
+          );
+          const replacementRange = new Range(
+            i,
+            line.firstNonWhitespaceCharacterIndex,
+            i,
+            line.text.length,
+          );
+          if (lineText.trim().length > 0) {
+            editBuilder.replace(replacementRange, `/* ${lineText} */`);
+          } else {
+            editBuilder.replace(replacementRange, `/*  */`);
+          }
+        }
+      }
+    });
+  });
+}
+
+/**
+ * Registers a command to remove SAS block comments (/* ... *\/) from the selected line or multiple lines.
+ * If the selection spans multiple lines, each line will be processed individually.
+ */
+export function registerRemoveCommentCommand() {
+  return commands.registerCommand("SAS.removeBlockComment", async () => {
+    const editor = window.activeTextEditor;
+    if (!editor) {
+      window.showInformationMessage("No active editor");
+      return;
+    }
+    const { selections, document } = editor;
+    // Regex to find SAS block comments, allowing for leading/trailing whitespace
+    // and optional space after /* and before */
+    // It captures the content within the comment
+    const commentRegex = /^\s*\/\*\s?(.*?)\s?\*\/\s*$/;
+    await editor.edit((editBuilder) => {
+      for (const selection of selections) {
+        const start = selection.start.line;
+        const end = selection.end.line;
+        for (let i = start; i <= end; i++) {
+          const line = document.lineAt(i);
+          const lineText = line.text;
+          const replacementRange = new Range(
+            i,
+            line.firstNonWhitespaceCharacterIndex,
+            i,
+            line.text.length,
+          );
+          const match = lineText.match(commentRegex);
+          if (match) {
+            // The actual content of the comment is in match[1]
+            const uncommentedText = match[1];
+            editBuilder.replace(replacementRange, uncommentedText);
+          }
+        }
+      }
+    });
+  });
+}

--- a/client/src/node/extension.ts
+++ b/client/src/node/extension.ts
@@ -32,6 +32,10 @@ import {
   updateProfile,
 } from "../commands/profile";
 import { run, runRegion, runSelected } from "../commands/run";
+import {
+  registerAddCommentCommand,
+  registerRemoveCommentCommand,
+} from "../commands/wrapLinesWithComment";
 import { getRestAPIs } from "../components/APIProvider";
 import { SASAuthProvider } from "../components/AuthProvider";
 import { installCAs } from "../components/CAHelper";
@@ -203,6 +207,8 @@ export function activate(context: ExtensionContext) {
     ),
     tasks.registerTaskProvider(SAS_TASK_TYPE, new SasTaskProvider()),
     ...sasDiagnostic.getSubscriptions(),
+    registerAddCommentCommand(),
+    registerRemoveCommentCommand(),
   );
 
   // Reset first to set "No Active Profiles"

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,5 +1,6 @@
 {
   "comments": {
+    // "lineComment": "*", //Can only add a beginning..
     "blockComment": ["/*", "*/"]
   },
   "brackets": [

--- a/package.json
+++ b/package.json
@@ -780,6 +780,11 @@
         "command": "SAS.saveHTML",
         "title": "%commands.SAS.download%",
         "category": "SAS"
+      },
+      {
+        "command": "SAS.wrapLinesWithComment",
+        "title": "Wrap Each Selected Line with /* */",
+        "category": "SAS"
       }
     ],
     "keybindings": [
@@ -792,6 +797,16 @@
         "when": "editorLangId == sas && !SAS.hideRunMenuItem",
         "command": "SAS.runSelected",
         "key": "f3"
+      },
+      {
+        "key": "ctrl+/",
+        "command": "SAS.addBlockComment",
+        "when": "editorTextFocus && editorLangId == 'sas'"
+      },
+      {
+        "key": "ctrl+shift+/",
+        "command": "SAS.removeBlockComment",
+        "when": "editorTextFocus && editorLangId == 'sas'"
       }
     ],
     "menus": {


### PR DESCRIPTION
**Summary**
ctrl+/ changes single-line comments to apply /*【code】*/ to each line in the selection, ctrl+shift+/ can cancel it. The original block comment mode alt+shift+a is retained.

**Testing**

![sasext](https://github.com/user-attachments/assets/2d8cccb3-420e-418a-b088-7f068056bc6a)
