### PR TITLE
feat: content pane image viewer

### DIFF
--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -52,6 +52,7 @@ import {
 import {
   ContentItem,
   ContentNavigatorConfig,
+  ContentSourceType,
   FileManipulationEvent,
 } from "./types";
 import {
@@ -77,6 +78,7 @@ class ContentDataProvider
   private model: ContentModel;
   private extensionUri: Uri;
   private mimeType: string;
+  private sourceType: ContentSourceType;
 
   public dropMimeTypes: string[];
   public dragMimeTypes: string[];
@@ -90,7 +92,7 @@ class ContentDataProvider
   constructor(
     model: ContentModel,
     extensionUri: Uri,
-    { mimeType, treeIdentifier }: ContentNavigatorConfig,
+    { mimeType, treeIdentifier, sourceType }: ContentNavigatorConfig,
   ) {
     this._onDidManipulateFile = new EventEmitter<FileManipulationEvent>();
     this._onDidChangeFile = new EventEmitter<FileChangeEvent[]>();
@@ -101,6 +103,7 @@ class ContentDataProvider
     this.dropMimeTypes = [mimeType, "text/uri-list"];
     this.dragMimeTypes = [mimeType];
     this.mimeType = mimeType;
+    this.sourceType = sourceType;
 
     this._treeView = window.createTreeView(treeIdentifier, {
       treeDataProvider: this,
@@ -224,6 +227,8 @@ class ContentDataProvider
       item.parentFolderUri ? item.parentFolderUri : STOP_SIGN,
     );
 
+    const openResourceCommand = `SAS.${this.sourceType === ContentSourceType.SASContent ? "content" : "server"}.openResource`;
+
     return {
       collapsibleState: isContainer
         ? TreeItemCollapsibleState.Collapsed
@@ -231,8 +236,8 @@ class ContentDataProvider
       command: isContainer
         ? undefined
         : {
-            command: "vscode.open",
-            arguments: [uri],
+            command: openResourceCommand,
+            arguments: [item],
             title: "Open SAS File",
           },
       contextValue: item.contextValue || undefined,
@@ -264,6 +269,31 @@ class ContentDataProvider
   }
 
   public async readFile(uri: Uri): Promise<Uint8Array> {
+    const fileName = uri.path.split("/").pop() || "";
+    const extension = fileName.split(".").pop()?.toLowerCase() || "";
+    const binaryExtensions = [
+      "png",
+      "jpg",
+      "jpeg",
+      "gif",
+      "bmp",
+      "tiff",
+      "webp",
+      "svg",
+      "pdf",
+      "zip",
+      "tar",
+      "gz",
+      "exe",
+      "dll",
+      "so",
+      "bin",
+    ];
+
+    if (binaryExtensions.includes(extension)) {
+      return await this.model.getContentByUriAsBinary(uri);
+    }
+
     return await this.model
       .getContentByUri(uri)
       .then((content) => new TextEncoder().encode(content));

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -71,6 +71,20 @@ export class ContentModel {
     return data;
   }
 
+  public async getContentByUriAsBinary(uri: Uri): Promise<Uint8Array> {
+    try {
+      if (this.contentAdapter.getContentOfUriAsBinary) {
+        return await this.contentAdapter.getContentOfUriAsBinary(uri);
+      }
+
+      const content = await this.getContentByUri(uri);
+      return new TextEncoder().encode(content);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (e) {
+      throw new Error(Messages.FileOpenError);
+    }
+  }
+
   public async downloadFile(item: ContentItem): Promise<Buffer | undefined> {
     try {
       const data = await this.contentAdapter.getContentOfItem(item);

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -7,6 +7,7 @@ import {
   ExtensionContext,
   OpenDialogOptions,
   ProgressLocation,
+  TabInputCustom,
   Uri,
   commands,
   env,
@@ -16,6 +17,7 @@ import {
 } from "vscode";
 
 import { profileConfig } from "../../commands/profile";
+import { getGlobalStorageUri } from "../ExtensionContext";
 import { SubscriptionProvider } from "../SubscriptionProvider";
 import { ConnectionType, ProfileWithFileRootOptions } from "../profile";
 import { treeViewSelections } from "../utils/treeViewSelections";
@@ -67,6 +69,7 @@ class ContentNavigator implements SubscriptionProvider {
   private contentDataProvider: ContentDataProvider;
   private contentModel: ContentModel;
   private sourceType: ContentNavigatorConfig["sourceType"];
+  private temporaryImageUris = new Map<string, Uri>();
   private treeIdentifier: ContentNavigatorConfig["treeIdentifier"];
 
   constructor(context: ExtensionContext, config: ContentNavigatorConfig) {
@@ -97,8 +100,75 @@ class ContentNavigator implements SubscriptionProvider {
 
   public getSubscriptions(): Disposable[] {
     const SAS = `SAS.${this.sourceType === ContentSourceType.SASContent ? "content" : "server"}`;
+    const imageExtensions = [
+      "png",
+      "jpg",
+      "jpeg",
+      "gif",
+      "bmp",
+      "tiff",
+      "webp",
+      "svg",
+    ];
     return [
       ...this.contentDataProvider.getSubscriptions(),
+      window.tabGroups.onDidChangeTabs(async ({ closed }) => {
+        await Promise.all(
+          closed.map((tab) => this.deleteTemporaryImageUri(tab.input)),
+        );
+      }),
+      new Disposable(() => {
+        void this.deleteTemporaryImageUris();
+      }),
+      commands.registerCommand(
+        `${SAS}.openResource`,
+        async (resource: ContentItem) => {
+          if (!resource) {
+            return;
+          }
+          const extension =
+            resource.name?.split(".").pop()?.toLowerCase() || "";
+          const isImage = imageExtensions.includes(extension);
+
+          if (!isImage) {
+            await this.defaultOpenResource(resource);
+            return;
+          }
+
+          const globalStorageUri = getGlobalStorageUri();
+          const imagePreviewCacheUri = Uri.joinPath(
+            globalStorageUri,
+            "imagePreviewCache",
+          );
+          try {
+            await workspace.fs.readDirectory(imagePreviewCacheUri);
+          } catch {
+            await workspace.fs.createDirectory(imagePreviewCacheUri);
+          }
+
+          const safeName =
+            resource.name?.replace(/[\\/:*?"<>|]/g, "_") || "image.png";
+          const localUri = Uri.joinPath(
+            imagePreviewCacheUri,
+            `${Date.now()}-${safeName}`,
+          );
+
+          const bytes = await this.contentModel.getContentByUriAsBinary(
+            resource.vscUri,
+          );
+          await workspace.fs.writeFile(localUri, bytes);
+          this.temporaryImageUris.set(localUri.toString(), localUri);
+          try {
+            await commands.executeCommand(
+              "vscode.openWith",
+              localUri,
+              "imagePreview.previewEditor",
+            );
+          } catch {
+            await this.deleteTemporaryImageUri(localUri);
+          }
+        },
+      ),
       commands.registerCommand(
         `${SAS}.deleteResource`,
         async (item: ContentItem) => {
@@ -445,6 +515,44 @@ class ContentNavigator implements SubscriptionProvider {
         },
       ),
     ];
+  }
+
+  private async defaultOpenResource(item: ContentItem): Promise<void> {
+    const itemUri = await this.contentModel.getUri(item, false);
+    await commands.executeCommand("vscode.open", itemUri);
+  }
+
+  private async deleteTemporaryImageUri(input: unknown): Promise<void> {
+    const uri =
+      input instanceof Uri
+        ? input
+        : input instanceof TabInputCustom
+          ? input.uri
+          : undefined;
+    if (!uri) {
+      return;
+    }
+
+    const key = uri.toString();
+    const temporaryUri = this.temporaryImageUris.get(key);
+    if (!temporaryUri) {
+      return;
+    }
+
+    this.temporaryImageUris.delete(key);
+    try {
+      await workspace.fs.delete(temporaryUri);
+    } catch {
+      // Ignore cleanup failures for preview cache files.
+    }
+  }
+
+  private async deleteTemporaryImageUris(): Promise<void> {
+    await Promise.all(
+      [...this.temporaryImageUris.values()].map((uri) =>
+        this.deleteTemporaryImageUri(uri),
+      ),
+    );
   }
 
   private async collapseAllContent() {

--- a/client/src/components/ContentNavigator/types.ts
+++ b/client/src/components/ContentNavigator/types.ts
@@ -80,6 +80,7 @@ export interface ContentAdapter {
   getChildItems: (parentItem: ContentItem) => Promise<ContentItem[]>;
   getContentOfItem: (item: ContentItem) => Promise<string>;
   getContentOfUri: (uri: Uri) => Promise<string>;
+  getContentOfUriAsBinary?: (uri: Uri) => Promise<Uint8Array>;
   getFolderPathForItem: (item: ContentItem) => Promise<string> | string;
   getItemOfUri: (uri: Uri) => Promise<ContentItem>;
   getParentOfItem: (item: ContentItem) => Promise<ContentItem | undefined>;

--- a/client/src/connection/itc/ItcServerAdapter.ts
+++ b/client/src/connection/itc/ItcServerAdapter.ts
@@ -262,6 +262,12 @@ class ItcServerAdapter implements ContentAdapter {
     return ((await this.getContentOfItem(item)) || "").toString();
   }
 
+  public async getContentOfUriAsBinary(uri: Uri): Promise<Uint8Array> {
+    const item = await this.getItemAtPath(getResourceId(uri));
+    const content = await this.getContentOfItem(item);
+    return Buffer.from(content, "binary");
+  }
+
   public async getItemOfUri(uri: Uri): Promise<ContentItem> {
     return this.getItemAtPath(getResourceId(uri));
   }

--- a/client/src/connection/rest/RestContentAdapter.ts
+++ b/client/src/connection/rest/RestContentAdapter.ts
@@ -336,6 +336,15 @@ class RestContentAdapter implements ContentAdapter {
     return data;
   }
 
+  public async getContentOfUriAsBinary(uri: Uri): Promise<Uint8Array> {
+    const resourceId = getResourceId(uri);
+    const { data } = await this.connection.get(resourceId + "/content", {
+      responseType: "arraybuffer",
+    });
+
+    return new Uint8Array(data);
+  }
+
   public async getContentOfItem(item: ContentItem): Promise<string> {
     return await this.getContentOfUri(item.vscUri);
   }

--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -325,6 +325,11 @@ class RestServerAdapter implements ContentAdapter {
     return await this.getContentOfItemAtPath(path);
   }
 
+  public async getContentOfUriAsBinary(uri: Uri): Promise<Uint8Array> {
+    const content = await this.getContentOfUri(uri);
+    return Buffer.from(content, "binary");
+  }
+
   private async getContentOfItemAtPath(path: string) {
     const response = await this.fileSystemApi.getFileContentFromSystem(
       {

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -180,8 +180,8 @@ describe("ContentDataProvider", async function () {
       id: "unique-id",
       label: "testFile",
       command: {
-        command: "vscode.open",
-        arguments: [uri],
+        command: "SAS.content.openResource",
+        arguments: [contentItem],
         title: "Open SAS File",
       },
       resourceUri: uri,


### PR DESCRIPTION
**Issue:**
#1834 

**Summary:**
(Taken from https://github.com/sassoftware/vscode-sas-extension/pull/1891)
Add the ability to view images stored on SAS Content and SAS Server through the build in VS Code image viewer. By default, VS Code can open images stored on your local machine, but not on SAS Content/Server. So to get around this we are temporarily downloading the files for view, then cleaning them up after the tab is closed.

**Testing:**
1. Upload an image file to SAS Server and SAS Content
2. Navigate to that file in the VS Code SAS Extension 
3. Open the file 
4. Ensure that the image displays inside a new tab in VS Code

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
