### PR TITLE
fix: temp image clean up

### DIFF
--- a/client/src/components/ContentNavigator/index.ts
+++ b/client/src/components/ContentNavigator/index.ts
@@ -92,6 +92,11 @@ class ContentNavigator implements SubscriptionProvider {
       `${config.sourceType}ReadOnly`,
       this.contentDataProvider,
     );
+
+    // Remove any image preview cache files left behind by a previous session
+    // (e.g. VS Code was force-closed or the extension host crashed/timed-out
+    // before the tab-close/dispose cleanup could run).
+    void this.purgeImagePreviewCache();
   }
 
   get onDidManipulateFile(): Event<FileManipulationEvent> {
@@ -118,7 +123,7 @@ class ContentNavigator implements SubscriptionProvider {
         );
       }),
       new Disposable(() => {
-        void this.deleteTemporaryImageUris();
+        void this.purgeImagePreviewCache();
       }),
       commands.registerCommand(
         `${SAS}.openResource`,
@@ -135,11 +140,7 @@ class ContentNavigator implements SubscriptionProvider {
             return;
           }
 
-          const globalStorageUri = getGlobalStorageUri();
-          const imagePreviewCacheUri = Uri.joinPath(
-            globalStorageUri,
-            "imagePreviewCache",
-          );
+          const imagePreviewCacheUri = this.imagePreviewCacheUri();
           try {
             await workspace.fs.readDirectory(imagePreviewCacheUri);
           } catch {
@@ -522,6 +523,10 @@ class ContentNavigator implements SubscriptionProvider {
     await commands.executeCommand("vscode.open", itemUri);
   }
 
+  private imagePreviewCacheUri(): Uri {
+    return Uri.joinPath(getGlobalStorageUri(), "imagePreviewCache");
+  }
+
   private async deleteTemporaryImageUri(input: unknown): Promise<void> {
     const uri =
       input instanceof Uri
@@ -547,12 +552,16 @@ class ContentNavigator implements SubscriptionProvider {
     }
   }
 
-  private async deleteTemporaryImageUris(): Promise<void> {
-    await Promise.all(
-      [...this.temporaryImageUris.values()].map((uri) =>
-        this.deleteTemporaryImageUri(uri),
-      ),
-    );
+  private async purgeImagePreviewCache(): Promise<void> {
+    this.temporaryImageUris.clear();
+    try {
+      await workspace.fs.delete(this.imagePreviewCacheUri(), {
+        recursive: true,
+        useTrash: false,
+      });
+    } catch {
+      // Nothing to clean up if the cache directory does not exist.
+    }
   }
 
   private async collapseAllContent() {


### PR DESCRIPTION
**Issue:**
https://github.com/sassoftware/vscode-sas-extension/issues/1834

**Summary:**
we can't guarantee a seamless disposal... stuff happens. so add a case to the constructor that will clear the image cache as well. that way even if there were left over artifacts,next time you open the extension they will get cleaned up

**Testing:**
1. In a terminal, navigate /Users/<userid>/Library/Application Support/Code/User/globalStorage/sas.sas-lsp (mac)
2. Then open the SAS VS Code extension
3. On a Viya connection, open an image file from either SAS Content or SAS Server. 
4. "ls" in your terminal, notice there should be a "imagePreviewCache" dir
5. 'cd' into that dir
6. notice the image file you just opened
7. now close vs code/wait for it to time out
8. After VS Code closes, that "imagePreviewCache" dir may or may not still have files
9. If it is empty, great! Everything worked how it should (without this extra code)
10. If it isn't empty, open the SAS Extension in VS Code again, wait for the sign in to complete, and verify "imagePreviewCache" should now be empty

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
