### PR TITLE
fix: delete multiple tables from lib pane

### DIFF
--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -18,6 +18,7 @@ import {
 import { profileConfig } from "../../commands/profile";
 import { SubscriptionProvider } from "../SubscriptionProvider";
 import { ConnectionType, ProfileWithFileRootOptions } from "../profile";
+import { treeViewSelections } from "../utils/treeViewSelections";
 import ContentAdapterFactory from "./ContentAdapterFactory";
 import ContentDataProvider from "./ContentDataProvider";
 import { ContentModel } from "./ContentModel";
@@ -101,7 +102,7 @@ class ContentNavigator implements SubscriptionProvider {
       commands.registerCommand(
         `${SAS}.deleteResource`,
         async (item: ContentItem) => {
-          this.treeViewSelections(item).forEach(
+          this.getTreeViewSelections(item).forEach(
             async (resource: ContentItem) => {
               if (!resource.contextValue.includes("delete")) {
                 return;
@@ -154,7 +155,7 @@ class ContentNavigator implements SubscriptionProvider {
       commands.registerCommand(
         `${SAS}.restoreResource`,
         async (item: ContentItem) => {
-          this.treeViewSelections(item).forEach(
+          this.getTreeViewSelections(item).forEach(
             async (resource: ContentItem) => {
               const isContainer = getIsContainer(resource);
               if (!(await this.contentDataProvider.restoreResource(resource))) {
@@ -276,7 +277,7 @@ class ContentNavigator implements SubscriptionProvider {
       commands.registerCommand(
         `${SAS}.addToFavorites`,
         async (item: ContentItem) => {
-          this.treeViewSelections(item).forEach(
+          this.getTreeViewSelections(item).forEach(
             async (resource: ContentItem) => {
               if (
                 !(await this.contentDataProvider.addToMyFavorites(resource))
@@ -290,7 +291,7 @@ class ContentNavigator implements SubscriptionProvider {
       commands.registerCommand(
         `${SAS}.removeFromFavorites`,
         async (item: ContentItem) => {
-          this.treeViewSelections(item).forEach(
+          this.getTreeViewSelections(item).forEach(
             async (resource: ContentItem) => {
               if (
                 !(await this.contentDataProvider.removeFromMyFavorites(
@@ -369,7 +370,7 @@ class ContentNavigator implements SubscriptionProvider {
       commands.registerCommand(
         `${SAS}.downloadResource`,
         async (resource: ContentItem) => {
-          const selections = this.treeViewSelections(resource);
+          const selections = this.getTreeViewSelections(resource);
           const uris = await window.showOpenDialog({
             title: l10n.t("Choose where to save your files."),
             openLabel: l10n.t("Save"),
@@ -492,11 +493,8 @@ class ContentNavigator implements SubscriptionProvider {
       : "";
   }
 
-  private treeViewSelections(item: ContentItem): ContentItem[] {
-    const items =
-      this.contentDataProvider.treeView.selection.length > 1 || !item
-        ? this.contentDataProvider.treeView.selection
-        : [item];
+  private getTreeViewSelections(item: ContentItem): ContentItem[] {
+    const items = treeViewSelections(this.contentDataProvider.treeView, item);
 
     const uris: string[] = items.map(({ uri }: ContentItem) => uri);
 

--- a/client/src/components/LibraryNavigator/LibraryDataProvider.ts
+++ b/client/src/components/LibraryNavigator/LibraryDataProvider.ts
@@ -169,11 +169,6 @@ class LibraryDataProvider
     return this.model.writeTableContentsToStream(stream, item);
   }
 
-  public async deleteTable(item: LibraryItem): Promise<void> {
-    await this.model.deleteTable(item);
-    this._onDidChangeTreeData.fire(undefined);
-  }
-
   public async deleteTables(items: LibraryItem[]): Promise<void> {
     await this.model.deleteTables(items);
     this._onDidChangeTreeData.fire(undefined);

--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -121,17 +121,6 @@ class LibraryModel {
     return items;
   }
 
-  public async deleteTable(item: LibraryItem) {
-    try {
-      await this.libraryAdapter.deleteTable(item);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
-      throw new Error(
-        l10n.t(Messages.TableDeletionError, { tableName: item.uid }),
-      );
-    }
-  }
-
   public async deleteTables(items: LibraryItem[]) {
     const failures: string[] = [];
 

--- a/client/src/components/LibraryNavigator/const.ts
+++ b/client/src/components/LibraryNavigator/const.ts
@@ -5,7 +5,7 @@ import { l10n } from "vscode";
 export const Messages = {
   TableDeletionError: l10n.t("Unable to delete table {tableName}."),
   TablesDeletionWarning: l10n.t(
-    "Are you sure you want to delete {count} table(s): {tableNames}?",
+    "Are you sure you want to delete the selected tables?",
   ),
   ViewTableCommandTitle: l10n.t("View SAS Table"),
 };

--- a/client/src/components/utils/treeViewSelections.ts
+++ b/client/src/components/utils/treeViewSelections.ts
@@ -1,0 +1,23 @@
+// Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { TreeView } from "vscode";
+
+/**
+ * Gets the selected items from a tree view based on the current selection state.
+ *
+ * If multiple items are selected in the tree view, returns those selections.
+ * If no item is passed or no selections exist, returns the tree view's selection.
+ * Otherwise, returns the single clicked item.
+ *
+ * @param treeView - The VS Code TreeView instance
+ * @param item - The item that was clicked/activated
+ * @returns An array of selected items
+ */
+export function treeViewSelections<T>(
+  treeView: TreeView<T>,
+  item: T | undefined,
+): T[] {
+  return treeView.selection.length > 1 || !item
+    ? [...treeView.selection]
+    : [item];
+}

--- a/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryDataProvider.test.ts
@@ -225,34 +225,38 @@ describe("LibraryDataProvider", async function () {
     expect(treeItem.command === undefined).to.equal(true);
   });
 
-  it("deleteTable - deletes a table successfully", async () => {
-    const item: LibraryItem = {
-      uid: "test",
-      id: "test",
-      name: "test",
-      type: "table",
-      readOnly: false,
-      library: "lib",
-    };
+  it("deleteTables - deletes a single table successfully", async () => {
+    const items: LibraryItem[] = [
+      {
+        uid: "test",
+        id: "test",
+        name: "test",
+        type: "table",
+        readOnly: false,
+        library: "lib",
+      },
+    ];
 
     const api = dataAccessApi();
     const deleteTableStub = sinon.stub(api, "deleteTable");
 
     const provider = libraryDataProvider(api);
-    await provider.deleteTable(item);
+    await provider.deleteTables(items);
     expect(deleteTableStub.calledOnce).to.equal(true);
     deleteTableStub.restore();
   });
 
-  it("deleteTable - fails with error message", async () => {
-    const item: LibraryItem = {
-      uid: "test",
-      id: "test",
-      name: "test",
-      type: "table",
-      readOnly: false,
-      library: "lib",
-    };
+  it("deleteTables - fails with error message for single table", async () => {
+    const items: LibraryItem[] = [
+      {
+        uid: "test",
+        id: "test",
+        name: "test",
+        type: "table",
+        readOnly: false,
+        library: "lib",
+      },
+    ];
 
     const api = dataAccessApi();
     const deleteTableStub = sinon.stub(api, "deleteTable");
@@ -260,7 +264,7 @@ describe("LibraryDataProvider", async function () {
 
     const provider = libraryDataProvider(api);
     try {
-      await provider.deleteTable(item);
+      await provider.deleteTables(items);
     } catch (error) {
       expect(error.message).to.equal(
         new Error(l10n.t(Messages.TableDeletionError, { tableName: "test" }))


### PR DESCRIPTION
**Summary:**
Enhanced the delete functionality to support multiple table selection with a confirmation dialog that lists all selected tables. Once the user confirms, the tables are deleted. Single table deletion proceeds without a confirmation dialog.

**Testing:**
1) deleteTables - deletes multiple tables successfully
-Tests successful deletion of 2 tables
-Verifies API is called correct number of times

2) deleteTables - reports failures when some tables fail to delete
-Tests partial failure scenario (3 tables: succeed, fail, succeed)
-Verifies error message contains only failed table names
-Confirms all deletion attempts were made

Fixes: [#1216](https://github.com/sassoftware/vscode-sas-extension/issues/1216)
