### PR TITLE
fix: refresh table properties after code runs

### DIFF
--- a/client/src/components/LibraryNavigator/index.ts
+++ b/client/src/components/LibraryNavigator/index.ts
@@ -151,7 +151,10 @@ class LibraryNavigator implements SubscriptionProvider {
 
   public refreshOpenTableViewers(): void {
     Object.values(this.webviewManager.panels).forEach((panel) => {
-      if (panel instanceof DataViewer) {
+      if (
+        panel instanceof DataViewer ||
+        panel instanceof TablePropertiesViewer
+      ) {
         panel.refreshData();
       }
     });
@@ -174,6 +177,8 @@ class LibraryNavigator implements SubscriptionProvider {
           columns,
           showPropertiesTab,
           focusedColumn,
+          () => this.libraryDataProvider.getTableInfo(item),
+          () => this.libraryDataProvider.fetchColumns(item),
         ),
         `properties-${item.uid}`,
         true,

--- a/client/src/panels/TablePropertiesViewer.ts
+++ b/client/src/panels/TablePropertiesViewer.ts
@@ -1,6 +1,6 @@
 // Copyright © 2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Uri, l10n } from "vscode";
+import { Uri, l10n, window } from "vscode";
 
 import { TableColumn } from "../components/LibraryNavigator/types";
 import { TableInfo } from "../connection/rest/api/compute";
@@ -17,10 +17,12 @@ class TablePropertiesViewer extends WebView {
   constructor(
     extensionUri: Uri,
     private readonly tableName: string,
-    private readonly tableInfo: TableInfo,
-    private readonly columns: TableColumn[],
+    private tableInfo: TableInfo,
+    private columns: TableColumn[],
     private readonly showColumns: boolean = false,
     private readonly focusedColumn: string = "",
+    private readonly refreshTableInfo: () => Promise<TableInfo>,
+    private readonly refreshColumns: () => Promise<TableColumn[]>,
   ) {
     super(extensionUri, l10n.t("Table Properties"));
   }
@@ -53,6 +55,20 @@ class TablePropertiesViewer extends WebView {
 
   public processMessage(): void {
     // No messages to process for this static viewer
+  }
+
+  public async refreshData() {
+    try {
+      const [tableInfo, columns] = await Promise.all([
+        this.refreshTableInfo(),
+        this.refreshColumns(),
+      ]);
+      this.tableInfo = tableInfo;
+      this.columns = columns;
+      this.render();
+    } catch (error) {
+      window.showErrorMessage(error.message);
+    }
   }
 
   private generatePropertiesContent(): string {

--- a/client/test/components/LibraryNavigator/LibraryNavigator.test.ts
+++ b/client/test/components/LibraryNavigator/LibraryNavigator.test.ts
@@ -6,6 +6,7 @@ import * as sinon from "sinon";
 import LibraryNavigator from "../../../src/components/LibraryNavigator";
 import PaginatedResultSet from "../../../src/components/LibraryNavigator/PaginatedResultSet";
 import DataViewer from "../../../src/panels/DataViewer";
+import TablePropertiesViewer from "../../../src/panels/TablePropertiesViewer";
 
 interface WebviewMessagePanel {
   webview: {
@@ -24,6 +25,37 @@ const createDataViewer = () =>
     new PaginatedResultSet(async () => ({ data: { rows: [], count: 0 } })),
     () => [],
     () => {},
+  );
+
+const createTablePropertiesViewer = () =>
+  new TablePropertiesViewer(
+    Uri.file("C:/temp"),
+    "WORK.T_REFRESH",
+    {
+      name: "T_REFRESH",
+      libref: "WORK",
+    },
+    [
+      {
+        name: "date",
+        type: "num",
+        format: "YYMMDD10.",
+        index: 2,
+        formatCategory: "date",
+      },
+    ],
+    false,
+    "",
+    async () => ({ name: "T_REFRESH", libref: "WORK" }),
+    async () => [
+      {
+        name: "updatedDate",
+        type: "num",
+        format: "YYMMDD10.",
+        index: 2,
+        formatCategory: "date",
+      },
+    ],
   );
 
 describe("LibraryNavigator refresh flow", async function () {
@@ -50,17 +82,23 @@ describe("LibraryNavigator refresh flow", async function () {
     ).to.equal(true);
   });
 
-  it("refreshOpenTableViewers refreshes only open DataViewer panels", () => {
+  it("refreshOpenTableViewers refreshes open DataViewer and TablePropertiesViewer panels", () => {
     const navigator: LibraryNavigator = Object.create(
       LibraryNavigator.prototype,
     );
 
     const tableViewer = createDataViewer();
     const tableViewerRefresh = sinon.stub(tableViewer, "refreshData");
+    const tablePropertiesViewer = createTablePropertiesViewer();
+    const tablePropertiesViewerRefresh = sinon.stub(
+      tablePropertiesViewer,
+      "refreshData",
+    );
     const nonTablePanel = new RefreshTrackingPanel();
     const webviewManager = {
       panels: {
         table: tableViewer,
+        tableProperties: tablePropertiesViewer,
         other: nonTablePanel,
       },
     };
@@ -72,6 +110,7 @@ describe("LibraryNavigator refresh flow", async function () {
     navigator.refreshOpenTableViewers();
 
     expect(tableViewerRefresh.calledOnce).to.equal(true);
+    expect(tablePropertiesViewerRefresh.calledOnce).to.equal(true);
     expect(nonTablePanel.refreshData.called).to.equal(false);
   });
 });


### PR DESCRIPTION
**Summary:**
Changes to make sure any open TableProperties panels refresh when SAS Code is run. Updated a test handling DataViewer panels to include this as well.

**Testing:**

1. Create a new sas file and add this code:
```SAS
data work.test;
    input Date: Date9. Country :$13. Actual: 10. Name: $1000.;
    datalines;
08May2017 USA 1000000 test
;
```
3. Run that code.
4. Open the property page for the newly created WORK.TEST table.
5. Switch to the Columns tab and note the names are in english.
6. Copy the following code:
```SAS
option validvarname=any VALIDMEMNAME=EXTEND;

data work.test;
    input 日期: Date9. 国家 :$13. 实际销售 :10. 名称: $1000.;
    datalines;
08May2017 USA 1000000 test
;
```
10. Run that code now.
11. Switch back to the table properties panel and verify the column names have switched to chinese.

Screenshot of before and after:
<img width="465" height="732" alt="image" src="https://github.com/user-attachments/assets/de13d56b-cac8-4dc4-af07-0452f616c815" />

**TODOs:**

- [ ] Add any supporting documentation and (optionally) update [CHANGELOG.md](CHANGELOG.md)

Signed-off-by: Noah Howell <nhowell117@gmail.com>
