### PR TITLE
chore: update webviews to retain context when hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add the ability to pin columns ([#1781](https://github.com/sassoftware/vscode-sas-extension/pull/1781))
 - Allow running R code files in SAS Content ([#1845](https://github.com/sassoftware/vscode-sas-extension/pull/1845))
 
+### Fixed
+
+- Fix issue affecting data viewer scroll position ([#1800](https://github.com/sassoftware/vscode-sas-extension/pull/1800))
+
 ## [1.19.1] - 2026-04-01
 
 ### Fixed

--- a/client/src/panels/DataViewer.ts
+++ b/client/src/panels/DataViewer.ts
@@ -2,20 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Uri, l10n, window } from "vscode";
 
-import type { ColumnState, SortModelItem } from "ag-grid-community";
+import type { SortModelItem } from "ag-grid-community";
 
 import PaginatedResultSet from "../components/LibraryNavigator/PaginatedResultSet";
 import { TableData, TableQuery } from "../components/LibraryNavigator/types";
 import { Column } from "../connection/rest/api/compute";
 import { WebView } from "./WebviewManager";
 
-export type ViewProperties = {
-  columnState?: ColumnState[];
-  query?: TableQuery;
-};
-
 class DataViewer extends WebView {
-  protected viewProperties: ViewProperties = {};
   public constructor(
     extensionUri: Uri,
     uid: string,
@@ -82,7 +76,6 @@ class DataViewer extends WebView {
         end?: number;
         sortModel?: SortModelItem[];
         columnName?: string;
-        viewProperties?: Partial<ViewProperties>;
         query: TableQuery | undefined;
       };
     },
@@ -111,21 +104,12 @@ class DataViewer extends WebView {
           command: "response:loadColumns",
           data: {
             columns: await this.fetchColumns(),
-            viewProperties: this.viewProperties,
           },
         });
         break;
       case "request:loadColumnProperties":
         if (event.data.columnName) {
           this.loadColumnProperties(event.data.columnName);
-        }
-        break;
-      case "request:storeViewProperties":
-        if (event.data.viewProperties) {
-          this.viewProperties = {
-            ...this.viewProperties,
-            ...event.data.viewProperties,
-          };
         }
         break;
       default:

--- a/client/src/panels/WebviewManager.ts
+++ b/client/src/panels/WebviewManager.ts
@@ -18,6 +18,7 @@ export class WebViewManager {
 
     const panel = window.createWebviewPanel("webView", uid, ViewColumn.One, {
       enableScripts: true,
+      retainContextWhenHidden: true,
     });
 
     webview.onDispose = () => delete this.panels[uid];

--- a/client/src/panels/WebviewManager.ts
+++ b/client/src/panels/WebviewManager.ts
@@ -97,6 +97,12 @@ export abstract class WebView {
     this.panel = webviewPanel;
     this.panel.onDidDispose(() => this.dispose(), null, this._disposables);
     this.panel.webview.onDidReceiveMessage(this.processMessage.bind(this));
+    this.panel.onDidChangeViewState((e) =>
+      this.panel.webview.postMessage({
+        command: "panel:changeFocus",
+        data: { focused: e.webviewPanel.active },
+      }),
+    );
 
     return this;
   }

--- a/client/src/webview/DataViewer.tsx
+++ b/client/src/webview/DataViewer.tsx
@@ -35,7 +35,6 @@ const DataViewer = () => {
     gridRef,
     onGridReady,
     refreshResults,
-    viewProperties,
   } = useDataViewer();
 
   const handleKeydown = useCallback(
@@ -71,7 +70,7 @@ const DataViewer = () => {
         onCommit={(value) => {
           refreshResults({ filterValue: value });
         }}
-        initialValue={viewProperties()?.query?.filterValue ?? ""}
+        initialValue={""}
       />
       {columnMenu && <ColumnMenu {...columnMenu} />}
       <div

--- a/client/src/webview/DataViewer.tsx
+++ b/client/src/webview/DataViewer.tsx
@@ -50,14 +50,30 @@ const DataViewer = () => {
     [dismissMenu],
   );
 
+  const focusChanged = useCallback(
+    (event: MessageEvent) => {
+      if (
+        event.data.command === "panel:changeFocus" &&
+        event.data.data.focused
+      ) {
+        const cell = gridRef.current?.api.getFocusedCell();
+        if (cell) {
+          gridRef.current?.api.setFocusedCell(cell.rowIndex, cell.column);
+        }
+      }
+    },
+    [gridRef],
+  );
   useEffect(() => {
     document.addEventListener("keydown", handleKeydown);
     window.addEventListener("blur", dismissMenuWithoutFocus);
+    window.addEventListener("message", focusChanged);
     return () => {
       document.removeEventListener("keydown", handleKeydown);
       window.removeEventListener("blur", dismissMenuWithoutFocus);
+      window.removeEventListener("message", focusChanged);
     };
-  }, [handleKeydown, dismissMenuWithoutFocus]);
+  }, [handleKeydown, dismissMenuWithoutFocus, focusChanged]);
 
   if (columns.length === 0) {
     return null;

--- a/client/src/webview/useDataViewer.ts
+++ b/client/src/webview/useDataViewer.ts
@@ -22,7 +22,6 @@ import type {
   TableQuery,
 } from "../components/LibraryNavigator/types";
 import { Column } from "../connection/rest/api/compute";
-import type { ViewProperties } from "../panels/DataViewer";
 import ColumnHeader from "./ColumnHeader";
 import { ColumnMenuProps, getColumnMenu } from "./ColumnMenu";
 import localize from "./localize";
@@ -92,7 +91,6 @@ const clearFetchColumnsTimeout = () =>
   fetchColumnsTimeoutId && clearTimeout(fetchColumnsTimeoutId);
 const fetchColumns = (): Promise<{
   columns: Column[];
-  viewProperties?: ViewProperties;
 }> => {
   const requestKey = v4();
   vscode.postMessage({ command: "request:loadColumns", key: requestKey });

--- a/client/src/webview/useDataViewer.ts
+++ b/client/src/webview/useDataViewer.ts
@@ -39,7 +39,6 @@ const contextMenuHandler = (e) => {
 export const applyColumnState = (api: GridApi, state: ColumnState[]) => {
   api.applyColumnState({ state, defaultState: { sort: null } });
   api.ensureIndexVisible(0);
-  storeViewProperties({ columnState: state });
 };
 
 const defaultTimeout = 60 * 1000; // 60 seconds (accounting for compute session expiration)
@@ -121,12 +120,6 @@ const fetchColumns = (): Promise<{
   });
 };
 
-export const storeViewProperties = (viewProperties: ViewProperties) =>
-  vscode.postMessage({
-    command: "request:storeViewProperties",
-    data: { viewProperties },
-  });
-
 const useDataViewer = () => {
   const gridRef = useRef<AgGridReact>(null);
   const [columns, setColumns] = useState<ColDef[]>([]);
@@ -136,12 +129,9 @@ const useDataViewer = () => {
   );
   const setQueryParams = (query: TableQuery | undefined) => {
     setQueryParamsState(query);
-    storeViewProperties({ query });
   };
 
   const columnMenuRef = useRef<ColumnMenuProps | undefined>(columnMenu);
-  const columnStateRef = useRef<ColumnState[] | undefined>(undefined);
-  const loadedViewPropertiesRef = useRef<ViewProperties | undefined>(undefined);
   useEffect(() => {
     columnMenuRef.current = columnMenu;
   }, [columnMenu]);
@@ -189,21 +179,7 @@ const useDataViewer = () => {
 
   const onGridReady = useCallback(
     (event: GridReadyEvent) => {
-      const { columnState, query } = loadedViewPropertiesRef.current;
-      event.api.setGridOption("datasource", dataSource(query));
-
-      // Re-hydrate our view with persisted view properties
-      if (!loadedViewPropertiesRef.current) {
-        return;
-      }
-      if (query) {
-        setQueryParams(query);
-      }
-      if (columnState && columnState.length > 0) {
-        applyColumnState(event.api, columnState);
-        event.api.refreshHeader();
-        columnStateRef.current = undefined;
-      }
+      event.api.setGridOption("datasource", dataSource());
     },
     [dataSource],
   );
@@ -252,12 +228,7 @@ const useDataViewer = () => {
       return;
     }
 
-    fetchColumns().then(({ columns: columnsData, viewProperties }) => {
-      if (viewProperties.columnState && viewProperties.columnState.length > 0) {
-        columnStateRef.current = viewProperties.columnState;
-      }
-      loadedViewPropertiesRef.current = viewProperties;
-
+    fetchColumns().then(({ columns: columnsData }) => {
       const columns: ColDef[] = columnsData.map((column) => ({
         field: column.name,
         headerComponent: ColumnHeader,
@@ -331,7 +302,6 @@ const useDataViewer = () => {
     gridRef,
     onGridReady,
     refreshResults,
-    viewProperties: () => loadedViewPropertiesRef.current,
   };
 };
 


### PR DESCRIPTION
**Summary:**
This changes how `DataViewer` maintains context. In our first iteration,
`retainContextWhenHidden: true` was avoided because the
[documentation](https://code.visualstudio.com/api/extension-guides/webview)
said:

> keep in mind that this has high memory overhead and should only be used when
> other persistence techniques will not work

With that in mind, the implementation relied on re-fetching data each time a
view was displayed. As `DataViewer` grows increasingly complex, the amount of
state required to persist/fetch data will be increase. 

Thus, this PR changes things such that we retain context when switching between
tabs. The downside is that there is a higher memory footprint (it was hard to
find data on this but a stack overflow post suggested an empty web view
using `retainContextWhenHidden: true` consumes 50mb of memory).
However, there are numerous upsides:

 - This solves https://github.com/sassoftware/vscode-sas-extension/issues/1791
 - Grid state no longer has to be persisted/fetched when a tab is displayed
 - The excess xhr requests that were made to re-fetch data are no longer needed
 - From a developer perspective, adding new features to the dataviewer will
   require less time worrying about data persistence/retrieval for things that
   should be in-memory

**Testing:**
- [x] Open a table, apply filters & sorts, change scroll position, etc
- [x] Tab away and back to table, and make sure state hasn't changed
