### PR TITLE
Fix: pass buffer directly to updateContentOfItemAtPath without TextDecoder conversion

### DIFF
--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -202,7 +202,7 @@ class RestServerAdapter implements ContentAdapter {
       if (buffer) {
         await this.updateContentOfItemAtPath(
           this.trimComputePrefix(contentItem.uri),
-          new TextDecoder().decode(buffer),
+          buffer,
         );
       }
 
@@ -495,7 +495,7 @@ class RestServerAdapter implements ContentAdapter {
 
   private async updateContentOfItemAtPath(
     filePath: string,
-    content: string,
+    content: string | ArrayBufferLike,
   ): Promise<void> {
     const { etag } = await this.getFileInfo(filePath);
     const data = {


### PR DESCRIPTION
`Summary`
Fixes an issue where uploading sas7bdat files (via drag & drop or file upload) unnecessarily converts the file buffer to a string before sending it to the SAS server. As a result, the uploaded file was corrupted, making it impossible to create a library from it.

Problem
When a user uploads a file by dragging it into the Content Navigator or using the upload command, the file is decoded into a string using TextDecoder, only to be immediately cast back to File via as unknown as File inside updateContentOfItemAtPath.

Solution
Changed the content parameter type of updateContentOfItemAtPath from string to "string | ArrayBufferLike", allowing the buffer to be passed directly without the unnecessary decode step.

Testing
1. Upload a .sas7bdat file to SAS Server [car_price.zip](https://github.com/user-attachments/files/30748889/car_price.zip)                                                                                                                        
2. Run a script to create a library from that file
```
libname src "FILE PATH";

data work.car_prices;
  set src.car_price;
run;
```

4. Verify that the library appears with the data                                                                                                                
5. Verify that file creation functionality works in SAS Content and SAS Server (creating files of other types, dragging and dropping files, dragging and dropping folders, uploading files, etc.)

Issue:
https://github.com/sassoftware/vscode-sas-extension/issues/1890
