### PR TITLE
feat: restrict download of files, folders, and results

### DIFF
--- a/package.json
+++ b/package.json
@@ -912,7 +912,7 @@
       "webview/context": [
         {
           "command": "SAS.saveHTML",
-          "when": "webviewId =~ /SASResultPanel/"
+          "when": "webviewId =~ /SASResultPanel/ && SAS.allowDownload"
         }
       ],
       "view/title": [
@@ -1022,7 +1022,7 @@
         },
         {
           "command": "SAS.content.downloadResource",
-          "when": "(viewItem =~ /update/ || viewItem =~ /createChild/) && view == contentdataprovider",
+          "when": "(viewItem =~ /update/ || viewItem =~ /createChild/) && view == contentdataprovider && SAS.allowDownload",
           "group": "uploaddownloadgroup@0"
         },
         {
@@ -1092,7 +1092,7 @@
         },
         {
           "command": "SAS.server.downloadResource",
-          "when": "(viewItem =~ /update/ || viewItem =~ /createChild/) && view == serverdataprovider",
+          "when": "(viewItem =~ /update/ || viewItem =~ /createChild/) && view == serverdataprovider && SAS.allowDownload",
           "group": "uploaddownloadgroup@0"
         },
         {

--- a/website/docs/Configurations/Profiles/viya.md
+++ b/website/docs/Configurations/Profiles/viya.md
@@ -27,6 +27,14 @@ For more information about Client IDs and the authentication process, please see
 
 ## Context Properties
 
-In Viya environments, SAS Administrators have the option to specify the `allowDownload` property on the context definition for the SAS Compute Server. This property determines whether a user is able to download tables from the Libraries pane. The following screenshot provides an example context definition setup:
+In Viya environments, SAS Administrators have the option to specify the `allowDownload` property on the context definition for the SAS Compute Server. This property determines the appearance of the `Download` menu item in these areas:
+
+- Tables in the Libraries pane.
+
+- Files and folders in the SAS Content and SAS Server panes.
+
+- The Results pane.
+
+The following screenshot provides an example context definition setup:
 
 ![context definition for allowDownload setting](/images/context-allow-download.png)


### PR DESCRIPTION
**Summary:**
More changes to restrict the "Download" menu item which now includes files/folders in the SAS Content and SAS Server panes as well as the Results pane. I updated the website to account for these new areas. This change is only for Viya connection profiles.

**Testing:**
Can follow these steps to add the attribute on a Viya profile.

1. Open SAS Environment Manager via the endpoint used for your active profile.
2. Select the "Contexts" option from the left-hand sidebar.
3. From the "View:" dropdown, select "Compute contexts" and then the context used for your profile.
4. With your context selected, click the edit icon in the top right of the Basic Properties view.
5. Click the plus (+) icon in the attribute section to add a new attribute.
6. In this "New Attribute" dialog, set "Attribute:" to "allowDownload" and "Value" to "false".
7. Click OK and then Save.
8. You'll likely need to refresh your connection to pick up the new setting in the profile.

With this defined on the profile, then make sure that the "Download" menu item no longer appears on files and folders under SAS Content/Server. 

For testing it on Results, you can run `proc print data=sashelp.class;run;` in a SAS Program and right-click the Results pane. You should not see the "Download" option there either.

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
