### PR TITLE
fix: sas notebook filename

### DIFF
--- a/client/src/components/utils/SASCodeDocument.ts
+++ b/client/src/components/utils/SASCodeDocument.ts
@@ -139,18 +139,21 @@ export class SASCodeDocument {
     let fileName = this.parameters.fileName;
     let uri = this.parameters.uri;
 
-    if (uri !== undefined && uri.startsWith("sasContent")) {
-      // check if a uri is available, and if it is coming from sasContent.
-      // if so, parse out our service representation and add the sascontent prefix.
-      // should look like this at the end: "sascontent:/files/files/<uuid>"
-      uri = Uri.parse(uri).query.replace("id=", "sascontent:");
-      return "%let _SASPROGRAMFILE = %nrquote(%nrstr(" + uri + "));\n" + code;
-    } else if (fileName !== undefined) {
-      // if we are not in sasContent, we want to use the fileName instead
-      fileName = fileName.replace(/[('")]/g, "%$&");
-      return (
-        "%let _SASPROGRAMFILE = %nrquote(%nrstr(" + fileName + "));\n" + code
-      );
+    if (uri !== undefined) {
+      const uriObj = Uri.parse(uri);
+      if (uriObj.query.startsWith("id=/files/files")) {
+        // check if a uri is available, and if it is coming from sasContent.
+        // if so, parse out our service representation and add the sascontent prefix.
+        // should look like this at the end: "sascontent:/files/files/<uuid>"
+        uri = uriObj.query.replace("id=", "sascontent:");
+        return "%let _SASPROGRAMFILE = %nrquote(%nrstr(" + uri + "));\n" + code;
+      } else if (fileName !== undefined) {
+        // if we are not in sasContent, we want to use the fileName instead
+        fileName = fileName.replace(/[('")]/g, "%$&");
+        return (
+          "%let _SASPROGRAMFILE = %nrquote(%nrstr(" + fileName + "));\n" + code
+        );
+      }
     }
 
     // if a fileName was not found, just return the raw code

--- a/client/src/components/utils/SASCodeDocumentHelper.ts
+++ b/client/src/components/utils/SASCodeDocumentHelper.ts
@@ -161,7 +161,11 @@ function getFileName(textDocument: TextDocument): string {
 
   // Massage file path value
   const scheme = textDocument.uri?.scheme;
-  if (scheme === "sasServer" && params.has("id")) {
+  const isServerFile =
+    scheme === "sasServer" ||
+    (scheme === "vscode-notebook-cell" &&
+      textDocument.uri?.query?.startsWith("id=/compute/sessions/"));
+  if (isServerFile && params.has("id")) {
     const id = params.get("id");
     // Viya - server file
     // id = /compute/sessions/<guid>/files/~fs~studiodev~fs~myprogram.sas

--- a/client/test/components/util/SASCodeDocument.test.ts
+++ b/client/test/components/util/SASCodeDocument.test.ts
@@ -272,6 +272,29 @@ cas; caslib _all_ assign;
     );
   });
 
+  it("wrapCodeWithSASProgramFileName with sas notebook URI", () => {
+    const parameters: SASCodeDocumentParameters = {
+      languageId: "sas",
+      code: "this is the code",
+      selectedCode: "",
+      uri: "vscode-notebook-cell:/testContent.sasnb?id%3D%2Ffiles%2Ffiles%2F916e7678-a1c9-4f5b-9d72-5af9f19fae87#W0sc2FzQ29udGVudA%3D%3D",
+      fileName: "filename.sas",
+      htmlStyle: "Illuminate",
+      outputHtml: false,
+      checkKeyword: async () => false,
+    };
+
+    const sasCodeDoc = new SASCodeDocument(parameters);
+    const wrappedCode = sasCodeDoc.getWrappedCode();
+
+    assert(
+      wrappedCode.includes(
+        "%let _SASPROGRAMFILE = %nrquote(%nrstr(sascontent:/files/files/916e7678-a1c9-4f5b-9d72-5af9f19fae87));",
+      ),
+      "wrapped code should include _SASPROGRAMFILE with sascontent: prefix from sasContent URI",
+    );
+  });
+
   it("getProblemLocationInRawCode", async () => {
     const parameters: SASCodeDocumentParameters = {
       languageId: "sas",

--- a/client/test/components/util/SASCodeDocumentHelper.test.ts
+++ b/client/test/components/util/SASCodeDocumentHelper.test.ts
@@ -82,6 +82,46 @@ describe("sas code document helper", () => {
       getWordRangeAtPosition: () => undefined,
     };
 
+    const mockNotebookDocument = {
+      languageId: "sas",
+      getText: function () {
+        return "data _null_; run;";
+      },
+      uri: vscode.Uri.parse(
+        "vscode-notebook-cell:/sasNotebookServer.sasnb?id%3D%2Fcompute%2Fsessions%2F63d47209-f7cc-47df-b75c-605578b59a0f-ses0000%2Ffiles%2F~fs~dmtesting~fs~naurqu~fs~sasNotebookServer.sasnb#W0sc2FzU2VydmVy",
+      ),
+      fileName: "/sasNotebookServer.sasnb",
+      lineCount: 1,
+      lineAt: function (lineOrPos: number | vscode.Position = 0) {
+        const lineNumber =
+          typeof lineOrPos === "number" ? lineOrPos : lineOrPos.line;
+        return {
+          lineNumber,
+          text: "data _null_; run;",
+          range: new vscode.Range(lineNumber, 0, lineNumber, 16),
+          rangeIncludingLineBreak: new vscode.Range(
+            lineNumber,
+            0,
+            lineNumber,
+            17,
+          ),
+          firstNonWhitespaceCharacterIndex: 0,
+          isEmptyOrWhitespace: false,
+        };
+      },
+      isUntitled: false,
+      version: 1,
+      isDirty: false,
+      isClosed: false,
+      save: async () => true,
+      eol: 1,
+      offsetAt: () => 0,
+      positionAt: () => new vscode.Position(0, 0),
+      validateRange: (range: vscode.Range) => range,
+      validatePosition: (pos: vscode.Position) => pos,
+      getWordRangeAtPosition: () => undefined,
+    };
+
     it("should construct parameters with default values", () => {
       const params = getCodeDocumentConstructionParameters(mockTextDocument);
       assert.equal(params.languageId, "sas");
@@ -118,6 +158,16 @@ describe("sas code document helper", () => {
       const params = getCodeDocumentConstructionParameters(mockTextDocument);
       // the results.html.style should be applied
       assert.equal(params.htmlStyle, "HTMLBlue");
+    });
+
+    it("should generate correct file name for sas notebook", () => {
+      const params =
+        getCodeDocumentConstructionParameters(mockNotebookDocument);
+      // the results.html.style should be applied
+      assert.equal(
+        params.fileName,
+        "/dmtesting/naurqu/sasNotebookServer.sasnb",
+      );
     });
   });
 });


### PR DESCRIPTION
**Summary:**
sas notebook names in sas content and server were not being correctly identified,
which caused issues for the _SASPROGRAMFILE variable

**Testing:**
1. create a new sas notebook (file with .sasnb extension) in sas server, sas content, and locally
2. add a code block and include this line in your code
**%put &=_SASPROGRAMFILE;**
3. In the log, verify that the _SASPROGRAMFILE printout is correct (ie: sascontent:/files/files/<uuid>, /dmtesting/folder/filename.sasnb, Users/path/to/file/file.sasnb...)

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)
