### PR TITLE
fix:  reopens files that were opened when dragging and dropping files or folders

### DIFF
--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -36,6 +36,7 @@ import { basename, join } from "path";
 import { promisify } from "util";
 
 import { profileConfig } from "../../commands/profile";
+import { SAS_FILE_SEPARATOR } from "../../connection/rest/RestServerAdapter";
 import { getResourceId } from "../../connection/rest/util";
 import { SubscriptionProvider } from "../SubscriptionProvider";
 import { ViyaProfile } from "../profile";
@@ -59,8 +60,6 @@ import {
   getFileStatement,
   isContainer as getIsContainer,
 } from "./utils";
-
-const SAS_FILE_SEPARATOR = "~fs~";
 
 class ContentDataProvider
   implements

--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -60,6 +60,8 @@ import {
   isContainer as getIsContainer,
 } from "./utils";
 
+const SAS_FILE_SEPARATOR = "~fs~";
+
 class ContentDataProvider
   implements
     TreeDataProvider<ContentItem>,
@@ -684,7 +686,7 @@ class ContentDataProvider
           newUri,
         );
         if (newFileUri) {
-          commands.executeCommand("vscode.open", newFileUri);
+          await commands.executeCommand("vscode.open", newFileUri);
         }
       }
     }
@@ -733,10 +735,12 @@ class ContentDataProvider
           );
           try {
             return decodeURIComponent(uriWithoutPrefix);
-          } catch {
+          } catch (error) {
+            console.error("Failed to decode URI component:", error);
             return uriWithoutPrefix;
           }
-        } catch {
+        } catch (error) {
+          console.error("Failed to extract path from URI:", error);
           return "";
         }
       };
@@ -748,7 +752,7 @@ class ContentDataProvider
       if (
         oldBasePath &&
         closedFilePath &&
-        closedFilePath.startsWith(oldBasePath + "~fs~")
+        closedFilePath.startsWith(oldBasePath + SAS_FILE_SEPARATOR)
       ) {
         try {
           const relativePath = closedFilePath.substring(oldBasePath.length);
@@ -767,9 +771,10 @@ class ContentDataProvider
           );
 
           return Uri.parse(
-            `sasServer:/${filename}?${encodeURIComponent(newQuery)}`,
+            `${newItemUri.scheme}:/${filename}?${encodeURIComponent(newQuery)}`,
           );
-        } catch {
+        } catch (error) {
+          console.error("Failed to construct new file URI:", error);
           return null;
         }
       }

--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -674,18 +674,17 @@ class ContentDataProvider
     }
 
     const newUri = await this.model.moveTo(item, targetUri);
