### PR TITLE
fix: date formatting for SAS dates in TablePropertiesViewer

### DIFF
--- a/client/src/connection/itc/ItcLibraryAdapter.ts
+++ b/client/src/connection/itc/ItcLibraryAdapter.ts
@@ -212,8 +212,8 @@ class ItcLibraryAdapter implements LibraryAdapter {
       columnCount: 0,
       compressionRoutine: "",
       creationTimeStamp: "",
-      encoding: "", // Not available in vtable
-      engine: "", // Not available in sashelp.vtable for SAS 9.4
+      encoding: "",
+      engine: "",
       extendedType: "",
       label: "",
       libref: item.library,
@@ -221,7 +221,7 @@ class ItcLibraryAdapter implements LibraryAdapter {
       modifiedTimeStamp: "",
       name: item.name,
       physicalRecordCount: 0,
-      recordLength: 0, // Not available in vtable
+      recordLength: 0,
       rowCount: 0,
       type: "DATA",
     };
@@ -241,6 +241,8 @@ class ItcLibraryAdapter implements LibraryAdapter {
           tableInfo.compressionRoutine || basicInfo.compressionRoutine,
         creationTimeStamp:
           tableInfo.creationTimeStamp || basicInfo.creationTimeStamp,
+        encoding: tableInfo.encoding || basicInfo.encoding,
+        engine: tableInfo.engine || basicInfo.engine,
         extendedType: tableInfo.extendedType || basicInfo.extendedType,
         label: tableInfo.label || basicInfo.label,
         libref: tableInfo.libref || basicInfo.libref,
@@ -250,6 +252,7 @@ class ItcLibraryAdapter implements LibraryAdapter {
         name: tableInfo.name || basicInfo.name,
         physicalRecordCount:
           tableInfo.rowCount || basicInfo.physicalRecordCount,
+        recordLength: tableInfo.recordLength || basicInfo.recordLength,
         rowCount: tableInfo.rowCount || basicInfo.rowCount,
         type: tableInfo.type || basicInfo.type,
       };

--- a/client/src/connection/itc/script/itc.ps1
+++ b/client/src/connection/itc/script/itc.ps1
@@ -620,10 +620,11 @@ class SASRunner {
     $objRecordSet = New-Object -comobject ADODB.Recordset
     $objRecordSet.ActiveConnection = $this.dataConnection
     $query = @"
-      select memname, memtype, crdate, modate, nobs, nvar, compress,
-             memlabel, typemem, filesize, delobs
-      from sashelp.vtable
-      where libname='$libname' and memname='$memname';
+     select v.memname, v.memtype, v.crdate, v.modate, v.nobs, v.obslen, v.nvar, v.compress,
+        v.memlabel, v.typemem, v.filesize, v.delobs, v.encoding, m.engine
+        from sashelp.vtable v
+        left join sashelp.vmember m on v.libname = m.libname and v.memname = m.memname
+        where v.libname='$libname' and v.memname='$memname';
 "@
     $objRecordSet.Open(
       $query,
@@ -640,12 +641,15 @@ class SASRunner {
       $result | Add-Member -MemberType NoteProperty -Name "creationTimeStamp" -Value $objRecordSet.Fields.Item(2).Value
       $result | Add-Member -MemberType NoteProperty -Name "modifiedTimeStamp" -Value $objRecordSet.Fields.Item(3).Value
       $result | Add-Member -MemberType NoteProperty -Name "rowCount" -Value $objRecordSet.Fields.Item(4).Value
-      $result | Add-Member -MemberType NoteProperty -Name "columnCount" -Value $objRecordSet.Fields.Item(5).Value
-      $result | Add-Member -MemberType NoteProperty -Name "compressionRoutine" -Value $objRecordSet.Fields.Item(6).Value
-      $result | Add-Member -MemberType NoteProperty -Name "label" -Value $objRecordSet.Fields.Item(7).Value
-      $result | Add-Member -MemberType NoteProperty -Name "extendedType" -Value $objRecordSet.Fields.Item(8).Value
-      $result | Add-Member -MemberType NoteProperty -Name "fileSize" -Value $objRecordSet.Fields.Item(9).Value
-      $result | Add-Member -MemberType NoteProperty -Name "deletedObs" -Value $objRecordSet.Fields.Item(10).Value
+      $result | Add-Member -MemberType NoteProperty -Name "recordLength" -Value $objRecordSet.Fields.Item(5).Value
+      $result | Add-Member -MemberType NoteProperty -Name "columnCount" -Value $objRecordSet.Fields.Item(6).Value
+      $result | Add-Member -MemberType NoteProperty -Name "compressionRoutine" -Value $objRecordSet.Fields.Item(7).Value
+      $result | Add-Member -MemberType NoteProperty -Name "label" -Value $objRecordSet.Fields.Item(8).Value
+      $result | Add-Member -MemberType NoteProperty -Name "extendedType" -Value $objRecordSet.Fields.Item(9).Value
+      $result | Add-Member -MemberType NoteProperty -Name "fileSize" -Value $objRecordSet.Fields.Item(10).Value
+      $result | Add-Member -MemberType NoteProperty -Name "deletedObs" -Value $objRecordSet.Fields.Item(11).Value
+      $result | Add-Member -MemberType NoteProperty -Name "encoding" -Value $objRecordSet.Fields.Item(12).Value
+      $result | Add-Member -MemberType NoteProperty -Name "engine" -Value $objRecordSet.Fields.Item(13).Value
       $result | Add-Member -MemberType NoteProperty -Name "libref" -Value $libname
     }
     $objRecordSet.Close()

--- a/client/src/panels/TablePropertiesViewer.ts
+++ b/client/src/panels/TablePropertiesViewer.ts
@@ -70,8 +70,8 @@ class TablePropertiesViewer extends WebView {
 
         const numVal = parseFloat(stringVal);
         if (numVal > 0) {
-          // SAS datetime is seconds since 1960-01-01; subtract 315532800 seconds to shift to Unix epoch (1970-01-01), then multiply by 1000 for JavaScript milliseconds.
-          dateVal = new Date((numVal - 315532800) * 1000);
+          // SAS datetime is seconds since 1960-01-01; subtract the offset of 315619200 seconds to shift to Unix epoch (1970-01-01), then multiply by 1000 for JavaScript milliseconds.
+          dateVal = new Date((numVal - 315619200) * 1000);
           if (!isNaN(dateVal.getTime())) {
             return dateVal.toLocaleString();
           }

--- a/client/src/panels/TablePropertiesViewer.ts
+++ b/client/src/panels/TablePropertiesViewer.ts
@@ -61,11 +61,23 @@ class TablePropertiesViewer extends WebView {
     };
 
     const formatDate = (value: unknown): string => {
-      if (!value) {
-        return "";
-      }
       try {
-        return new Date(String(value)).toLocaleString();
+        const stringVal = String(value);
+        let dateVal = new Date(stringVal);
+        if (!isNaN(dateVal.getTime())) {
+          return dateVal.toLocaleString();
+        }
+
+        const numVal = parseFloat(stringVal);
+        if (numVal > 0) {
+          // SAS datetime is seconds since 1960-01-01; subtract 315532800 seconds to shift to Unix epoch (1970-01-01), then multiply by 1000 for JavaScript milliseconds.
+          dateVal = new Date((numVal - 315532800) * 1000);
+          if (!isNaN(dateVal.getTime())) {
+            return dateVal.toLocaleString();
+          }
+        }
+
+        return stringVal;
       } catch {
         return String(value);
       }


### PR DESCRIPTION
**Summary:**
- For IOM connections, the date timestamps are returned as an unformatted SAS date, so we have to convert those to a UNIX timestamp so they can be properly displayed. 
- There's also a few other properties that weren't being pulled in for IOM, so pull those in too (record length, encoding, engine)

Testing:

- [x] make sure that table/column properties are populated in the table properties viewer when connected with IOM 