### PR TITLE
fix: correct server content ordering for numbered filenames

### DIFF
--- a/client/src/components/ContentNavigator/utils.ts
+++ b/client/src/components/ContentNavigator/utils.ts
@@ -135,7 +135,10 @@ export const sortedContentItems = (items: ContentItem[]) =>
     } else if (!aIsDirectory && bIsDirectory) {
       return 1;
     } else {
-      return a.name.localeCompare(b.name);
+      return a.name.localeCompare(b.name, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      });
     }
   });
 


### PR DESCRIPTION
**Summary:**
This PR updates the ordering of files and folders with numerical names so that they properly respect numerical order when sorting, i.e. a file named `test10.sas` should come after `test9.sas` not `test1.sas`.

**Testing:**
I made a series of files with numerical names beforehand and confirmed that sorting was incorrect:
<img width="168" height="420" alt="image" src="https://github.com/user-attachments/assets/edc454c3-f1b6-4e6f-903a-555b8fb90f0c" />

I then made my changes and created several files and folders to confirm the new sorting was correct:
<img width="674" height="1548" alt="image" src="https://github.com/user-attachments/assets/c9459f86-d3c1-46b2-a61e-61feb43bcc99" />


**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
