### PR TITLE
chore: only copy files once during build

### DIFF
--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -89,7 +89,7 @@ if (process.env.npm_config_webviews || process.env.npm_config_client) {
   await ctx.rebuild();
 
   if (dev) {
-    copyFiles();
+    process.env.npm_config_client && copyFiles();
     await ctx.watch();
   } else {
     await ctx.dispose();


### PR DESCRIPTION
**Summary:**
Currently the `copyFiles` function will be executed twice with webviews and client builds. And they run concurrently thus may cause disk failures.

**Testing:**
See build pass
