### PR TITLE
feat: be able to ignore region from format

### DIFF
--- a/client/testFixture/formatter/expected.sas
+++ b/client/testFixture/formatter/expected.sas
@@ -172,3 +172,13 @@ print('hello')
 endinteractive;
   /* comment */
 run;
+
+proc format library=library;
+/* region format-ignore */
+  invalue evaluation 'O'=4
+                     'S'=3
+                     'E'=2
+                     'C'=1
+                     'N'=0;
+/* endregion */
+run;

--- a/client/testFixture/formatter/unformatted.sas
+++ b/client/testFixture/formatter/unformatted.sas
@@ -166,3 +166,12 @@ print('hello')
 endinteractive;
 /* comment */
 run;
+proc format library=library;
+/* region format-ignore */
+  invalue evaluation 'O'=4
+                     'S'=3
+                     'E'=2
+                     'C'=1
+                     'N'=0;
+/* endregion */
+run;

--- a/server/src/sas/formatter/parser.ts
+++ b/server/src/sas/formatter/parser.ts
@@ -411,7 +411,7 @@ export const getParser =
         context.startStatement(node.text);
         if (
           context.currentStatement &&
-          context.region?.children.length === 0 &&
+          context.region?.children.length === 1 &&
           context.prevStatement?.children.length === 1 &&
           context.prevToken &&
           isComment(context.prevToken)

--- a/website/docs/Features/sasCodeEditing.md
+++ b/website/docs/Features/sasCodeEditing.md
@@ -94,6 +94,24 @@ To format your code, open context menu and select `Format Document`.
 
 ![formatter](/images/formatter.gif)
 
+:::tip
+
+You can define custom regions as below to exclude code from being formatted.
+
+```sas
+proc format library=library;
+/* region format-ignore */
+  invalue evaluation 'O'=4
+                     'S'=3
+                     'E'=2
+                     'C'=1
+                     'N'=0;
+/* endregion */
+run;
+```
+
+:::
+
 ## Function Signature Help
 
 Signature help provides information for current parameter as you are writing function calls.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -94,7 +94,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ["bash", "json"],
+      additionalLanguages: ["bash", "json", "sas"],
     },
   } satisfies Preset.ThemeConfig,
 


### PR DESCRIPTION
**Summary**
Resolves #1197

User can now add a custom region as below, which will be ignored by SAS code formatter.
```sas
proc format library=library;
/* region format-ignore */
  invalue evaluation 'O'=4
                     'S'=3
                     'E'=2
                     'C'=1
                     'N'=0;
/* endregion */
run;
```

Note that if your custom region intersect with other regions, the result may be unexpected.

**Testing**
See code within the custom region remain unchanged after performing "Format Document" command. Other code get formatted as expected.
