### PR TITLE
chore: remove nock dependency

### DIFF
--- a/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
@@ -65,8 +65,8 @@ describe("LibraryDataProvider", async function () {
     };
 
     const api = dataAccessApi();
-    sinon
-      .stub(api, "getTables")
+    const getTablesStub = sinon.stub(api, "getTables");
+    getTablesStub
       .withArgs({
         sessionId: "1234",
         libref: library.id,
@@ -96,12 +96,13 @@ describe("LibraryDataProvider", async function () {
       type: "table",
       readOnly: library.readOnly,
     });
+    getTablesStub.restore();
   });
 
   it("getChildren - returns libraries without content item", async () => {
     const api = dataAccessApi();
     // One call to get libraries
-    sinon.stub(api, "getLibraries").resolves({
+    const getLibrariesStub = sinon.stub(api, "getLibraries").resolves({
       data: {
         items: [
           {
@@ -114,11 +115,13 @@ describe("LibraryDataProvider", async function () {
     } as AxiosResponse);
 
     // One to get library summary
-    sinon.stub(api, "getLibrarySummary").resolves({
-      data: {
-        readOnly: true,
-      },
-    } as AxiosResponse);
+    const getLibrarySummaryStub = sinon
+      .stub(api, "getLibrarySummary")
+      .resolves({
+        data: {
+          readOnly: true,
+        },
+      } as AxiosResponse);
 
     const provider = libraryDataProvider(api);
     const children = await provider.getChildren();
@@ -131,6 +134,9 @@ describe("LibraryDataProvider", async function () {
       type: "library",
       readOnly: true,
     });
+
+    getLibrariesStub.restore();
+    getLibrarySummaryStub.restore();
   });
 
   it("getTreeItem - returns table tree item", async () => {
@@ -235,6 +241,7 @@ describe("LibraryDataProvider", async function () {
     const provider = libraryDataProvider(api);
     await provider.deleteTable(item);
     expect(deleteTableStub.calledOnce).to.equal(true);
+    deleteTableStub.restore();
   });
 
   it("deleteTable - fails with error message", async () => {
@@ -260,5 +267,7 @@ describe("LibraryDataProvider", async function () {
           .message,
       );
     }
+
+    deleteTableStub.restore();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "glob": "^7.2.0",
         "mocha": "^11.5.0",
-        "nock": "^13.5.5",
         "papaparse": "^5.5.3",
         "path-browserify": "^1.0.1",
         "prettier": "^3.5.3",
@@ -4594,12 +4593,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
@@ -4995,20 +4988,6 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nock": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
-      "integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      }
     },
     "node_modules/node-html-markdown": {
       "version": "1.3.0",
@@ -5450,15 +5429,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/proxyquire": {

--- a/package.json
+++ b/package.json
@@ -1412,7 +1412,6 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "glob": "^7.2.0",
     "mocha": "^11.5.0",
-    "nock": "^13.5.5",
     "papaparse": "^5.5.3",
     "path-browserify": "^1.0.1",
     "prettier": "^3.5.3",


### PR DESCRIPTION
**Summary**
Upgrading nock was leading to some strange errors around not being able to resolve the host. It looks like we were only using it for one test, where it makes enough sense to mock the compute api _instead_ of axios directly. 

**Testing**
 - [x] Made sure tests passed as expected
