### PR TITLE
chore: Set default CSV save location to workspace root 

### DIFF
--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -6,15 +6,15 @@ import {
   ExtensionContext,
   Uri,
   commands,
+  env,
   window,
   workspace,
 } from "vscode";
 
 import { createWriteStream } from "fs";
-
 // fs data parsing imports
 // import * as fs from 'fs';
-import * as path from 'path';
+import * as path from "path";
 
 import { profileConfig } from "../../commands/profile";
 import { Column } from "../../connection/rest/api/compute";
@@ -74,11 +74,18 @@ class LibraryNavigator implements SubscriptionProvider {
         "SAS.downloadTable",
         async (item: LibraryItem) => {
           let dataFilePath: string = "";
-          if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+          if (
+            env.remoteName !== undefined &&
+            workspace.workspaceFolders &&
+            workspace.workspaceFolders.length > 0
+          ) {
             // start from 'rootPath' workspace folder
             dataFilePath = workspace.workspaceFolders[0].uri.fsPath;
           }
-          dataFilePath = path.join(dataFilePath, `${item.library}.${item.name}.csv`.toLocaleLowerCase());
+          dataFilePath = path.join(
+            dataFilePath,
+            `${item.library}.${item.name}.csv`.toLocaleLowerCase(),
+          );
 
           // display save file dialog
           const uri = await window.showSaveDialog({

--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -12,8 +12,6 @@ import {
 } from "vscode";
 
 import { createWriteStream } from "fs";
-// fs data parsing imports
-// import * as fs from 'fs';
 import * as path from "path";
 
 import { profileConfig } from "../../commands/profile";

--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -12,6 +12,10 @@ import {
 
 import { createWriteStream } from "fs";
 
+// fs data parsing imports
+// import * as fs from 'fs';
+import * as path from 'path';
+
 import { profileConfig } from "../../commands/profile";
 import { Column } from "../../connection/rest/api/compute";
 import DataViewer from "../../panels/DataViewer";
@@ -69,10 +73,16 @@ class LibraryNavigator implements SubscriptionProvider {
       commands.registerCommand(
         "SAS.downloadTable",
         async (item: LibraryItem) => {
+          let dataFilePath: string = "";
+          if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+            // start from 'rootPath' workspace folder
+            dataFilePath = workspace.workspaceFolders[0].uri.fsPath;
+          }
+          dataFilePath = path.join(dataFilePath, `${item.library}.${item.name}.csv`.toLocaleLowerCase());
+
+          // display save file dialog
           const uri = await window.showSaveDialog({
-            defaultUri: Uri.file(
-              `${item.library}.${item.name}.csv`.toLocaleLowerCase(),
-            ),
+            defaultUri: Uri.file(dataFilePath),
           });
 
           if (!uri) {


### PR DESCRIPTION
**Summary**
Set default CSV save location to workspace root as https://github.com/sassoftware/vscode-sas-extension/issues/952

**Testing**
How did you test this change?

Using ITC profile:
- local matchine + remote server: the save dialog starts from the the last used directory as before
- remote+SSH + remote server: the default diretory is the root of the workspace.