### PR TITLE
Update package.json to enable the plugin for .py and .sql files

### DIFF
--- a/package.json
+++ b/package.json
@@ -877,12 +877,12 @@
     ],
     "keybindings": [
       {
-        "when": "editorFocus && editorLangId == sas && !SAS.hideRunMenuItem",
+        "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && editorFocus && !SAS.hideRunMenuItem",
         "command": "SAS.run",
         "key": "f8"
       },
       {
-        "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+        "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && editorFocus && !SAS.hideRunMenuItem",
         "command": "SAS.runSelected",
         "key": "f3"
       },
@@ -1108,23 +1108,23 @@
       ],
       "editor/title/run": [
         {
-          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && !SAS.hideRunMenuItem",
           "command": "SAS.runSelected"
         }
       ],
       "editor/context": [
         {
-          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && !SAS.hideRunMenuItem",
           "command": "SAS.run",
           "group": "navigation@2"
         },
         {
-          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && !SAS.hideRunMenuItem",
           "command": "SAS.runSelected",
           "group": "navigation@1"
         },
         {
-          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && !SAS.hideRunMenuItem",
           "command": "SAS.runRegion",
           "group": "navigation@3"
         }
@@ -1143,15 +1143,15 @@
       ],
       "commandPalette": [
         {
-          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && !SAS.hideRunMenuItem",
           "command": "SAS.run"
         },
         {
-          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && !SAS.hideRunMenuItem",
           "command": "SAS.runSelected"
         },
         {
-          "when": "editorLangId == sas && !SAS.hideRunMenuItem",
+          "when": "(editorLangId == sas || editorLangId == python || editorLangId == sql) && !SAS.hideRunMenuItem",
           "command": "SAS.runRegion"
         },
         {


### PR DESCRIPTION
feat(editor): enable proc python/sql execution in .py/.sql; expose Run UI + hotkeys Previously, wrapping and execution for `proc python` and `proc sql` were only enabled in `.sasnb` notebooks. This change extends that functionality to the regular code editor for `.sas`, `.py`, and `.sql` files.

UI & commands
- Show the SAS “Running man” Run button in Python/SQL editors
- Enable F8 → `SAS.run` and F3 → `SAS.runSelected`

- Expose `SAS.run`, `SAS.runRegion`, and `SAS.runSelected` in:
  - editor context menu
  - command palette

Keybinding & menu conditions
- Broaden `when` clauses to `(editorLangId == sas || python || sql)`
- Require `editorFocus` for both F8 and F3 bindings
- Continue to respect `!SAS.hideRunMenuItem` so shortcuts/menus are hidden when the Run item is disabled

User impact
- Unified run experience across SAS notebooks and code files
- Improved discoverability and consistency for running code blocks and selections
- Same user experiance when exectuing python code as in SAS Studio

No breaking changes; behavior is scoped to Python/SQL editors and guarded by existing visibility flags.

**Summary:**
Enables the plugin for .py and .sql files

**Testing:**
Tested hot keys, command pallets from my local VS Code with .sql & .py files, 
If use has a local python env the "running man" icon is overwritten by the python "play" button, the run SAS command is acceible using the drop down next to the "play" button, hot keys and command pallet.

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
