### PR TITLE
fix: two line gaps gets added on double formatting sas program

### DIFF
--- a/server/src/sas/formatter/parser.ts
+++ b/server/src/sas/formatter/parser.ts
@@ -443,7 +443,12 @@ export const getParser =
             currentStatement.children.push(nextToken);
             ++i;
           }
-          if (nextToken.start.line - node.end.line > 1) {
+          const lineGap = nextToken.start.line - node.end.line;
+          const hasCardsData = currentStatement.children.some(
+            (token) => token.type === "cards-data",
+          );
+          const minGapToPreserve = hasCardsData ? 2 : 1;
+          if (lineGap > minGapToPreserve) {
             // preserve user explicit empty line
             currentStatement.children.push({
               type: "raw-data",


### PR DESCRIPTION
**Summary:**
Fixed an issue where clicking the Format Program button a second time modified the SAS program formatting by adding an extra blank line before the sort procedure statement. This was resolved by refining blank-line preservation logic in the parser formatter, applying a stricter gap threshold for cards-data statements compared to normal statements.
**Testing:**
I compiled the extension with _npm run compile_, launched it with F5 in Extension Development Host, and verified the fix by formatting a SAS file containing cards-data.

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
