### PR TITLE
Fix: Rename fails for files/folders with semicolon in path

### DIFF
--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -468,7 +468,8 @@ class RestServerAdapter implements ContentAdapter {
 
     const parsedFilePath = filePath.split(SAS_FILE_SEPARATOR);
     parsedFilePath.pop();
-    const path = parsedFilePath.join("/");
+    const encodedPath = parsedFilePath.join("/");
+    const path = this.decodePath(encodedPath);
 
     try {
       const response = await this.fileSystemApi.updateFileOrDirectoryOnSystem({
@@ -618,6 +619,18 @@ class RestServerAdapter implements ContentAdapter {
     return {
       etag: "",
     };
+  }
+
+  private decodePath(path: string): string {
+    return path.replace(/~~|~sc~/g, (match) => {
+      if (match === "~~") {
+        return "~";
+      }
+      if (match === "~sc~") {
+        return ";";
+      }
+      return match;
+    });
   }
 }
 


### PR DESCRIPTION
**Summary**
Fixes an issue where renaming a file or directory whose path contains a semicolon (;) fails. The rename request was being sent to the SAS server with an unencoded semicolon, causing the server to reject it.

**Problem**
When a user renames a file or folder located under a path that contains a ; (e.g. tmp/new;/1.sas), the operation fails.

**Root Cause**
The encoded path (with ; represented as ~sc~) was being passed directly as a parameter, without first being decoded back to its original form. Since the SAS server expects the real, unencoded path, sending it the encoded string caused the rename request to fail.

**Solution**
Wrote and applied a decoding function that converts the encoded path back to its original form before it's used, decoding ~sc~ back to ; and ~~ back to a literal ~, so the SAS server receives the correct, unencoded path.

**Testing**
npm run compile
npm run pretest
npm run test-client

Manually reproduced the bug by creating a folder with ; and/or ~ in its name and attempting to rename a file inside it.
Verified the rename now succeeds with the fix applied.

**Issue:**
[https://github.com/sassoftware/vscode-sas-extension/issues/1304]
