### PR TITLE
fix: avoid SAS server crashes when switching language modes

### DIFF
--- a/client/test/languageServer/languageModeSwitch.test.ts
+++ b/client/test/languageServer/languageModeSwitch.test.ts
@@ -1,0 +1,90 @@
+// Copyright © 2022-2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from "vscode";
+
+import * as assert from "assert";
+
+import { getUri } from "../utils";
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("Language mode switch", () => {
+  let sasDoc: vscode.TextDocument;
+  const sasDocUri = getUri("SampleCode.sas");
+
+  before(async () => {
+    sasDoc = await vscode.workspace.openTextDocument(sasDocUri);
+    await vscode.window.showTextDocument(sasDoc);
+    await sleep(5000);
+  });
+
+  after(async () => {
+    // Restore so other test suites see a SAS-mode document
+    if (sasDoc.languageId !== "sas") {
+      sasDoc = await vscode.languages.setTextDocumentLanguage(sasDoc, "sas");
+      await sleep(1000);
+    }
+  });
+
+  it("provides SAS hover before switching language", async () => {
+    const hovers: vscode.Hover[] = await vscode.commands.executeCommand(
+      "vscode.executeHoverProvider",
+      sasDocUri,
+      new vscode.Position(0, 0),
+    );
+    assert.ok(hovers?.length > 0, "SAS hover should be active before switch");
+  });
+
+  it("switches to Python without crashing the SAS server", async () => {
+    sasDoc = await vscode.languages.setTextDocumentLanguage(sasDoc, "python");
+    // Give the language server time to process the language switch.
+    // Switching from SAS to Python triggers a didClose event for the SAS document.
+    await sleep(2000);
+
+    // Previously, switching a SAS file to another language could lead to
+    // requests being sent for a document the server was no longer tracking.
+    // This hover request helps verify that the server does not crash after
+    // the language change.
+    await vscode.commands.executeCommand(
+      "vscode.executeHoverProvider",
+      sasDocUri,
+      new vscode.Position(0, 0),
+    );
+  });
+
+  it("still serves SAS features for other documents after the switch", async () => {
+    // Open a second SAS document. If the server crashed, it cannot respond.
+    const otherUri = getUri("SampleCode2.sas");
+    const otherDoc = await vscode.workspace.openTextDocument(otherUri);
+    await vscode.window.showTextDocument(otherDoc);
+    await sleep(2000);
+
+    const hovers: vscode.Hover[] = await vscode.commands.executeCommand(
+      "vscode.executeHoverProvider",
+      otherUri,
+      new vscode.Position(0, 0),
+    );
+    assert.ok(
+      hovers?.length > 0,
+      "SAS server must still respond for other SAS documents after a language switch",
+    );
+  });
+
+  it("resumes SAS features when switched back to SAS", async () => {
+    await vscode.window.showTextDocument(sasDoc);
+    sasDoc = await vscode.languages.setTextDocumentLanguage(sasDoc, "sas");
+    await sleep(2000);
+
+    const hovers: vscode.Hover[] = await vscode.commands.executeCommand(
+      "vscode.executeHoverProvider",
+      sasDocUri,
+      new vscode.Position(0, 0),
+    );
+    assert.ok(
+      hovers?.length > 0,
+      "SAS hover should resume after switching back to SAS",
+    );
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,13 +4,19 @@ import {
   CancellationToken,
   CodeActionKind,
   CompletionItemKind,
+  CompletionRegistrationOptions,
   CompletionTriggerKind,
   Connection,
   DidChangeConfigurationParams,
   DidChangeWatchedFilesParams,
+  DocumentFormattingRegistrationOptions,
   DocumentHighlightParams,
+  DocumentOnTypeFormattingRegistrationOptions,
+  DocumentSelector,
   DocumentSymbol,
+  DocumentSymbolRegistrationOptions,
   ExecuteCommandParams,
+  HoverRegistrationOptions,
   InitializeResult,
   Location,
   Position,
@@ -22,6 +28,7 @@ import {
   RenameParams,
   ResultProgressReporter,
   SemanticTokensRequest,
+  SignatureHelpRegistrationOptions,
   TextDocumentPositionParams,
   TextDocumentSyncKind,
   Unregistration,
@@ -69,37 +76,56 @@ export const runServer = (
     }
     _pyrightLanguageProvider.initialize(params, [], []);
 
+    const sasSel: DocumentSelector = [{ language: "sas" }];
+    const formattingOpts: DocumentFormattingRegistrationOptions = {
+      documentSelector: sasSel,
+    };
+    const onTypeFormattingOpts: DocumentOnTypeFormattingRegistrationOptions = {
+      documentSelector: sasSel,
+      firstTriggerCharacter: "\n",
+      moreTriggerCharacter: [";"],
+    };
+    const docSymbolOpts: DocumentSymbolRegistrationOptions = {
+      documentSelector: sasSel,
+      workDoneProgress: true,
+    };
+    const hoverOpts: HoverRegistrationOptions = {
+      documentSelector: sasSel,
+      workDoneProgress: true,
+    };
+    const completionOpts: CompletionRegistrationOptions = {
+      documentSelector: sasSel,
+      triggerCharacters: _pyrightLanguageProvider.getClientCapabilities()
+        .hasVisualStudioExtensionsCapability
+        ? [".", "[", "@", '"', "'", " "]
+        : [".", "[", '"', "'", " "],
+      resolveProvider: true,
+      workDoneProgress: true,
+      completionItem: {
+        labelDetailsSupport: true,
+      },
+    };
+    const sigHelpOpts: SignatureHelpRegistrationOptions = {
+      documentSelector: sasSel,
+      triggerCharacters: ["(", ",", ")"],
+      workDoneProgress: true,
+    };
     const result: InitializeResult = {
       capabilities: {
         textDocumentSync: TextDocumentSyncKind.Incremental,
         semanticTokensProvider: {
+          documentSelector: sasSel,
           legend,
           full: true,
         },
-        documentFormattingProvider: true,
-        foldingRangeProvider: true,
-        documentOnTypeFormattingProvider: {
-          firstTriggerCharacter: "\n",
-          moreTriggerCharacter: [";"],
-        },
-        documentSymbolProvider: { workDoneProgress: true },
+        documentFormattingProvider: formattingOpts,
+        foldingRangeProvider: { documentSelector: sasSel },
+        documentOnTypeFormattingProvider: onTypeFormattingOpts,
+        documentSymbolProvider: docSymbolOpts,
         workspaceSymbolProvider: { workDoneProgress: true },
-        hoverProvider: { workDoneProgress: true },
-        completionProvider: {
-          triggerCharacters: _pyrightLanguageProvider.getClientCapabilities()
-            .hasVisualStudioExtensionsCapability
-            ? [".", "[", "@", '"', "'", " "]
-            : [".", "[", '"', "'", " "],
-          resolveProvider: true,
-          workDoneProgress: true,
-          completionItem: {
-            labelDetailsSupport: true,
-          },
-        },
-        signatureHelpProvider: {
-          triggerCharacters: ["(", ",", ")"],
-          workDoneProgress: true,
-        },
+        hoverProvider: hoverOpts,
+        completionProvider: completionOpts,
+        signatureHelpProvider: sigHelpOpts,
         workspace: {
           workspaceFolders: {
             supported: true,


### PR DESCRIPTION
Bug fix for #1303 

**Summary:**
Scoped SAS language providers to SAS documents only by adding a DocumentSelector ({ language: "sas" }) to capabilities including hover, folding ranges, formatting, completions, semantic tokens, document symbols, and signature help. This prevents the SAS language server from receiving requests for documents that have been switched to another language mode after being removed from documentPool, avoiding potential server crashes.

Also added an integration test covering the language mode switch workflow: verifying SAS features before the switch, switching a SAS document to Python, confirming the server remains responsive for other SAS documents, and verifying SAS features resume when switching the document back to SAS.

**Testing:**
```
npm run compile
npm test
```
Manual Testing

Open a .sas file and verify SAS features (such as hover) are available.
Change the file's language mode from SAS to Python.
Verify the SAS language server remains responsive and does not crash.
Open another .sas file and confirm SAS features are still available.
Change the original file back to SAS and verify SAS features resume.
Expected Result

Switching a .sas file to Python should not cause the SAS language server to crash. SAS language features should continue to work for other SAS documents, and the original file should regain SAS features when switched back to SAS mode.

**TODOs:**
