### PR TITLE
feat: allow users to define custom mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -510,6 +510,25 @@
             ],
             "description": "%configuration.SAS.results.html.style%"
           },
+          "SAS.results.html.styleMapping": {
+            "type": "object",
+            "default": {},
+            "description": "%configuration.SAS.results.html.styleMapping%",
+            "properties": {
+              "illuminate": {
+                "type": "string",
+                "description": "Style to use for illuminate theme"
+              },
+              "ignite": {
+                "type": "string",
+                "description": "Style to use for ignite theme"
+              },
+              "highContrast": {
+                "type": "string",
+                "description": "Style to use for high contrast theme"
+              }
+            }
+          },
           "SAS.problems.log.enabled": {
             "type": "boolean",
             "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -70,6 +70,7 @@
   "configuration.SAS.results.html.style": "Specifies the style for ODS HTML5 results.",
   "configuration.SAS.results.html.style.(auto)": "Let the extension pick a style that most closely matches the color theme.",
   "configuration.SAS.results.html.style.(server default)": "Default to the style configured on the SAS server.",
+  "configuration.SAS.results.html.styleMapping": "Map editor color themes to ODS HTML5 styles. Specify an object with properties like 'illuminate', 'ignite', and 'highContrast' to control which style is used for each theme.",
   "configuration.SAS.results.sideBySide": "Display results to the side of the code",
   "configuration.SAS.results.singlePanel": "Reuse single panel to display results",
   "configuration.SAS.userProvidedCertificates": "Provide trusted CA certificate files",


### PR DESCRIPTION
**Summary**
Allows users to use customized style when SAS.results.html.style is auto. for example to use customized ignite, user defines SAS.results.html.styleMapping in settings as an object like this:

"SAS.results.html.styleMapping": {
"ignite": "customizedIgnite"
}

customizedIgnite style should be defined before it is added to the settings. for example:

proc template;
define style styles.customizedIgnite;
parent = styles.ignite;
style body /
backgroundcolor = red;
end;
run;

in this case whenever 'SAS dark' (ignite) is selected as a theme, the customizedIgnite will be applied in each ODS html display.

Fix https://github.com/sassoftware/vscode-sas-extension/issues/1566
