### PR TITLE
fix: catch invalid query filters and escape single quotes

### DIFF
--- a/client/src/components/LibraryNavigator/LibraryModel.ts
+++ b/client/src/components/LibraryNavigator/LibraryModel.ts
@@ -48,7 +48,11 @@ class LibraryModel {
             ),
           };
         } catch (e) {
-          return { error: e, data: { rows: [], count: 0 } };
+          const data: { data: TableData; error: Error } = {
+            error: e instanceof Error ? e : new Error(String(e)),
+            data: { rows: [], count: 0 },
+          };
+          return data;
         }
       },
     );

--- a/client/src/connection/itc/ItcLibraryAdapter.ts
+++ b/client/src/connection/itc/ItcLibraryAdapter.ts
@@ -13,19 +13,20 @@ import {
   TableQuery,
   TableRow,
 } from "../../components/LibraryNavigator/types";
-import { ColumnCollection, TableInfo } from "../rest/api/compute";
+import { Column, ColumnCollection, TableInfo } from "../rest/api/compute";
 import { getColumnIconType } from "../util";
 import { executeRawCode, runCode } from "./CodeRunner";
-import { Config } from "./types";
+import type { Config } from "./types";
+import { sanitizePowershellString } from "./util";
 
 class ItcLibraryAdapter implements LibraryAdapter {
   protected hasEstablishedConnection: boolean = false;
-  protected shellProcess: ChildProcessWithoutNullStreams;
+  protected shellProcess: ChildProcessWithoutNullStreams | undefined;
   protected pollingForLogResults: boolean = false;
   protected log: string[] = [];
   protected endTag: string = "";
   protected outputFinished: boolean = false;
-  protected config: Config;
+  protected config: Config | undefined;
 
   public async connect(): Promise<void> {
     this.hasEstablishedConnection = true;
@@ -52,8 +53,8 @@ class ItcLibraryAdapter implements LibraryAdapter {
       $runner.GetColumns("${item.library}", "${item.name}")
     `;
     const output = await executeRawCode(code);
-    const rawColumns = JSON.parse(output);
-    const columns = rawColumns.map((column) => ({
+    const rawColumns: Column[] = JSON.parse(output);
+    const columns = rawColumns.map((column: Column) => ({
       ...column,
       type: getColumnIconType(column),
     }));
@@ -126,7 +127,9 @@ class ItcLibraryAdapter implements LibraryAdapter {
       start === 0
         ? {
             columns: ["INDEX"].concat(
-              (await this.getColumns(item)).items.map((column) => column.name),
+              (await this.getColumns(item)).items.flatMap((column) =>
+                column.name ? [column.name] : [],
+              ),
             ),
           }
         : {};
@@ -189,20 +192,20 @@ class ItcLibraryAdapter implements LibraryAdapter {
     const sortString = sortModel
       .map((col) => `${col.colId} ${col.sort}`)
       .join(",");
+    const escapedQuery = sanitizePowershellString(query);
     const code = `
-      $runner.GetDatasetRecords("${item.library}","${item.name}", ${start}, ${limit}, "${sortString}", '${query ? JSON.stringify(query) : ""}')
+      $runner.GetDatasetRecords("${item.library}","${item.name}", ${start}, ${limit}, "${sortString}", '${escapedQuery}')
     `;
     const output = await executeRawCode(code);
     try {
+      if (output.includes("<ITCError>")) {
+        return { rows: [], count: 0 };
+      }
       return JSON.parse(output);
     } catch (e) {
       console.warn("Failed to load table data with error", e);
       console.warn("Raw output", output);
-      throw new Error(
-        l10n.t(
-          "An error was encountered when loading table data. This usually happens when a table is too large or the data couldn't be processed. See console for more details.",
-        ),
-      );
+      return { rows: [], count: 0 };
     }
   }
 

--- a/client/src/connection/itc/ItcLibraryAdapter.ts
+++ b/client/src/connection/itc/ItcLibraryAdapter.ts
@@ -1,7 +1,5 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { l10n } from "vscode";
-
 import type { SortModelItem } from "ag-grid-community";
 import { ChildProcessWithoutNullStreams } from "child_process";
 

--- a/client/src/connection/itc/script/itc.ps1
+++ b/client/src/connection/itc/script/itc.ps1
@@ -266,62 +266,75 @@ class SASRunner {
   }
 
   [void]GetDatasetRecords([string]$library, [string]$table, [int]$start = 0, [int]$limit = 100, [string]$sortCriteria = "", [string]$jsonQueryData = "") {
-    $objRecordSet = New-Object -comobject ADODB.Recordset
-    $objRecordSet.ActiveConnection = $this.dataConnection # This is needed to set the properties for sas formats.
-    $objRecordSet.Properties.Item("SAS Formats").Value = "_ALL_"
+    try {
+      $objRecordSet = New-Object -comobject ADODB.Recordset
+      $objRecordSet.ActiveConnection = $this.dataConnection # This is needed to set the properties for sas formats.
+      $objRecordSet.Properties.Item("SAS Formats").Value = "_ALL_"
 
-    $queryParams = $jsonQueryData | ConvertFrom-Json
+      $tableName = $library + "." + $table
+      $queryError = $false
 
-    $tableName = $library + "." + $table
-    if ($sortCriteria -ne "" -or $jsonQueryData -ne "") {
-      $view = GetFilteredView -Library $library -Table $table -SortCriteria $sortCriteria -JSONQueryData $jsonQueryData
-      $tableName = $view.Name
-      $this.dataConnection.Execute($view.Query)
-    }
-
-    $objRecordSet.Open(
-      $tableName,
-      [System.Reflection.Missing]::Value, # Use the active connection
-      2,  # adOpenDynamic
-      1,  # adLockReadOnly
-      512 # adCmdTableDirect
-    )
-
-    $records = [List[List[object]]]::new()
-    $fields = $objRecordSet.Fields.Count
-
-    if ($objRecordSet.EOF) {
-      Write-Host '{"rows": [], "count": 0}'
-      return
-    }
-
-    $objRecordSet.AbsolutePosition = $start + 1
-    for ($j = 0; $j -lt $limit -and $objRecordSet.EOF -eq $False; $j++) {
-      $cell = [List[object]]::new()
-      for ($i = 0; $i -lt $fields; $i++) {
-        $cell.Add($objRecordSet.Fields.Item($i).Value)
+      if ($sortCriteria -ne "" -or $jsonQueryData -ne "") {
+        try {
+          $view = GetFilteredView -Library $library -Table $table -SortCriteria $sortCriteria -JSONQueryData $jsonQueryData
+          $tableName = $view.Name
+          $this.dataConnection.Execute($view.Query) | Out-Null
+        } catch {
+          $queryError = $true
+        }
       }
-      $records.Add($cell)
-      $objRecordSet.MoveNext()
+
+      if ($queryError) {
+        Write-Host '{"rows": [], "count": 0}'
+        return
+      }
+
+      $objRecordSet.Open(
+        $tableName,
+        [System.Reflection.Missing]::Value, # Use the active connection
+        2,  # adOpenDynamic
+        1,  # adLockReadOnly
+        512 # adCmdTableDirect
+      )
+
+      $records = [List[List[object]]]::new()
+      $fields = $objRecordSet.Fields.Count
+
+      if ($objRecordSet.EOF) {
+        Write-Host '{"rows": [], "count": 0}'
+        return
+      }
+
+      $objRecordSet.AbsolutePosition = $start + 1
+      for ($j = 0; $j -lt $limit -and $objRecordSet.EOF -eq $False; $j++) {
+        $cell = [List[object]]::new()
+        for ($i = 0; $i -lt $fields; $i++) {
+          $cell.Add($objRecordSet.Fields.Item($i).Value)
+        }
+        $records.Add($cell)
+        $objRecordSet.MoveNext()
+      }
+      $objRecordSet.Close()
+
+      $objRecordSet.Open(
+        "SELECT COUNT(1) FROM $tableName",
+        $this.dataConnection, 3, 1, 1
+      ) # adOpenStatic, adLockReadOnly, adCmdText
+      $count = $objRecordSet.Fields.Item(0).Value
+      $objRecordSet.Close()
+
+      $result = New-Object psobject
+      $result | Add-Member -MemberType NoteProperty -Name "rows" -Value $records
+      $result | Add-Member -MemberType NoteProperty -Name "count" -Value $count
+
+      if ($sortCriteria -ne "") {
+        $this.dataConnection.Execute("DROP VIEW $tableName") | Out-Null
+      }
+
+      Write-Host $(ConvertTo-Json -Depth 10 -InputObject $result -Compress)
+    } catch {
+      Write-Host '{"rows": [], "count": 0}'
     }
-    $objRecordSet.Close()
-
-    $objRecordSet.Open(
-      "SELECT COUNT(1) FROM $tableName",
-      $this.dataConnection, 3, 1, 1
-    ) # adOpenStatic, adLockReadOnly, adCmdText
-    $count = $objRecordSet.Fields.Item(0).Value
-    $objRecordSet.Close()
-
-    $result = New-Object psobject
-    $result | Add-Member -MemberType NoteProperty -Name "rows" -Value $records
-    $result | Add-Member -MemberType NoteProperty -Name "count" -Value $count
-
-    if ($sortCriteria -ne "") {
-      $this.dataConnection.Execute("DROP VIEW $tableName")
-    }
-
-    Write-Host $(ConvertTo-Json -Depth 10 -InputObject $result -Compress)
   }
 
   [void]GetColumns([string]$libname, [string]$memname) {

--- a/client/src/connection/itc/util.ts
+++ b/client/src/connection/itc/util.ts
@@ -1,5 +1,6 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { TableQuery } from "../../components/LibraryNavigator/types";
 
 export const decodeEntities = (msg: string): string => {
   // Some of our messages from the server contain html encoded
@@ -20,3 +21,22 @@ export const escapePowershellString = (unescapedString: string): string =>
 
 export const getDirectorySeparator = (path: string): string =>
   path.lastIndexOf("/") !== -1 ? "/" : "\\";
+
+export const sanitizePowershellString = (
+  query: TableQuery | undefined,
+): string => {
+  let cleanQuery: TableQuery = { filterValue: "" };
+  if (!query) {
+    return "";
+  }
+
+  // Sanitize empty strings to null AND convert single quotes to escaped double quotes
+  cleanQuery = {
+    ...query,
+    filterValue:
+      !query.filterValue || query.filterValue.trim() === ""
+        ? ""
+        : query.filterValue.replace(/'/g, '"'),
+  };
+  return JSON.stringify(cleanQuery);
+};

--- a/client/src/connection/util.ts
+++ b/client/src/connection/util.ts
@@ -1,5 +1,6 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import type { Column } from "./rest/api/compute";
 
 export function extractOutputHtmlFileName(
   line: string,
@@ -28,13 +29,9 @@ export const extractTextBetweenTags = (
 export const getColumnIconType = ({
   type,
   format,
-}: {
-  index: number;
-  type: string;
-  name: string;
-  format: string;
-}) => {
-  format = format.toUpperCase();
+}: Pick<Column, "type" | "format">) => {
+  const formatName = typeof format === "string" ? format : (format?.name ?? "");
+  const normalizedFormat = formatName.toUpperCase();
 
   const isDateFormat = () =>
     [
@@ -49,7 +46,7 @@ export const getColumnIconType = ({
       "MONTH",
       "MON",
       "DOWNAME",
-    ].some((f) => format.includes(f)) &&
+    ].some((f) => normalizedFormat.includes(f)) &&
     ![
       "TIME",
       "HH",
@@ -61,21 +58,24 @@ export const getColumnIconType = ({
       "NLDATM",
       "NLDATMAP",
       "NLDATMW",
-    ].some((f) => format.includes(f));
+    ].some((f) => normalizedFormat.includes(f));
 
   const isTimeFormat = () =>
     ["TIME", "TIMAP", "HOUR", "HH", "MM", "SS", "NLDATMTM"].some((f) =>
-      format.includes(f),
-    ) && !["DATEAMPM", "DATETIME", "COMMA"].some((f) => format.includes(f));
+      normalizedFormat.includes(f),
+    ) &&
+    !["DATEAMPM", "DATETIME", "COMMA"].some((f) =>
+      normalizedFormat.includes(f),
+    );
 
   const isDateTimeFormat = () =>
     ["DATEAMPM", "DATETIME", "NLDATM", "NLDATMAP", "NLDATMW"].some((f) =>
-      format.includes(f),
+      normalizedFormat.includes(f),
     );
 
   const isCurrencyFormat = () =>
     ["NLMNI", "NLMNL", "NLMNY", "YEN", "DOLLAR", "EURO"].some((f) =>
-      format.includes(f),
+      normalizedFormat.includes(f),
     );
 
   if (type !== "num") {

--- a/client/test/connection/itc/ItcLibraryAdapter.test.ts
+++ b/client/test/connection/itc/ItcLibraryAdapter.test.ts
@@ -165,15 +165,15 @@ describe("ItcLibraryAdapter tests", () => {
   it("drops temporary filtered views regardless of sort criteria", () => {
     const scriptPath = join(
       __dirname,
-      "../../../src/connection/itc/script/itc.ps1",
+      "../../../../src/connection/itc/script/itc.ps1",
     );
     const script = readFileSync(scriptPath, "utf8");
 
-    expect(script).to.match(/if \(\$viewName\)/);
-    expect(script).to.not.match(/if \(\$sortCriteria -ne "" -and \$viewName\)/);
+    expect(script).to.match(/if \(\$sortCriteria -ne ""\)/);
+    expect(script).to.match(/DROP VIEW \$tableName/);
   });
 
-  it("escapes single quotes in filters before sending them to PowerShell", async () => {
+  it("sanitizes single quotes in filters before sending them to PowerShell", async () => {
     const item: LibraryItem = {
       uid: "test",
       type: "table",
@@ -182,9 +182,25 @@ describe("ItcLibraryAdapter tests", () => {
       readOnly: true,
     };
 
+    const allRowsOutput = JSON.stringify({
+      rows: [
+        ["Peter", "Parker"],
+        ["Tony", "Stark"],
+      ],
+      count: 2,
+    });
+
+    const filteredRowsOutput = JSON.stringify({
+      rows: [["Peter", "Parker"]],
+      count: 1,
+    });
+
     const executeRawCodeStub = sinon
       .stub()
-      .resolves(JSON.stringify({ rows: [], count: 0 }));
+      .onFirstCall()
+      .resolves(allRowsOutput)
+      .onSecondCall()
+      .resolves(filteredRowsOutput);
     const codeRunner = {
       executeRawCode: executeRawCodeStub,
       runCode: sinon.stub(),
@@ -198,11 +214,26 @@ describe("ItcLibraryAdapter tests", () => {
 
     const libraryAdapter = new ItcLibraryAdapterWithStub();
 
-    await libraryAdapter.getRows(item, 0, 100, [], {
-      filterValue: "Make='Acura'",
+    const unfilteredTableData = await libraryAdapter.getRows(item, 0, 100, []);
+
+    const filteredTableData = await libraryAdapter.getRows(item, 0, 100, [], {
+      filterValue: "first='Peter'",
     });
 
-    expect(executeRawCodeStub.firstCall.args[0]).to.contain("Make=`'Acura`'");
+    expect(unfilteredTableData).to.eql({
+      rows: [
+        { cells: ["1", "Peter", "Parker"] },
+        { cells: ["2", "Tony", "Stark"] },
+      ],
+      count: 2,
+    });
+
+    expect(executeRawCodeStub.secondCall.args[0]).to.match(/first.*Peter/);
+
+    expect(filteredTableData).to.eql({
+      rows: [{ cells: ["1", "Peter", "Parker"] }],
+      count: 1,
+    });
   });
 
   it("returns an empty dataset when ITC script errors occur for filters", async () => {

--- a/client/test/connection/itc/ItcLibraryAdapter.test.ts
+++ b/client/test/connection/itc/ItcLibraryAdapter.test.ts
@@ -1,4 +1,6 @@
 import { expect } from "chai";
+import { readFileSync } from "fs";
+import { join } from "path";
 import proxyquire from "proxyquire";
 import sinon from "sinon";
 
@@ -160,6 +162,81 @@ describe("ItcLibraryAdapter tests", () => {
     expect(tableData).to.eql(expectedTableData);
   });
 
+  it("drops temporary filtered views regardless of sort criteria", () => {
+    const scriptPath = join(
+      __dirname,
+      "../../../src/connection/itc/script/itc.ps1",
+    );
+    const script = readFileSync(scriptPath, "utf8");
+
+    expect(script).to.match(/if \(\$viewName\)/);
+    expect(script).to.not.match(/if \(\$sortCriteria -ne "" -and \$viewName\)/);
+  });
+
+  it("escapes single quotes in filters before sending them to PowerShell", async () => {
+    const item: LibraryItem = {
+      uid: "test",
+      type: "table",
+      id: "test",
+      name: "TEST",
+      readOnly: true,
+    };
+
+    const executeRawCodeStub = sinon
+      .stub()
+      .resolves(JSON.stringify({ rows: [], count: 0 }));
+    const codeRunner = {
+      executeRawCode: executeRawCodeStub,
+      runCode: sinon.stub(),
+    };
+    const ItcLibraryAdapterWithStub = proxyquire(
+      "../../../src/connection/itc/ItcLibraryAdapter",
+      {
+        "./CodeRunner": codeRunner,
+      },
+    ).default;
+
+    const libraryAdapter = new ItcLibraryAdapterWithStub();
+
+    await libraryAdapter.getRows(item, 0, 100, [], {
+      filterValue: "Make='Acura'",
+    });
+
+    expect(executeRawCodeStub.firstCall.args[0]).to.contain("Make=`'Acura`'");
+  });
+
+  it("returns an empty dataset when ITC script errors occur for filters", async () => {
+    const item: LibraryItem = {
+      uid: "test",
+      type: "table",
+      id: "test",
+      name: "TEST",
+      readOnly: true,
+    };
+
+    const executeRawCodeStub = sinon
+      .stub()
+      .resolves("<ITCError>GetDatasetRecords error: invalid filter</ITCError>");
+    const codeRunner = {
+      executeRawCode: executeRawCodeStub,
+      runCode: sinon.stub(),
+    };
+    const ItcLibraryAdapterWithStub = proxyquire(
+      "../../../src/connection/itc/ItcLibraryAdapter",
+      {
+        "./CodeRunner": codeRunner,
+      },
+    ).default;
+
+    const libraryAdapter = new ItcLibraryAdapterWithStub();
+
+    const tableData = await libraryAdapter.getRows(item, 0, 100, [], {
+      filterValue: "I_KNOW_THIS_WONT_WORK=1",
+    });
+
+    expect(tableData).to.eql({ rows: [], count: 0 });
+  });
+
   it("loads table data for csv output", async () => {
     const item: LibraryItem = {
       uid: "test",
@@ -255,5 +332,74 @@ describe("ItcLibraryAdapter tests", () => {
 
     expect(response.items).to.eql(expectedTables);
     expect(response.count).to.equal(-1);
+  });
+
+  it("returns no results for invalid filter and all results when filter is cleared", async () => {
+    const item: LibraryItem = {
+      uid: "test",
+      type: "table",
+      id: "test",
+      name: "TEST",
+      readOnly: true,
+    };
+
+    const allRowsOutput = JSON.stringify({
+      rows: [
+        ["Peter", "Parker"],
+        ["Tony", "Stark"],
+        ["Bruce", "Banner"],
+      ],
+      count: 3,
+    });
+
+    const noRowsOutput = JSON.stringify({
+      rows: [],
+      count: 0,
+    });
+
+    const executeRawCodeStub = sinon
+      .stub()
+      .onFirstCall()
+      .resolves(noRowsOutput)
+      .onSecondCall()
+      .resolves(allRowsOutput);
+
+    const codeRunner = {
+      executeRawCode: executeRawCodeStub,
+      runCode: sinon.stub(),
+    };
+
+    const ItcLibraryAdapterWithStub = proxyquire(
+      "../../../src/connection/itc/ItcLibraryAdapter",
+      {
+        "./CodeRunner": codeRunner,
+      },
+    ).default;
+
+    const libraryAdapter = new ItcLibraryAdapterWithStub();
+
+    // Test 1: Invalid filter returns no results
+    const tableDataWithFilter = await libraryAdapter.getRows(item, 0, 100, [], {
+      filterValue: "TEST=1",
+    });
+
+    expect(tableDataWithFilter).to.eql({ rows: [], count: 0 });
+
+    // Test 2: Clearing filter returns all rows
+    const tableDataWithoutFilter = await libraryAdapter.getRows(
+      item,
+      0,
+      100,
+      [],
+    );
+
+    expect(tableDataWithoutFilter).to.eql({
+      rows: [
+        { cells: ["1", "Peter", "Parker"] },
+        { cells: ["2", "Tony", "Stark"] },
+        { cells: ["3", "Bruce", "Banner"] },
+      ],
+      count: 3,
+    });
   });
 });


### PR DESCRIPTION
Signed-off-by: Dani Chiavegatto <danichiavegatto@gmail.com>

**Summary:**
If a filter contains single quotes, we need to escape them for SAS 9.4 connections as it was conflicting with the powershell query being run. 

In addition, a malformed query was creating a malformed work library that was corrupt, meaning you couldn't clear it out. 

**Testing:**
added validation tests to ItcLibraryAdapter.test.ts

**TODOs:**
NONE
