### PR TITLE
fix: syntax errors causes no libraries to display (#1931)

### DIFF
--- a/client/src/connection/itc/script.ts
+++ b/client/src/connection/itc/script.ts
@@ -563,6 +563,12 @@ class SASRunner{
   }
 
   [void]GetLibraries() {
+    # Reset LanguageService to clear any error state from previous syntax errors
+    $this.objSAS.LanguageService.Reset()
+    
+    # Flush any pending output/errors
+    $this.objSAS.LanguageService.FlushLog(32768) | Out-Null
+    
     $objRecordSet = New-Object -comobject ADODB.Recordset
     $objRecordSet.ActiveConnection = $this.dataConnection
     $query = @"


### PR DESCRIPTION
**Summary:**
When SAS code is submitted with syntax issues, the LanguageService throws errors (expected) but this also causes the request to getLibraries to return no values (which is not valid). So, when fetching libraries, clear the cache of errors and query the libraries table properly

**Testing:**
Verified on a local install of the extension

**TODOs:**
none