### PR TITLE
fix: outline for dataset not respect '&' in dataset name

### DIFF
--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -4,7 +4,8 @@ import * as assert from "assert";
 
 import { getUri, openDoc } from "./utils";
 
-let docUri;
+// Fix: to resolve implicit 'any' type error
+let docUri: vscode.Uri;
 
 describe("lsp", () => {
   before(async () => {
@@ -55,5 +56,50 @@ describe("lsp", () => {
         docUri,
       );
     assert.ok(actualDocumentSymbol.length > 0);
+  });
+
+  it("provides full DATA step names in document symbol", async () => {
+    const docUri3 = getUri("OutlineDataStepNames.sas");
+    await openDoc(docUri3);
+
+    let actualDocumentSymbol: Array<
+      vscode.DocumentSymbol | vscode.SymbolInformation
+    > = [];
+
+    for (let i = 0; i < 20; i++) {
+      actualDocumentSymbol =
+        (await vscode.commands.executeCommand<
+          Array<vscode.DocumentSymbol | vscode.SymbolInformation>
+        >("vscode.executeDocumentSymbolProvider", docUri3)) ?? [];
+
+      if (actualDocumentSymbol.length > 0) {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    assert.ok(
+      actualDocumentSymbol.length > 0,
+      "No document symbols returned for OutlineDataStepNames.sas",
+    );
+
+    const names = actualDocumentSymbol.map((symbol) =>
+      symbol.name.toLowerCase(),
+    );
+
+    assert.ok(
+      names.includes("data ___&danal."),
+      `Expected outline item "DATA ___&danal.", got: ${actualDocumentSymbol
+        .map((symbol) => symbol.name)
+        .join(", ")}`,
+    );
+
+    assert.ok(
+      names.includes("data _null_"),
+      `Expected outline item "DATA _null_", got: ${actualDocumentSymbol
+        .map((symbol) => symbol.name)
+        .join(", ")}`,
+    );
   });
 });

--- a/client/testFixture/OutlineDataStepNames.sas
+++ b/client/testFixture/OutlineDataStepNames.sas
@@ -1,0 +1,8 @@
+%let danal=anal;
+
+data ___&danal.;
+run;
+
+data _null_;
+  set sashelp.class(obs=1);
+run;

--- a/server/src/sas/SyntaxProvider.ts
+++ b/server/src/sas/SyntaxProvider.ts
@@ -413,28 +413,19 @@ export class SyntaxProvider {
   getSymbolName(block: FoldingBlock) {
     const line = block.startLine;
     const tokens = this.getSyntax(line);
-    for (let i = 2; i < tokens.length; i++) {
-      const token = tokens[i];
-      if (token.start <= block.startCol) {
-        continue;
-      }
-      if (token.style === "proc-name" || token.style === "text") {
-        const end =
-          i === tokens.length - 1
-            ? this.model.getColumnCount(line)
-            : tokens[i + 1].start;
-        const tokenText = this.model.getText({
-          start: { line, column: token.start },
-          end: { line, column: end },
-        });
-        if (tokenText.trim() === "") {
-          continue;
-        }
-        return `${block.name} ${
-          token.style === "proc-name" ? tokenText.toUpperCase() : tokenText
-        }`;
-      }
+    const keywordToken = tokens.find((token) => token.start > block.startCol);
+    const startCol = keywordToken
+      ? keywordToken.start
+      : block.startCol + block.name.length;
+    const lineText = this.model.getLine(line).substring(startCol).trimStart();
+    const match = /^([^\s;()]+)/.exec(lineText);
+
+    if (match && match[1]) {
+      const fullName =
+        block.name === "PROC" ? match[1].toUpperCase() : match[1];
+      return `${block.name} ${fullName}`;
     }
+
     return block.name;
   }
   getMultilineComments(): Array<{ startLine: number; endLine: number }> {


### PR DESCRIPTION
**Summary:**
Fixed outline display for DATA step names to preserve full dataset identifiers, including macro variables and special names.

**Problem:**
- `data ___&danal.;` was displayed as `DATA ___` in outline
- `data _null_;` was displayed as `DATA` in outline

**Root cause:**
The `getSymbolName()` function in `SyntaxProvider.ts` was using a brittle token-based approach:
- Started iteration from token index 2 (could skip valid tokens)
- Returned immediately on first matching token (broke multi-part names like `___&danal.`)
- Didn't handle all name patterns correctly

**Solution:**
Changed approach from token by token assembly to raw text extraction:
- Extract text from the line after DATA/PROC keyword
- Use regex to capture the full name up to first whitespace/semicolon/bracket
- Preserves macro variables (`&var.`), underscores, and special keywords like `_null_`

**Files changed:**
- `server/src/sas/SyntaxProvider.ts` - rewrote `getSymbolName()` logic
- `client/test/extension.test.ts` - added test case for outline names
- `client/testFixture/OutlineDataStepNames.sas` - test fixture with both cases

**Testing:**
   powershell
   npm run compile
   npm run pretest
   npm run test-client
   
Manual verification in Extension Development Host:
Opened OutlineDataStepNames.sas file
Verified Outline panel displays:
DATA ___&danal.
DATA _null_
Both names now display completely and correctly

After changes 

<img width="1137" height="873" alt="outlineTicket" src="https://github.com/user-attachments/assets/239d9495-5ea6-4aa6-a11f-3bdc5906de35" />

Test passed
<img width="826" height="342" alt="outlineTestPass" src="https://github.com/user-attachments/assets/bd3dc6c9-7eca-49b4-8dc4-00729ea23c7b" />

**Issue:**
(https://github.com/sassoftware/vscode-sas-extension/issues/1553)
**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
