### PR TITLE
fix: skip client secret if empty

### DIFF
--- a/client/src/connection/rest/auth.ts
+++ b/client/src/connection/rest/auth.ts
@@ -30,16 +30,19 @@ export async function refreshToken(
   await rootApi.headersForRoot().catch((err) => {
     if (err.response?.status === 401) {
       // token expired, try refresh token
+
+      const tokenParams = new URLSearchParams({
+        client_id: clientId,
+        grant_type: "refresh_token",
+        refresh_token: tokens?.refresh_token,
+      });
+
+      if (clientSecret) {
+        tokenParams.set("client_secret", clientSecret);
+      }
+
       return axios
-        .post(
-          `${config.endpoint}/SASLogon/oauth/token`,
-          new URLSearchParams({
-            client_id: clientId,
-            client_secret: clientSecret,
-            grant_type: "refresh_token",
-            refresh_token: tokens?.refresh_token,
-          }).toString(),
-        )
+        .post(`${config.endpoint}/SASLogon/oauth/token`, tokenParams.toString())
         .then(
           (res) => {
             tokens = res.data;
@@ -109,16 +112,21 @@ export async function getTokens(
     throw new Error(l10n.t("No authorization code"));
   }
 
+  const tokenParams = new URLSearchParams({
+    client_id: clientId,
+    grant_type: "authorization_code",
+    code: authCode,
+    code_verifier: codeVerifier,
+  });
+
+  if (clientSecret) {
+    tokenParams.set("client_secret", clientSecret);
+  }
+
   tokens = (
     await axios.post(
       `${config.endpoint}/SASLogon/oauth/token`,
-      new URLSearchParams({
-        client_id: clientId,
-        client_secret: clientSecret,
-        grant_type: "authorization_code",
-        code: authCode,
-        code_verifier: codeVerifier,
-      }).toString(),
+      tokenParams.toString(),
     )
   ).data;
   return tokens;

--- a/client/test/connection/rest/auth.test.ts
+++ b/client/test/connection/rest/auth.test.ts
@@ -1,0 +1,66 @@
+import axios from "axios";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import { Config } from "../../../src/connection/rest";
+import * as computeApi from "../../../src/connection/rest/api/compute";
+import { refreshToken } from "../../../src/connection/rest/auth";
+
+describe("auth.refreshToken - client secret handling", () => {
+  let axiosPostStub: sinon.SinonStub;
+
+  const baseTokens = { access_token: "old", refresh_token: "r" };
+
+  beforeEach(() => {
+    // Stub RootApi to simulate headersForRoot throwing 401 so refresh path runs
+    sinon.stub(computeApi, "RootApi").callsFake(() => {
+      // Return an object shaped like the RootApi return value with only headersForRoot
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrow shape for test
+      return {
+        headersForRoot: () => Promise.reject({ response: { status: 401 } }),
+      } as any;
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("includes client_secret when provided in config", async () => {
+    const config: Config = {
+      endpoint: "https://test-host.sas.com",
+      clientId: "cid",
+      clientSecret: "s3cr3t",
+    };
+
+    axiosPostStub = sinon
+      .stub(axios, "post")
+      .resolves({ data: { access_token: "new", refresh_token: "nr" } });
+
+    const tokens = await refreshToken(config, baseTokens);
+
+    expect(axiosPostStub.calledOnce).to.equal(true);
+    const bodyArg = axiosPostStub.firstCall.args[1];
+    expect(String(bodyArg)).to.include("client_secret=s3cr3t");
+    expect(tokens?.access_token).to.equal("new");
+  });
+
+  it("does not include client_secret when not provided in config", async () => {
+    const config: Config = {
+      endpoint: "https://test-host.sas.com",
+      clientId: "cid",
+      clientSecret: "",
+    };
+
+    axiosPostStub = sinon
+      .stub(axios, "post")
+      .resolves({ data: { access_token: "new2", refresh_token: "nr2" } });
+
+    const tokens = await refreshToken(config, baseTokens);
+
+    expect(axiosPostStub.calledOnce).to.equal(true);
+    const bodyArg = axiosPostStub.firstCall.args[1];
+    expect(String(bodyArg)).to.not.include("client_secret=");
+    expect(tokens?.access_token).to.equal("new2");
+  });
+});


### PR DESCRIPTION
**Summary:**
Conditionally include the client secret in the token refresh request only when a client secret is provided.

**Testing:**
Added unit tests to verify that client secret is included in the body when provided and excluded when not provided.

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
