### PR TITLE
Fix: encoding corruption

### DIFF
--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -362,7 +362,7 @@ class ContentDataProvider
   }
 
   public writeFile(uri: Uri, content: Uint8Array): void | Promise<void> {
-    return this.model.saveContentToUri(uri, new TextDecoder().decode(content));
+    return this.model.saveContentToUri(uri, content);
   }
 
   public async deleteResource(item: ContentItem): Promise<boolean> {

--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -250,7 +250,7 @@ class ContentDataProvider
 
   public async provideTextDocumentContent(uri: Uri): Promise<string> {
     // use text document content provider to display the readonly editor for the files in the recycle bin
-    return await this.model.getContentByUri(uri);
+    return (await this.model.getContentByUri(uri)).toString();
   }
 
   public getChildren(item?: ContentItem): ProviderResult<ContentItem[]> {
@@ -269,34 +269,7 @@ class ContentDataProvider
   }
 
   public async readFile(uri: Uri): Promise<Uint8Array> {
-    const fileName = uri.path.split("/").pop() || "";
-    const extension = fileName.split(".").pop()?.toLowerCase() || "";
-    const binaryExtensions = [
-      "png",
-      "jpg",
-      "jpeg",
-      "gif",
-      "bmp",
-      "tiff",
-      "webp",
-      "svg",
-      "pdf",
-      "zip",
-      "tar",
-      "gz",
-      "exe",
-      "dll",
-      "so",
-      "bin",
-    ];
-
-    if (binaryExtensions.includes(extension)) {
-      return await this.model.getContentByUriAsBinary(uri);
-    }
-
-    return await this.model
-      .getContentByUri(uri)
-      .then((content) => new TextEncoder().encode(content));
+    return await this.model.getContentByUri(uri);
   }
 
   public async createFolder(
@@ -502,7 +475,8 @@ class ContentDataProvider
   }
 
   public readDirectory():
-    [string, FileType][] | Thenable<[string, FileType][]> {
+    | [string, FileType][]
+    | Thenable<[string, FileType][]> {
     throw new Error("Method not implemented.");
   }
 

--- a/client/src/components/ContentNavigator/ContentDataProvider.ts
+++ b/client/src/components/ContentNavigator/ContentDataProvider.ts
@@ -475,8 +475,7 @@ class ContentDataProvider
   }
 
   public readDirectory():
-    | [string, FileType][]
-    | Thenable<[string, FileType][]> {
+    [string, FileType][] | Thenable<[string, FileType][]> {
     throw new Error("Method not implemented.");
   }
 

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -135,7 +135,7 @@ export class ContentModel {
     return await this.contentAdapter.renameItem(item, name);
   }
 
-  public async saveContentToUri(uri: Uri, content: string): Promise<void> {
+  public async saveContentToUri(uri: Uri, content: Uint8Array): Promise<void> {
     await this.contentAdapter.updateContentOfItem(uri, content);
   }
 

--- a/client/src/components/ContentNavigator/ContentModel.ts
+++ b/client/src/components/ContentNavigator/ContentModel.ts
@@ -53,43 +53,18 @@ export class ContentModel {
     return await this.contentAdapter.getItemOfUri(uri);
   }
 
-  public async getContentByUri(uri: Uri): Promise<string> {
-    let data;
+  public async getContentByUri(uri: Uri): Promise<Uint8Array> {
     try {
-      data = (await this.contentAdapter.getContentOfUri(uri)).toString();
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (e) {
-      throw new Error(Messages.FileOpenError);
-    }
-
-    // We expect the returned data to be a string. If this isn't a string,
-    // we can't really open it
-    if (typeof data === "object") {
-      throw new Error(Messages.FileOpenError);
-    }
-
-    return data;
-  }
-
-  public async getContentByUriAsBinary(uri: Uri): Promise<Uint8Array> {
-    try {
-      if (this.contentAdapter.getContentOfUriAsBinary) {
-        return await this.contentAdapter.getContentOfUriAsBinary(uri);
-      }
-
-      const content = await this.getContentByUri(uri);
-      return new TextEncoder().encode(content);
+      return await this.contentAdapter.getContentOfUri(uri);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       throw new Error(Messages.FileOpenError);
     }
   }
 
-  public async downloadFile(item: ContentItem): Promise<Buffer | undefined> {
+  public async downloadFile(item: ContentItem): Promise<Uint8Array> {
     try {
-      const data = await this.contentAdapter.getContentOfItem(item);
-
-      return Buffer.from(data, "binary");
+      return await this.contentAdapter.getContentOfItem(item);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       throw new Error(Messages.FileDownloadError);

--- a/client/src/components/ContentNavigator/convert.ts
+++ b/client/src/components/ContentNavigator/convert.ts
@@ -379,7 +379,9 @@ export class NotebookToFlowConverter {
 
   public async content() {
     return isContentItem(this.resource)
-      ? await this.contentModel.getContentByUri(this.resource.vscUri)
+      ? (
+          await this.contentModel.getContentByUri(this.resource.vscUri)
+        ).toString()
       : (await workspace.fs.readFile(this.resource)).toString();
   }
 

--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -153,7 +153,7 @@ class ContentNavigator implements SubscriptionProvider {
             `${Date.now()}-${safeName}`,
           );
 
-          const bytes = await this.contentModel.getContentByUriAsBinary(
+          const bytes = await this.contentModel.getContentByUri(
             resource.vscUri,
           );
           await workspace.fs.writeFile(localUri, bytes);

--- a/client/src/components/ContentNavigator/types.ts
+++ b/client/src/components/ContentNavigator/types.ts
@@ -101,7 +101,7 @@ export interface ContentAdapter {
     newName: string,
   ) => Promise<ContentItem | undefined>;
   restoreItem?: (item: ContentItem) => Promise<boolean>;
-  updateContentOfItem(uri: Uri, content: string): Promise<void>;
+  updateContentOfItem(uri: Uri, content: Uint8Array): Promise<void>;
 }
 
 export enum ContentSourceType {

--- a/client/src/components/ContentNavigator/types.ts
+++ b/client/src/components/ContentNavigator/types.ts
@@ -78,9 +78,8 @@ export interface ContentAdapter {
   ) => Promise<ContentItem | undefined>;
   deleteItem: (item: ContentItem) => Promise<boolean>;
   getChildItems: (parentItem: ContentItem) => Promise<ContentItem[]>;
-  getContentOfItem: (item: ContentItem) => Promise<string>;
-  getContentOfUri: (uri: Uri) => Promise<string>;
-  getContentOfUriAsBinary?: (uri: Uri) => Promise<Uint8Array>;
+  getContentOfItem: (item: ContentItem) => Promise<Uint8Array>;
+  getContentOfUri: (uri: Uri) => Promise<Uint8Array>;
   getFolderPathForItem: (item: ContentItem) => Promise<string> | string;
   getItemOfUri: (uri: Uri) => Promise<ContentItem>;
   getParentOfItem: (item: ContentItem) => Promise<ContentItem | undefined>;

--- a/client/src/connection/itc/ItcServerAdapter.ts
+++ b/client/src/connection/itc/ItcServerAdapter.ts
@@ -332,12 +332,15 @@ class ItcServerAdapter implements ContentAdapter {
     }
   }
 
-  public async updateContentOfItem(uri: Uri, content: string): Promise<void> {
+  public async updateContentOfItem(
+    uri: Uri,
+    content: Uint8Array,
+  ): Promise<void> {
     try {
       const item = await this.getItemAtPath(getResourceId(uri));
       await this.execute(ScriptActions.UpdateFile, {
         filePath: item.uri,
-        content,
+        content: Buffer.from(content).toString("base64"),
       });
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {

--- a/client/src/connection/itc/ItcServerAdapter.ts
+++ b/client/src/connection/itc/ItcServerAdapter.ts
@@ -234,7 +234,7 @@ class ItcServerAdapter implements ContentAdapter {
     return outputFile;
   }
 
-  public async getContentOfItem(item: ContentItem): Promise<string> {
+  public async getContentOfItem(item: ContentItem): Promise<Uint8Array> {
     const filePath = item.uri;
     const outputFile = await this.getTempFile();
 
@@ -244,22 +244,22 @@ class ItcServerAdapter implements ContentAdapter {
         outputFile: outputFile.fsPath,
       });
       if (!success) {
-        return "";
+        return new Uint8Array();
       }
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
-      return "";
+      return new Uint8Array();
     }
 
     const file = await workspace.fs.readFile(outputFile);
     await workspace.fs.delete(outputFile);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return file as unknown as string;
+    return file as unknown as Uint8Array;
   }
 
-  public async getContentOfUri(uri: Uri): Promise<string> {
+  public async getContentOfUri(uri: Uri): Promise<Uint8Array> {
     const item = await this.getItemAtPath(getResourceId(uri));
-    return ((await this.getContentOfItem(item)) || "").toString();
+    return (await this.getContentOfItem(item)) || new Uint8Array();
   }
 
   public async getContentOfUriAsBinary(uri: Uri): Promise<Uint8Array> {

--- a/client/src/connection/itc/ItcServerAdapter.ts
+++ b/client/src/connection/itc/ItcServerAdapter.ts
@@ -262,12 +262,6 @@ class ItcServerAdapter implements ContentAdapter {
     return (await this.getContentOfItem(item)) || new Uint8Array();
   }
 
-  public async getContentOfUriAsBinary(uri: Uri): Promise<Uint8Array> {
-    const item = await this.getItemAtPath(getResourceId(uri));
-    const content = await this.getContentOfItem(item);
-    return Buffer.from(content, "binary");
-  }
-
   public async getItemOfUri(uri: Uri): Promise<ContentItem> {
     return this.getItemAtPath(getResourceId(uri));
   }

--- a/client/src/connection/itc/script/itc.ps1
+++ b/client/src/connection/itc/script/itc.ps1
@@ -455,8 +455,7 @@ class SASRunner {
       $fileRefName = ""
       $objFile = $this.objSAS.FileService.AssignFileref("", "DISK", $filePath, "", [ref] $fileRefName)
       $objStream = $objFile.OpenBinaryStream([SAS.StreamOpenMode]::StreamOpenModeForWriting);
-      $encoding = [System.Text.Encoding]::UTF8
-      $objStream.Write($encoding.GetBytes($content));
+      $objStream.Write([System.Convert]::FromBase64String($content));
 
       $objStream.Close()
       $this.objSAS.FileService.DeassignFileref($objFile.FilerefName)

--- a/client/src/connection/rest/RestContentAdapter.ts
+++ b/client/src/connection/rest/RestContentAdapter.ts
@@ -327,7 +327,7 @@ class RestContentAdapter implements ContentAdapter {
     return await this.getItemOfId(resourceId);
   }
 
-  public async getContentOfUri(uri: Uri): Promise<string> {
+  public async getContentOfUri(uri: Uri): Promise<Uint8Array> {
     const resourceId = getResourceId(uri);
     const { data } = await this.connection.get(resourceId + "/content", {
       responseType: "arraybuffer",
@@ -336,16 +336,7 @@ class RestContentAdapter implements ContentAdapter {
     return data;
   }
 
-  public async getContentOfUriAsBinary(uri: Uri): Promise<Uint8Array> {
-    const resourceId = getResourceId(uri);
-    const { data } = await this.connection.get(resourceId + "/content", {
-      responseType: "arraybuffer",
-    });
-
-    return new Uint8Array(data);
-  }
-
-  public async getContentOfItem(item: ContentItem): Promise<string> {
+  public async getContentOfItem(item: ContentItem): Promise<Uint8Array> {
     return await this.getContentOfUri(item.vscUri);
   }
 

--- a/client/src/connection/rest/RestContentAdapter.ts
+++ b/client/src/connection/rest/RestContentAdapter.ts
@@ -514,7 +514,10 @@ class RestContentAdapter implements ContentAdapter {
     return true;
   }
 
-  public async updateContentOfItem(uri: Uri, content: string): Promise<void> {
+  public async updateContentOfItem(
+    uri: Uri,
+    content: Uint8Array,
+  ): Promise<void> {
     const resourceId = getResourceId(uri);
     const { etag, lastModified, contentType } = this.getFileInfo(resourceId);
     const headers = {

--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -315,22 +315,17 @@ class RestServerAdapter implements ContentAdapter {
     return sortedContentItems(allItems);
   }
 
-  public async getContentOfItem(item: ContentItem): Promise<string> {
+  public async getContentOfItem(item: ContentItem): Promise<Uint8Array> {
     const path = this.trimComputePrefix(item.uri);
     return await this.getContentOfItemAtPath(path);
   }
 
-  public async getContentOfUri(uri: Uri): Promise<string> {
+  public async getContentOfUri(uri: Uri): Promise<Uint8Array> {
     const path = this.trimComputePrefix(getResourceId(uri));
     return await this.getContentOfItemAtPath(path);
   }
 
-  public async getContentOfUriAsBinary(uri: Uri): Promise<Uint8Array> {
-    const content = await this.getContentOfUri(uri);
-    return Buffer.from(content, "binary");
-  }
-
-  private async getContentOfItemAtPath(path: string) {
+  private async getContentOfItemAtPath(path: string): Promise<Uint8Array> {
     const response = await this.fileSystemApi.getFileContentFromSystem(
       {
         sessionId: this.sessionId,
@@ -345,9 +340,9 @@ class RestServerAdapter implements ContentAdapter {
 
     // Disabling typescript checks on this line as this function is typed
     // to return AxiosResponse<void,any>. However, it appears to return
-    // AxiosResponse<string,>.
+    // AxiosResponse<Uint8Array,>.
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return response.data as unknown as string;
+    return response.data as unknown as Uint8Array;
   }
 
   public async getFolderPathForItem(): Promise<string> {

--- a/client/src/connection/rest/RestServerAdapter.ts
+++ b/client/src/connection/rest/RestServerAdapter.ts
@@ -488,14 +488,17 @@ class RestServerAdapter implements ContentAdapter {
     }
   }
 
-  public async updateContentOfItem(uri: Uri, content: string): Promise<void> {
+  public async updateContentOfItem(
+    uri: Uri,
+    content: Uint8Array,
+  ): Promise<void> {
     const filePath = this.trimComputePrefix(getResourceId(uri));
     return await this.updateContentOfItemAtPath(filePath, content);
   }
 
   private async updateContentOfItemAtPath(
     filePath: string,
-    content: string | ArrayBufferLike,
+    content: Uint8Array | ArrayBufferLike,
   ): Promise<void> {
     const { etag } = await this.getFileInfo(filePath);
     const data = {

--- a/client/test/components/ContentNavigator/ContentDataProvider.test.ts
+++ b/client/test/components/ContentNavigator/ContentDataProvider.test.ts
@@ -339,7 +339,7 @@ describe("ContentDataProvider", async function () {
     const dataProvider = createDataProvider();
 
     axiosInstance.get.withArgs("uri://test/content").resolves({
-      data: "/* file content */",
+      data: new TextEncoder().encode("/* file content */"),
       headers: { etag: "1234", "last-modified": "5678" },
     });
 


### PR DESCRIPTION
**Summary**
Fixes an issue where reading or writing files with non-UTF-8 encodings (e.g. WLatin1) causes content corruption. The file data was being converted to/from string mid-pipeline, destroying the original byte representation.

**Problem**
When a user opens or saves a file encoded in a non-UTF-8 encoding (e.g. WLatin1), the content becomes corrupted, special characters are mangled or lost entirely.

**Root Cause**
File content was passed as string through the entire read/write pipeline, causing binary data to be silently corrupted for any non-UTF-8 encoding.

**Solution**
Replaced string with Uint8Array throughout the read/write pipeline, from the ContentAdapter interface down through all three adapter implementations, ContentModel, and ContentDataProvider. Places that need a string call .toString() at the boundary. For the ITC adapter, file content is now sent as base64 to the PowerShell script, which decodes it as raw bytes instead of assuming a charset. Updated the test mock accordingly.

**Testing**
npm run lint 
npm run compile 
npm test

To reproduce the bug:
1. Create a .sas file.
2. Change the encoding from UTF-8 to another encoding. I used Windows-1252.
3. Insert a non-ASCII character. I used Ü.
4. Save the file.
5. Reopen the file and change the encoding from UTF-8 back to the previously selected encoding.
6. The bug is that Ü should not appear.

It is necessary to verify that the bug cannot be reproduced in SAS Content, SAS Server, or when using an IOM connection (instructions for configuring it are available here https://rndconfluence.sas.com/spaces/COREUI/pages/967742347/Contributor+Guide+FAQ#ContributorGuide&FAQ-RemoteIOMconnectivity).

The changes also affected file upload and download functionality.