-    if (Array.isArray(closedFiles) && closedFiles.length > 0) {
-      // Reopen only the files that were closed
-      for (const closedFileUri of closedFiles) {
-        // Calculate the new URI for each closed file using the adapter
-        if (typeof newUri === "object" && newUri) {
-          const newFileUri = this.model
-            .getAdapter()
-            .calculateNewFileUri?.(closedFileUri, item, newUri);
-          if (newFileUri) {
-            await commands.executeCommand("vscode.open", newFileUri);
-          }
-        }
+    if (!newUri || !Array.isArray(closedFiles)) {
+      return !!newUri;
+    }
+    // Reopen only the files that were closed
+    for (const closedFileUri of closedFiles) {
+      // Calculate the new URI for each closed file using the adapter
+      const newFileUri = this.model
+        .getAdapter()
+        .calculateNewFileUri?.(closedFileUri, item, newUri);
+      if (newFileUri) {
+        await commands.executeCommand("vscode.open", newFileUri);
       }
     }
 

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -169,7 +169,7 @@ export class ContentModel {
   public async moveTo(
     item: ContentItem,
     targetParentFolderUri: string,
-  ): Promise<boolean | Uri> {
+  ): Promise<Uri | undefined> {
     return await this.contentAdapter.moveItem(item, targetParentFolderUri);
   }
 

--- a/client/src/components/ContentNavigator/types.ts
+++ b/client/src/components/ContentNavigator/types.ts
@@ -94,6 +94,11 @@ export interface ContentAdapter {
     item: ContentItem,
     targetParentFolderUri: string,
   ) => Promise<Uri | undefined>;
+  calculateNewFileUri?: (
+    closedFileUri: Uri,
+    movedItem: ContentItem,
+    newItemUri: Uri,
+  ) => Uri | null;
   recycleItem?: (item: ContentItem) => Promise<{ newUri?: Uri; oldUri?: Uri }>;
   removeItemFromFavorites: (item: ContentItem) => Promise<boolean>;
   renameItem: (

--- a/client/src/components/ContentNavigator/types.ts
+++ b/client/src/components/ContentNavigator/types.ts
@@ -76,6 +76,11 @@ export interface ContentAdapter {
     fileName: string,
     buffer?: ArrayBufferLike,
   ) => Promise<ContentItem | undefined>;
+  calculateNewFileUri?: (
+    closedFileUri: Uri,
+    movedItem: ContentItem,
+    newItemUri: Uri,
+  ) => Uri | null;
   deleteItem: (item: ContentItem) => Promise<boolean>;
   getChildItems: (parentItem: ContentItem) => Promise<ContentItem[]>;
   getContentOfItem: (item: ContentItem) => Promise<string>;
@@ -94,11 +99,6 @@ export interface ContentAdapter {
     item: ContentItem,
     targetParentFolderUri: string,
   ) => Promise<Uri | undefined>;
-  calculateNewFileUri?: (
-    closedFileUri: Uri,
-    movedItem: ContentItem,
-    newItemUri: Uri,
-  ) => Uri | null;
   recycleItem?: (item: ContentItem) => Promise<{ newUri?: Uri; oldUri?: Uri }>;
   removeItemFromFavorites: (item: ContentItem) => Promise<boolean>;
   renameItem: (

--- a/client/src/connection/itc/ItcServerAdapter.ts
+++ b/client/src/connection/itc/ItcServerAdapter.ts
@@ -29,7 +29,11 @@ import { ProfileWithFileRootOptions } from "../../components/profile";
 import { getLink, getResourceId, getSasServerUri } from "../rest/util";
 import { executeRawCode } from "./CodeRunner";
 import { PowershellResponse, ScriptActions } from "./types";
-import { getDirectorySeparator } from "./util";
+import {
+  extractPathFromUri,
+  generateNewFilePath,
+  getDirectorySeparator,
+} from "./util";
 
 class ItcServerAdapter implements ContentAdapter {
   protected sessionId: string;
@@ -323,19 +327,6 @@ class ItcServerAdapter implements ContentAdapter {
 
     // If the moved item is a folder, calculate the new path for files within it
     if (isFolder && movedItem.vscUri) {
-      const extractPathFromUri = (uri: string): string => {
-        try {
-          const queryStart = uri.indexOf("?");
-          if (queryStart === -1) {
-            return uri;
-          }
-          return uri.substring(0, queryStart);
-        } catch (error) {
-          console.error("Failed to extract path from URI:", error);
-          return "";
-        }
-      };
-
       const oldBasePath = extractPathFromUri(movedItem.vscUri.toString());
       const closedFilePath = extractPathFromUri(closedFileUri.toString());
 
@@ -348,31 +339,12 @@ class ItcServerAdapter implements ContentAdapter {
           closedFilePath === oldBasePath);
 
       if (isChildFile && oldBasePath !== closedFilePath) {
-        try {
-          const relativePath = closedFilePath.substring(oldBasePath.length);
-          const newUriStr = newItemUri.toString();
-
-          // Extract the path without query parameters
-          const queryStart = newUriStr.indexOf("?");
-          const newPath =
-            queryStart === -1 ? newUriStr : newUriStr.substring(0, queryStart);
-
-          // Combine new path with relative path
-          const newFilePath = newPath.endsWith(dirSeparator)
-            ? newPath + relativePath.substring(1)
-            : newPath + relativePath;
-
-          // Reconstruct URI with query parameters if present
-          if (queryStart !== -1) {
-            const queryString = newUriStr.substring(queryStart);
-            return Uri.parse(newFilePath + queryString);
-          }
-
-          return Uri.parse(newFilePath);
-        } catch (error) {
-          console.error("Failed to construct new file URI:", error);
-          return null;
-        }
+        return generateNewFilePath(
+          oldBasePath,
+          closedFilePath,
+          newItemUri,
+          dirSeparator,
+        );
       }
     }
 

--- a/client/src/connection/itc/util.ts
+++ b/client/src/connection/itc/util.ts
@@ -1,5 +1,6 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { Uri } from "vscode";
 
 export const decodeEntities = (msg: string): string => {
   // Some of our messages from the server contain html encoded
@@ -18,5 +19,51 @@ export const decodeEntities = (msg: string): string => {
 export const escapePowershellString = (unescapedString: string): string =>
   unescapedString.replace(/(`|"|'|\$|\(|\)|%|{|}|\[|\])/g, "`$1");
 
+export const extractPathFromUri = (uri: string): string => {
+  try {
+    const queryStart = uri.indexOf("?");
+    if (queryStart === -1) {
+      return uri;
+    }
+    return uri.substring(0, queryStart);
+  } catch (error) {
+    console.error("Failed to extract path from URI:", error);
+    return "";
+  }
+};
+
 export const getDirectorySeparator = (path: string): string =>
   path.lastIndexOf("/") !== -1 ? "/" : "\\";
+
+export const generateNewFilePath = (
+  oldBasePath: string,
+  closedFilePath: string,
+  newItemUri: Uri,
+  dirSeparator: string,
+): Uri | null => {
+  try {
+    const relativePath = closedFilePath.substring(oldBasePath.length);
+    const newUriStr = newItemUri.toString();
+
+    // Extract the path without query parameters
+    const queryStart = newUriStr.indexOf("?");
+    const newPath =
+      queryStart === -1 ? newUriStr : newUriStr.substring(0, queryStart);
+
+    // Combine new path with relative path
+    const newFilePath = newPath.endsWith(dirSeparator)
+      ? newPath + relativePath.substring(1)
+      : newPath + relativePath;
+
+    // Reconstruct URI with query parameters if present
+    if (queryStart !== -1) {
+      const queryString = newUriStr.substring(queryStart);
+      return Uri.parse(newFilePath + queryString);
+    }
+
+    return Uri.parse(newFilePath);
+  } catch (error) {
+    console.error("Failed to construct new file URI:", error);
+    return null;
+  }
+};

--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -39,7 +39,7 @@ import {
 } from "./util";
 
 export const SAS_SERVER_HOME_DIRECTORY = "SAS_SERVER_HOME_DIRECTORY";
-const SAS_FILE_SEPARATOR = "~fs~";
+export const SAS_FILE_SEPARATOR = "~fs~";
 
 class RestServerAdapter implements ContentAdapter {
   protected baseUrl: string;

--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -39,7 +39,7 @@ import {
 } from "./util";
 
 export const SAS_SERVER_HOME_DIRECTORY = "SAS_SERVER_HOME_DIRECTORY";
-export const SAS_FILE_SEPARATOR = "~fs~";
+const SAS_FILE_SEPARATOR = "~fs~";
 
 class RestServerAdapter implements ContentAdapter {
   protected baseUrl: string;
@@ -458,6 +458,97 @@ class RestServerAdapter implements ContentAdapter {
     } catch (error) {
       return;
     }
+  }
+
+  public calculateNewFileUri(
+    closedFileUri: Uri,
+    movedItem: ContentItem,
+    newItemUri: Uri,
+  ): Uri | null {
+    const isFolder = movedItem.fileStat?.type === FileType.Directory;
+
+    // If the moved item is a file and matches the closed file, return the new URI
+    if (
+      !isFolder &&
+      closedFileUri.toString() === movedItem.vscUri?.toString()
+    ) {
+      return newItemUri;
+    }
+
+    // If the moved item is a folder, calculate the new path for files within it
+    if (isFolder && movedItem.vscUri) {
+      const extractPathFromUri = (uri: string): string => {
+        try {
+          const queryStart = uri.indexOf("?");
+          if (queryStart === -1) {
+            return "";
+          }
+
+          const queryString = uri.substring(queryStart + 1);
+          const decodedQuery = decodeURIComponent(queryString);
+          const idMatch = decodedQuery.match(/id=(.+)/);
+          if (!idMatch || !idMatch[1]) {
+            return "";
+          }
+
+          // Extract the file path from the REST server URI format
+          // Removes the compute session prefix to get the actual file path
+          const uriWithoutPrefix = idMatch[1].replace(
+            /\/compute\/sessions\/[a-zA-Z0-9-]*\/files\//,
+            "",
+          );
+          try {
+            return decodeURIComponent(uriWithoutPrefix);
+          } catch (error) {
+            console.error("Failed to decode URI component:", error);
+            return uriWithoutPrefix;
+          }
+        } catch (error) {
+          console.error("Failed to extract path from URI:", error);
+          return "";
+        }
+      };
+
+      const oldBasePath = extractPathFromUri(movedItem.vscUri.toString());
+      const closedFilePath = extractPathFromUri(closedFileUri.toString());
+
+      // Check if the closed file was inside the moved folder
+      // Match if: closedFilePath starts with oldBasePath followed by separator
+      const isChildFile =
+        oldBasePath &&
+        closedFilePath &&
+        (closedFilePath.startsWith(oldBasePath + SAS_FILE_SEPARATOR) ||
+          closedFilePath === oldBasePath);
+
+      if (isChildFile && oldBasePath !== closedFilePath) {
+        try {
+          const relativePath = closedFilePath.substring(oldBasePath.length);
+          const filename = relativePath.replace(/^~fs~/, "");
+          const newUriStr = newItemUri.toString();
+
+          // Extract and modify the query to append the filename path
+          const queryMatch = newUriStr.match(/\?(.+)$/);
+          if (!queryMatch) {
+            return null;
+          }
+
+          const decodedQuery = decodeURIComponent(queryMatch[1]);
+          const newQuery = decodedQuery.replace(
+            /(\/files\/[^&]*)/,
+            `$1~fs~${filename}`,
+          );
+
+          return Uri.parse(
+            `${newItemUri.scheme}:/${filename}?${encodeURIComponent(newQuery)}`,
+          );
+        } catch (error) {
+          console.error("Failed to construct new file URI:", error);
+          return null;
+        }
+      }
+    }
+
+    return null;
   }
 
   public async renameItem(

--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -32,6 +32,8 @@ import { ProfileWithFileRootOptions } from "../../components/profile";
 import { FileProperties, FileSystemApi } from "./api/compute";
 import { getApiConfig } from "./common";
 import {
+  extractPathFromUri,
+  generateNewFilePath,
   getLink,
   getResourceId,
   getResourceIdFromItem,
@@ -477,38 +479,6 @@ class RestServerAdapter implements ContentAdapter {
 
     // If the moved item is a folder, calculate the new path for files within it
     if (isFolder && movedItem.vscUri) {
-      const extractPathFromUri = (uri: string): string => {
-        try {
-          const queryStart = uri.indexOf("?");
-          if (queryStart === -1) {
-            return "";
-          }
-
-          const queryString = uri.substring(queryStart + 1);
-          const decodedQuery = decodeURIComponent(queryString);
-          const idMatch = decodedQuery.match(/id=(.+)/);
-          if (!idMatch || !idMatch[1]) {
-            return "";
-          }
-
-          // Extract the file path from the REST server URI format
-          // Removes the compute session prefix to get the actual file path
-          const uriWithoutPrefix = idMatch[1].replace(
-            /\/compute\/sessions\/[a-zA-Z0-9-]*\/files\//,
-            "",
-          );
-          try {
-            return decodeURIComponent(uriWithoutPrefix);
-          } catch (error) {
-            console.error("Failed to decode URI component:", error);
-            return uriWithoutPrefix;
-          }
-        } catch (error) {
-          console.error("Failed to extract path from URI:", error);
-          return "";
-        }
-      };
-
       const oldBasePath = extractPathFromUri(movedItem.vscUri.toString());
       const closedFilePath = extractPathFromUri(closedFileUri.toString());
 
@@ -521,30 +491,7 @@ class RestServerAdapter implements ContentAdapter {
           closedFilePath === oldBasePath);
 
       if (isChildFile && oldBasePath !== closedFilePath) {
-        try {
-          const relativePath = closedFilePath.substring(oldBasePath.length);
-          const filename = relativePath.replace(/^~fs~/, "");
-          const newUriStr = newItemUri.toString();
-
-          // Extract and modify the query to append the filename path
-          const queryMatch = newUriStr.match(/\?(.+)$/);
-          if (!queryMatch) {
-            return null;
-          }
-
-          const decodedQuery = decodeURIComponent(queryMatch[1]);
-          const newQuery = decodedQuery.replace(
-            /(\/files\/[^&]*)/,
-            `$1~fs~${filename}`,
-          );
-
-          return Uri.parse(
-            `${newItemUri.scheme}:/${filename}?${encodeURIComponent(newQuery)}`,
-          );
-        } catch (error) {
-          console.error("Failed to construct new file URI:", error);
-          return null;
-        }
+        return generateNewFilePath(oldBasePath, closedFilePath, newItemUri);
       }
     }
 

--- a/client/src/connection/rest/util.ts
+++ b/client/src/connection/rest/util.ts
@@ -89,3 +89,66 @@ export const getItemContentType = (item: ContentItem): string | undefined => {
 };
 
 export const getResourceId = (uri: Uri): string => uri.query.substring(3); // ?id=...
+
+export const extractPathFromUri = (uri: string): string => {
+  try {
+    const queryStart = uri.indexOf("?");
+    if (queryStart === -1) {
+      return "";
+    }
+
+    const queryString = uri.substring(queryStart + 1);
+    const decodedQuery = decodeURIComponent(queryString);
+    const idMatch = decodedQuery.match(/id=(.+)/);
+    if (!idMatch || !idMatch[1]) {
+      return "";
+    }
+
+    // Extract the file path from the REST server URI format
+    // Removes the compute session prefix to get the actual file path
+    const uriWithoutPrefix = idMatch[1].replace(
+      /\/compute\/sessions\/[a-zA-Z0-9-]*\/files\//,
+      "",
+    );
+    try {
+      return decodeURIComponent(uriWithoutPrefix);
+    } catch (error) {
+      console.error("Failed to decode URI component:", error);
+      return uriWithoutPrefix;
+    }
+  } catch (error) {
+    console.error("Failed to extract path from URI:", error);
+    return "";
+  }
+};
+
+export const generateNewFilePath = (
+  oldBasePath: string,
+  closedFilePath: string,
+  newItemUri: Uri,
+): Uri | null => {
+  try {
+    const relativePath = closedFilePath.substring(oldBasePath.length);
+    const filename = relativePath.replace(/^~fs~/, "");
+    const newUriStr = newItemUri.toString();
+
+    // Extract and modify the query to append the filename path
+    const queryMatch = newUriStr.match(/\?(.+)$/);
+    if (!queryMatch) {
+      return null;
+    }
+
+    const decodedQuery = decodeURIComponent(queryMatch[1]);
+    const newQuery = decodedQuery.replace(
+      /(\/files\/[^&]*)/,
+      `$1~fs~${filename}`,
+    );
+
+    return Uri.parse(
+      `${newItemUri.scheme}:/${filename}?${encodeURIComponent(newQuery)}`,
+    );
+  } catch (error) {
+    console.error("Failed to construct new file URI:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
**Summary:**

1. it opens previously opened files when dragging and dropping a file or a folder.
2. it prevents VSCode from opening a folder as a file when moving a folder  from one folder to another folder. it  instead opens the file that was opened in that folder

**Testing:**
 verified it opens previously opened files instead of opening a folder as a file.
 
 Fixes https://github.com/sassoftware/vscode-sas-extension/issues/1478

