### PR TITLE
fix(ContentNavigator): added name checking for duplicates on drag and drop

### DIFF
--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -681,21 +681,6 @@ class ContentDataProvider
     return !!newUri;
   }
 
-  private async checkIfItemExistsInTarget(
-    itemName: string,
-    target: ContentItem,
-  ): Promise<boolean> {
-    try {
-      const children = await this.getChildren(target);
-      return children.some((child) => child.name === itemName);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
-      // If we can't retrieve children, assume the item doesn't exist
-      // to avoid blocking the move operation unnecessarily
-      return false;
-    }
-  }
-
   private async handleContentItemDrop(
     target: ContentItem,
     item: ContentItem,
@@ -711,19 +696,10 @@ class ContentDataProvider
     } else if (target.type === FAVORITES_FOLDER_TYPE) {
       success = await this.addToMyFavorites(item);
     } else {
-      // Check if an item with the same name already exists in the target
-      const itemExists = await this.checkIfItemExistsInTarget(
-        item.name,
-        target,
-      );
-      if (itemExists) {
-        message = Messages.FileAlreadyExistsError;
-      } else {
-        const targetUri = target.resourceId ?? target.uri;
-        success = await this.moveItem(item, targetUri);
-        if (success) {
-          this.refresh();
-        }
+      const targetUri = target.resourceId ?? target.uri;
+      success = await this.moveItem(item, targetUri);
+      if (success) {
+        this.refresh();
       }
     }
 
@@ -742,20 +718,6 @@ class ContentDataProvider
     displayErrorMessages: boolean = true,
   ): Promise<boolean> {
     const folderName = basename(path);
-
-    // Check if a folder with the same name already exists in the target
-    const itemExists = await this.checkIfItemExistsInTarget(folderName, target);
-    if (itemExists) {
-      displayErrorMessages &&
-        window.showErrorMessage(
-          l10n.t(Messages.FileAlreadyExistsError, {
-            name: folderName,
-          }),
-        );
-
-      return false;
-    }
-
     const folder = await this.model.createFolder(target, folderName);
     let success = true;
     if (!folder) {
@@ -822,17 +784,6 @@ class ContentDataProvider
             this.refresh();
           }
 
-          return;
-        }
-
-        // Check if a file with the same name already exists in the target
-        const itemExists = await this.checkIfItemExistsInTarget(name, target);
-        if (itemExists) {
-          window.showErrorMessage(
-            l10n.t(Messages.FileAlreadyExistsError, {
-              name,
-            }),
-          );
           return;
         }
 

--- a/client/src/components/ContentNavigator/const.ts
+++ b/client/src/components/ContentNavigator/const.ts
@@ -79,9 +79,6 @@ export const Messages = {
   FileDragFromFavorites: l10n.t("Unable to drag files from my favorites."),
   FileDragFromTrashError: l10n.t("Unable to drag files from trash."),
   FileDropError: l10n.t('Unable to drop item "{name}".'),
-  FileAlreadyExistsError: l10n.t(
-    'A file or folder named "{name}" already exists in the target location.',
-  ),
   FileNavigationRootAdminError: l10n.t(
     "The files cannot be accessed from the path specified in the context definition for the SAS Compute Server. Contact your SAS administrator.",
   ),

--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -447,12 +447,17 @@ class RestServerAdapter implements ContentAdapter {
       },
     };
 
-    const response =
-      await this.fileSystemApi.updateFileOrDirectoryOnSystem(params);
-    delete this.fileMetadataMap[currentFilePath];
-    this.updateFileMetadata(newFilePath, response);
+    try {
+      const response =
+        await this.fileSystemApi.updateFileOrDirectoryOnSystem(params);
+      delete this.fileMetadataMap[currentFilePath];
+      this.updateFileMetadata(newFilePath, response);
 
-    return this.filePropertiesToContentItem(response.data).vscUri;
+      return this.filePropertiesToContentItem(response.data).vscUri;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      return;
+    }
   }
 
   public async renameItem(


### PR DESCRIPTION
**Summary:**

I implemented error handling for drag-and-drop file operations to the SAS Server by adding a try-catch block to RestServerAdapter.moveItem(). The Viya server's updateFileOrDirectoryOnSystem API already validates for duplicate file names by default and returns an error if a file with the same name exists at the destination. The try-catch properly catches these server errors and returns undefined, allowing the UI to display an error message to the user. This fix makes RestServerAdapter consistent with the error handling patterns in RestContentAdapter and ItcServerAdapter, and relies on server-side validation as the single source of truth rather than unreliable client-side checks.

**Testing:**
Made a new file with the same name as one within a folder on a SAS Server. Then, I dragged the root file into the folder and it prevented me from moving it. 

Fixes https://github.com/sassoftware/vscode-sas-extension/issues/1578

**TODOs:**
- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
