### PR TITLE
fix: preserve focus when opening table

### DIFF
--- a/client/src/panels/WebviewManager.ts
+++ b/client/src/panels/WebviewManager.ts
@@ -16,10 +16,15 @@ export class WebViewManager {
       return;
     }
 
-    const panel = window.createWebviewPanel("webView", uid, ViewColumn.One, {
-      enableScripts: true,
-      retainContextWhenHidden: true,
-    });
+    const panel = window.createWebviewPanel(
+      "webView",
+      uid,
+      { viewColumn: ViewColumn.One, preserveFocus: true },
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+      },
+    );
 
     webview.onDispose = () => delete this.panels[uid];
     this.panels[uid] = webview.withPanel(panel).render();
@@ -123,7 +128,7 @@ export abstract class WebView {
   }
 
   public display() {
-    this.panel.reveal(ViewColumn.One);
+    this.panel.reveal(ViewColumn.One, true);
   }
 
   public webviewUri(extensionUri: Uri, name: string): Uri {


### PR DESCRIPTION
**Summary:**
Changes to make sure that focus is preserved on the table tree item when it is opened or re-revealed. This matches what is done with tree items in SAS Content and Server.

**Testing:**
Tested the change locally with run and debug. First put focus on a table like SASHELP.CARS in the tree view and pressed spacebar to open it. Verified focus was still on the tree item and not in the new table webview. I also opened another table and then re-revealed SASHELP.CARS using keyboard controls, making sure focus was still on the tree item there too.

**TODOs:**

- [ ] N/A
