### PR TITLE
fix: library cache refresh

### DIFF
--- a/client/src/components/LibraryNavigator/LibraryAdapterFactory.ts
+++ b/client/src/components/LibraryNavigator/LibraryAdapterFactory.ts
@@ -6,14 +6,17 @@ import { ConnectionType } from "../profile";
 import { LibraryAdapter } from "./types";
 
 class LibraryAdapterFactory {
-  public create(connectionType: ConnectionType): LibraryAdapter {
+  public create(
+    connectionType: ConnectionType,
+    onConnect?: () => void,
+  ): LibraryAdapter {
     switch (connectionType) {
       case ConnectionType.IOM:
       case ConnectionType.COM:
-        return new ItcLibraryAdapter();
+        return new ItcLibraryAdapter(onConnect);
       case ConnectionType.Rest:
       default:
-        return new RestLibraryAdapter();
+        return new RestLibraryAdapter(onConnect);
     }
   }
 }

--- a/client/src/components/LibraryNavigator/LibraryDataProvider.ts
+++ b/client/src/components/LibraryNavigator/LibraryDataProvider.ts
@@ -179,6 +179,11 @@ class LibraryDataProvider
     return new Disposable(() => {});
   }
 
+  // Invalidates the tree cache so libraries/tables are refetched.
+  public refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
   public useAdapter(libraryAdapter: LibraryAdapter): void {
     this.model.useAdapter(libraryAdapter);
     this._onDidChangeTreeData.fire(undefined);

--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -194,7 +194,10 @@ class LibraryNavigator implements SubscriptionProvider {
       return;
     }
 
-    return new LibraryAdapterFactory().create(activeProfile.connectionType);
+    return new LibraryAdapterFactory().create(
+      activeProfile.connectionType,
+      () => this.libraryDataProvider.refresh(),
+    );
   }
 }
 

--- a/client/src/connection/itc/ItcLibraryAdapter.ts
+++ b/client/src/connection/itc/ItcLibraryAdapter.ts
@@ -35,9 +35,14 @@ class ItcLibraryAdapter implements LibraryAdapter {
     (formatNames) => this.fetchFormatCategories(formatNames),
   );
 
+  public constructor(private readonly onConnect?: () => void) {}
+
   public async connect(): Promise<void> {
     this.hasEstablishedConnection = true;
     this.formatCategories.clear();
+    if (this.onConnect) {
+      this.onConnect();
+    }
   }
 
   public async setup(): Promise<void> {

--- a/client/src/connection/rest/RestLibraryAdapter.ts
+++ b/client/src/connection/rest/RestLibraryAdapter.ts
@@ -36,7 +36,7 @@ class RestLibraryAdapter implements LibraryAdapter {
     (formatNames) => this.fetchFormatCategories(formatNames),
   );
 
-  public constructor() {}
+  public constructor(private readonly onConnect?: () => void) {}
 
   public async connect(): Promise<void> {
     const session = getSession();
@@ -50,6 +50,10 @@ class RestLibraryAdapter implements LibraryAdapter {
     this.FormatsApi = FormatsApi(getApiConfig());
     // Format definitions are session scoped, so previously resolved categories no longer apply.
     this.formatCategories.clear();
+
+    if (this.onConnect) {
+      this.onConnect();
+    }
   }
 
   public async setup(): Promise<void> {


### PR DESCRIPTION
**Issue:**
https://github.com/sassoftware/vscode-sas-extension/issues/981

**Summary:**
when your session has timed out, and a new session is created, we need to refresh the libraries pane automatically.

The architecture made this a little interesting... I wanted to trigger the refresh after a retryOnFail when a new connection needed to be created. But the refresh function needed to be defined at the LibraryDataProvider level so it could fire off the _onDidChangeTreeData event. So in order to call it in the Adapters, I had to pass it through where the LibraryAdapterFactory gets called and created.

**Testing:**

1. Create a new SAS Program with code that will create a temp library:

libname ATEST '/tmp';

data ATEST.test;
set sashelp.class;
run;

2. Wait until your compute context times out (work on something else for 30 minutes, then come back)
3. Expand SASHELP, or some other library
4. Toast will appear indicating that it needs to reconnect to a compute session
5. After a reconnect happens, the Library Pane should refresh and the Temp Library should disappear

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
