### PR TITLE
feat: _SASPROGRAMFILE for sas content

### DIFF
--- a/client/src/components/utils/SASCodeDocument.ts
+++ b/client/src/components/utils/SASCodeDocument.ts
@@ -1,5 +1,7 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { Uri } from "vscode";
+
 import { dirname } from "path";
 
 import {
@@ -135,14 +137,24 @@ export class SASCodeDocument {
 
   private wrapCodeWithSASProgramFileName(code: string): string {
     let fileName = this.parameters.fileName;
-    if (fileName === undefined) {
-      return code;
-    } else {
+    let uri = this.parameters.uri;
+
+    if (uri !== undefined && uri.startsWith("sasContent")) {
+      // check if a uri is available, and if it is coming from sasContent.
+      // if so, parse out our service representation and add the sascontent prefix.
+      // should look like this at the end: "sascontent:/files/files/<uuid>"
+      uri = Uri.parse(uri).query.replace("id=", "sascontent:");
+      return "%let _SASPROGRAMFILE = %nrquote(%nrstr(" + uri + "));\n" + code;
+    } else if (fileName !== undefined) {
+      // if we are not in sasContent, we want to use the fileName instead
       fileName = fileName.replace(/[('")]/g, "%$&");
-      const wrapped =
-        "%let _SASPROGRAMFILE = %nrquote(%nrstr(" + fileName + "));\n" + code;
-      return wrapped;
+      return (
+        "%let _SASPROGRAMFILE = %nrquote(%nrstr(" + fileName + "));\n" + code
+      );
     }
+
+    // if a fileName was not found, just return the raw code
+    return code;
   }
 
   private wrapCodeWithPreambleAndPostamble(code: string): string {

--- a/client/test/components/util/SASCodeDocument.test.ts
+++ b/client/test/components/util/SASCodeDocument.test.ts
@@ -226,6 +226,52 @@ cas; caslib _all_ assign;
     );
   });
 
+  it("wrapCodeWithSASProgramFileName with no fileName or uri", () => {
+    const parameters: SASCodeDocumentParameters = {
+      languageId: "sas",
+      code: "data test; run;",
+      selectedCode: "",
+      htmlStyle: "Illuminate",
+      outputHtml: false,
+      checkKeyword: async () => false,
+    };
+
+    const sasCodeDoc = new SASCodeDocument(parameters);
+    const wrappedCode = sasCodeDoc.getWrappedCode();
+
+    assert(
+      !wrappedCode.includes("_SASPROGRAMFILE"),
+      "wrapped code should not include _SASPROGRAMFILE when fileName and uri are not provided",
+    );
+    assert(
+      wrappedCode.includes("data test; run;"),
+      "wrapped code should include the original code",
+    );
+  });
+
+  it("wrapCodeWithSASProgramFileName with sasContent URI", () => {
+    const parameters: SASCodeDocumentParameters = {
+      languageId: "sas",
+      code: "this is the code",
+      selectedCode: "",
+      uri: "sasContent:/test.sas?id%3D%2Ffiles%2Ffiles%2F349be085-146d-4e0e-9fdc-99d330fa18d1",
+      fileName: "filename.sas",
+      htmlStyle: "Illuminate",
+      outputHtml: false,
+      checkKeyword: async () => false,
+    };
+
+    const sasCodeDoc = new SASCodeDocument(parameters);
+    const wrappedCode = sasCodeDoc.getWrappedCode();
+
+    assert(
+      wrappedCode.includes(
+        "%let _SASPROGRAMFILE = %nrquote(%nrstr(sascontent:/files/files/349be085-146d-4e0e-9fdc-99d330fa18d1));",
+      ),
+      "wrapped code should include _SASPROGRAMFILE with sascontent: prefix from sasContent URI",
+    );
+  });
+
   it("getProblemLocationInRawCode", async () => {
     const parameters: SASCodeDocumentParameters = {
       languageId: "sas",


### PR DESCRIPTION
**Issue:**
https://github.com/sassoftware/vscode-sas-extension/issues/1936

**Summary:**
Set the _SASPROGRAMFILE to the file uri when in SAS Content
_SASPROGRAMFILE will still be the full file path and name for SAS Server files

**Testing:**
Run a SAS Content program with:
%put &=_SASPROGRAMFILE;

In the log, verify that you see the variable printed in the form "sascontent:/files/files/id"

Run a SAS Server program with:
%put &=_SASPROGRAMFILE;

In the log, verify that you see the file name and path

Run a program saved locally with:
%put &=_SASPROGRAMFILE;

In the log, verify that you see the local path

**TODOs:**

- [ ] add support for _SASPROGRAMDIR
- [ ] update [CHANGELOG.md](CHANGELOG.md)
