### PR TITLE
feat(ContentNavigator): added more detailed path information

### DIFF
--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -213,6 +213,15 @@ class ContentDataProvider
   public async getTreeItem(item: ContentItem): Promise<TreeItem> {
     const isContainer = getIsContainer(item);
     const uri = await this.model.getUri(item, false);
+    let tooltip = item.name; // fallback to item name
+    try {
+      const fullPath = await this.model.getPathOfItem(item);
+      if (fullPath) {
+        tooltip = fullPath;
+      }
+    } catch {
+      // If getPathOfItem fails, tooltip will remain as item.name
+    }
 
     return {
       collapsibleState: isContainer
@@ -230,6 +239,7 @@ class ContentDataProvider
       id: item.uid,
       label: item.name,
       resourceUri: uri,
+      tooltip: tooltip,
     };
   }
 


### PR DESCRIPTION
 **Summary**

This change improves the user experience in the SAS Content Navigator by showing full hierarchical paths when hovering over files and folders, instead of just displaying the filename.

### Key Changes:
1. **Modified `ContentDataProvider.getTreeItem()`** to fetch and display full path information in tooltips
2. **Added fallback behavior** - if full path retrieval fails, tooltips gracefully degrade to showing just the item name

### Before:
- Hovering over a file showed: `/test1.sas`
### After:
- Hovering over a file shows: `/My Folder/Subfolder/test1.sas` 

---

## **Testing**
-Verified tooltips show full paths for files in nested folder structures