### PR TITLE
show missing value as '.' instead of null

### DIFF
--- a/client/src/connection/rest/RestLibraryAdapter.ts
+++ b/client/src/connection/rest/RestLibraryAdapter.ts
@@ -66,6 +66,7 @@ class RestLibraryAdapter implements LibraryAdapter {
             includeIndex: true,
             start,
             limit,
+            formatMissingValues: true,
           },
           requestOptions,
         ),


### PR DESCRIPTION
**Summary:**
When making the request for rows, we weren't requesting missing values to be formatted, so instead they were being returned as (null). Adding in the right request parameter returns the expected missing '.' value instead.

**Testing:**
- [x] Made sure empty values displayed in the table viewer as '.' instead of empty values 
